### PR TITLE
get BaseUrl from env var: OPENAI_BASE_URL

### DIFF
--- a/openai-java-core/src/main/kotlin/com/openai/core/ClientOptions.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/core/ClientOptions.kt
@@ -227,8 +227,8 @@ private constructor(
                     // dependency.
                     baseUrl(azureEndpoint)
                 }
-                !openAIBaseUrl.isNullOrEmpty() && azureEndpoint.isNullOrEmpty()-> {
-                    // if 'openAIBaseUrl' is set, its added as the BASE_URL provided 'azureEndpoint' is not set.
+                !openAIBaseUrl.isNullOrEmpty() && azureEndpoint.isNullOrEmpty() && azureOpenAIKey.isNullOrEmpty() -> {
+                    // if 'openAIBaseUrl' is set, its added as the BASE_URL provided 'azureEndpoint' and 'azureOpenAIKey' are not set.
                     // if both 'openAIBaseUrl' and 'azureEndpoint' are set, 'azureEndpoint' takes higher priority.
                     baseUrl(openAIBaseUrl)
                 }

--- a/openai-java-core/src/main/kotlin/com/openai/core/ClientOptions.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/core/ClientOptions.kt
@@ -202,8 +202,12 @@ private constructor(
             val openAIProjectId = System.getenv("OPENAI_PROJECT_ID")
             val azureOpenAIKey = System.getenv("AZURE_OPENAI_KEY")
             val azureEndpoint = System.getenv("AZURE_OPENAI_ENDPOINT")
+            val openAIBaseUrl = System.getenv("OPENAI_BASE_URL")
 
             when {
+                !openAIBaseUrl.isNullOrEmpty() -> {
+                    baseUrl(openAIBaseUrl)
+                }
                 !openAIKey.isNullOrEmpty() && !azureOpenAIKey.isNullOrEmpty() -> {
                     throw IllegalArgumentException(
                         "Both OpenAI and Azure OpenAI API keys, `OPENAI_API_KEY` and `AZURE_OPENAI_KEY`, are set. Please specify only one"

--- a/openai-java-core/src/main/kotlin/com/openai/core/ClientOptions.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/core/ClientOptions.kt
@@ -40,8 +40,7 @@ private constructor(
     fun toBuilder() = Builder().from(this)
 
     companion object {
-
-        const val PRODUCTION_URL = "https://api.openai.com/v1"
+        val PRODUCTION_URL: String = System.getenv("OPENAI_BASE_URL") ?: "https://api.openai.com/v1"
 
         @JvmStatic fun builder() = Builder()
 

--- a/openai-java-core/src/main/kotlin/com/openai/core/ClientOptions.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/core/ClientOptions.kt
@@ -205,9 +205,6 @@ private constructor(
             val openAIBaseUrl = System.getenv("OPENAI_BASE_URL")
 
             when {
-                !openAIBaseUrl.isNullOrEmpty() -> {
-                    baseUrl(openAIBaseUrl)
-                }
                 !openAIKey.isNullOrEmpty() && !azureOpenAIKey.isNullOrEmpty() -> {
                     throw IllegalArgumentException(
                         "Both OpenAI and Azure OpenAI API keys, `OPENAI_API_KEY` and `AZURE_OPENAI_KEY`, are set. Please specify only one"
@@ -229,6 +226,11 @@ private constructor(
                     // to get the token through the supplier, which requires Azure Entra ID as a
                     // dependency.
                     baseUrl(azureEndpoint)
+                }
+                !openAIBaseUrl.isNullOrEmpty() && azureEndpoint.isNullOrEmpty()-> {
+                    // if 'openAIBaseUrl' is set, its added as the BASE_URL provided 'azureEndpoint' is not set.
+                    // if both 'openAIBaseUrl' and 'azureEndpoint' are set, 'azureEndpoint' takes higher priority.
+                    baseUrl(openAIBaseUrl)
                 }
             }
         }

--- a/openai-java-core/src/main/kotlin/com/openai/core/ClientOptions.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/core/ClientOptions.kt
@@ -40,7 +40,8 @@ private constructor(
     fun toBuilder() = Builder().from(this)
 
     companion object {
-        val PRODUCTION_URL: String = System.getenv("OPENAI_BASE_URL") ?: "https://api.openai.com/v1"
+
+        const val PRODUCTION_URL = "https://api.openai.com/v1"
 
         @JvmStatic fun builder() = Builder()
 


### PR DESCRIPTION
Changes:
- Check if env var: `OPENAI_BASE_URL` is present
- If yes, set the baseUrl as `OPENAI_BASE_URL`; provided the env vars `AZURE_OPENAI_KEY` or `AZURE_OPENAI_ENDPOINT` are not set.

---
Motivation:
Currently the Python OpenAI client has support for OPENAI_BASE_URL to be taken from env vars. But there is no such implementation for the JVM client, and it created inconsistencies in user environment. Is there any plan or ticket to add the OPENAI_BASE_URL in the JVM client and respect it if baseUrl is not specified during client initialization.
Issue: https://github.com/openai/openai-java/issues/201
