### PR TITLE
Minor text change: Update readme to say beta instead of alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # OpenAI Java API Library
 
 > [!NOTE]  
-> The OpenAI Java API Library is currently in _alpha_.
+> The OpenAI Java API Library is currently in _beta_.
 >
 > There may be frequent breaking changes.
 >


### PR DESCRIPTION
Readme currently says this library is in alpha while beta was announced in December in the official OpenAI guidance [here](https://platform.openai.com/docs/libraries#official-rest-api-libraries)