### PR TITLE
docs: embeddings example

### DIFF
--- a/openai-java-core/src/test/kotlin/com/openai/services/blocking/EmbeddingServiceTest.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/services/blocking/EmbeddingServiceTest.kt
@@ -25,7 +25,7 @@ class EmbeddingServiceTest {
             embeddingService.create(
                 EmbeddingCreateParams.builder()
                     .input("The quick brown fox jumped over the lazy dog")
-                    .model(EmbeddingModel.TEXT_EMBEDDING_ADA_002)
+                    .model(EmbeddingModel.TEXT_EMBEDDING_3_SMALL)
                     .dimensions(1L)
                     .encodingFormat(EmbeddingCreateParams.EncodingFormat.FLOAT)
                     .user("user-1234")

--- a/openai-java-example/src/main/java/com/openai/example/EmbeddingsAsyncExample.java
+++ b/openai-java-example/src/main/java/com/openai/example/EmbeddingsAsyncExample.java
@@ -1,0 +1,24 @@
+package com.openai.example;
+
+import com.openai.client.OpenAIClientAsync;
+import com.openai.client.okhttp.OpenAIOkHttpClientAsync;
+import com.openai.models.EmbeddingCreateParams;
+import com.openai.models.EmbeddingModel;
+
+public final class EmbeddingsAsyncExample {
+    private EmbeddingsAsyncExample() {}
+
+    public static void main(String[] args) {
+        // Configures using one of:
+        // - The `OPENAI_API_KEY` environment variable
+        // - The `AZURE_OPENAI_ENDPOINT` and `AZURE_OPENAI_KEY` environment variables
+        OpenAIClientAsync client = OpenAIOkHttpClientAsync.fromEnv();
+
+        EmbeddingCreateParams createParams = EmbeddingCreateParams.builder()
+                .input("The quick brown fox jumped over the lazy dog")
+                .model(EmbeddingModel.TEXT_EMBEDDING_3_SMALL)
+                .build();
+
+        client.embeddings().create(createParams).thenAccept(System.out::println).join();
+    }
+}

--- a/openai-java-example/src/main/java/com/openai/example/EmbeddingsExample.java
+++ b/openai-java-example/src/main/java/com/openai/example/EmbeddingsExample.java
@@ -1,0 +1,24 @@
+package com.openai.example;
+
+import com.openai.client.OpenAIClient;
+import com.openai.client.okhttp.OpenAIOkHttpClient;
+import com.openai.models.EmbeddingCreateParams;
+import com.openai.models.EmbeddingModel;
+
+public final class EmbeddingsExample {
+    private EmbeddingsExample() {}
+
+    public static void main(String[] args) {
+        // Configures using one of:
+        // - The `OPENAI_API_KEY` environment variable
+        // - The `AZURE_OPENAI_ENDPOINT` and `AZURE_OPENAI_KEY` environment variables
+        OpenAIClient client = OpenAIOkHttpClient.fromEnv();
+
+        EmbeddingCreateParams createParams = EmbeddingCreateParams.builder()
+                .input("The quick brown fox jumped over the lazy dog")
+                .model(EmbeddingModel.TEXT_EMBEDDING_3_SMALL)
+                .build();
+
+        System.out.println(client.embeddings().create(createParams));
+    }
+}


### PR DESCRIPTION
This PR includes the following changes:

1. Fix embedding model selection
  - `TEXT_EMBEDDING_ADA_002` does not support the dimensions option(400 error but not in mock server).
    - https://platform.openai.com/docs/api-reference/embeddings/create#embeddings-create-dimensions 
  - Changed the model to `TEXT_EMBEDDING_3_SMALL` to ensure proper functionality.

2. Add an `EmbeddingsExample`
  - Added an example for embedding usage to improve documentation and clarity.
