### PR TITLE
Fix Issue #211 : Improved Embedding Performance by Handling Base64 Encoding

### DIFF
--- a/openai-java-core/src/main/kotlin/com/openai/models/EmbeddingCreateParams.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/models/EmbeddingCreateParams.kt
@@ -271,7 +271,9 @@ private constructor(
             private var input: JsonField<Input>? = null
             private var model: JsonField<EmbeddingModel>? = null
             private var dimensions: JsonField<Long> = JsonMissing.of()
-            private var encodingFormat: JsonField<EncodingFormat> = JsonMissing.of()
+            // Default EncodingFormat value is set to BASE64 for performance improvements.
+            private var encodingFormat: JsonField<EncodingFormat> =
+                JsonField.of(EncodingFormat.BASE64)
             private var user: JsonField<String> = JsonMissing.of()
             private var additionalProperties: MutableMap<String, JsonValue> = mutableMapOf()
 

--- a/openai-java-core/src/main/kotlin/com/openai/models/EmbeddingValue.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/models/EmbeddingValue.kt
@@ -1,0 +1,81 @@
+package com.openai.models
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.util.Base64
+import java.util.Optional
+import kotlin.collections.MutableList
+
+/** Represents an embedding vector returned by embedding endpoint. */
+@JsonDeserialize(using = EmbeddingValueDeserializer::class)
+class EmbeddingValue(
+    var base64Embedding: Optional<String> = Optional.empty(),
+    floatEmbedding: Optional<MutableList<Double>> = Optional.empty(),
+) {
+
+    /**
+     * The embedding vector, which is a list of float32.
+     * [embedding guide](https://platform.openai.com/docs/guides/embeddings).
+     */
+    var floatEmbedding: Optional<MutableList<Double>> = Optional.empty()
+        get() {
+            if (field.isPresent) {
+                return field
+            }
+            if (base64Embedding.isPresent) {
+                field = convertBase64ToFloat(base64Embedding)
+            }
+            return field
+        }
+        set(value) {
+            field = value
+        }
+
+    /**
+     * Converting Base64 float32 array to Optional<MutableList>
+     *
+     * To improve performance, requests are made in Base64 by default. However, not all developers
+     * need to decode Base64. Therefore, when a request is made in Base64, the system will
+     * internally convert the Base64 data to MutableList<Double> and make this converted data
+     * available, allowing developers to obtain both the Base64 data and the MutableList<Double>
+     * data by default.
+     */
+    private fun convertBase64ToFloat(
+        base64Embedding: Optional<String>
+    ): Optional<MutableList<Double>> {
+        // The response of Embedding returns a List<Float>(float32),
+        // but the Kotlin API handles MutableList<Double>.
+        // If we directly convert from List<Float> to MutableList<Double>,
+        // it increases the precision and changing it from float32 to double.
+        //
+        // Since JSON is assigned to MutableList<Double> from a String of JSON Value,
+        // the precision does not increase.
+        // Therefore, by first converting the Base64-decoded List<Float> to a String,
+        // and then converting the String to Double,
+        // we can handle it as MutableList<Double> without increasing the precision.
+        return base64Embedding.map { base64String ->
+            val decoded = Base64.getDecoder().decode(base64String)
+            val byteBuffer = ByteBuffer.wrap(decoded).order(ByteOrder.LITTLE_ENDIAN)
+
+            val floatList = mutableListOf<String>()
+            while (byteBuffer.hasRemaining()) {
+                floatList.add(byteBuffer.float.toString())
+            }
+            floatList.map { it.replace("f", "").toDouble() }.toMutableList()
+        }
+    }
+
+    /**
+     * Output the embedding vector as a string. By default, it will be output as both list of floats
+     * and Base64 string. if user specifies floatEmbedding, it will be output as list of floats
+     * only.
+     */
+    override fun toString(): String {
+        return if (base64Embedding.isPresent) {
+            "base64: $base64Embedding, float:  [${floatEmbedding.get().joinToString(", ")}]"
+        } else {
+            "float:  [${floatEmbedding.get().joinToString(", ")}]"
+        }
+    }
+}

--- a/openai-java-core/src/main/kotlin/com/openai/models/EmbeddingValueDeserializer.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/models/EmbeddingValueDeserializer.kt
@@ -1,0 +1,32 @@
+package com.openai.models
+
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JsonDeserializer
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.node.ArrayNode
+import java.io.IOException
+import java.util.Optional
+
+/** JsonDeserializer for EmbeddingValue */
+class EmbeddingValueDeserializer : JsonDeserializer<EmbeddingValue>() {
+    @Throws(IOException::class)
+
+    /*
+     * Deserialize the JSON representation of an EmbeddingValue.
+     * The JSON can either be an array of floats or a base64 string.
+     */
+    override fun deserialize(jp: JsonParser, ctxt: DeserializationContext): EmbeddingValue {
+        val node = jp.codec.readTree<JsonNode>(jp)
+        val embeddingValue = EmbeddingValue()
+
+        if (node.isArray) {
+            val floats = mutableListOf<Double>()
+            (node as ArrayNode).forEach { item -> floats.add(item.asDouble()) }
+            embeddingValue.floatEmbedding = Optional.of(floats)
+        } else if (node.isTextual) {
+            embeddingValue.base64Embedding = Optional.of(node.asText())
+        }
+        return embeddingValue
+    }
+}

--- a/openai-java-core/src/test/kotlin/com/openai/models/CreateEmbeddingResponseTest.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/models/CreateEmbeddingResponseTest.kt
@@ -2,6 +2,7 @@
 
 package com.openai.models
 
+import java.util.Optional
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -9,9 +10,20 @@ class CreateEmbeddingResponseTest {
 
     @Test
     fun createCreateEmbeddingResponse() {
+
         val createEmbeddingResponse =
             CreateEmbeddingResponse.builder()
-                .addData(Embedding.builder().addEmbedding(0.0).index(0L).build())
+                .addData(
+                    Embedding.builder()
+                        .addEmbedding(
+                            EmbeddingValue(
+                                floatEmbedding = Optional.of(mutableListOf(0.0)),
+                                base64Embedding = Optional.empty(),
+                            )
+                        )
+                        .index(0L)
+                        .build()
+                )
                 .model("model")
                 .usage(
                     CreateEmbeddingResponse.Usage.builder().promptTokens(0L).totalTokens(0L).build()
@@ -19,7 +31,17 @@ class CreateEmbeddingResponseTest {
                 .build()
         assertThat(createEmbeddingResponse).isNotNull
         assertThat(createEmbeddingResponse.data())
-            .containsExactly(Embedding.builder().addEmbedding(0.0).index(0L).build())
+            .containsExactly(
+                Embedding.builder()
+                    .addEmbedding(
+                        EmbeddingValue(
+                            floatEmbedding = Optional.of(mutableListOf(0.0)),
+                            base64Embedding = Optional.empty(),
+                        )
+                    )
+                    .index(0L)
+                    .build()
+            )
         assertThat(createEmbeddingResponse.model()).isEqualTo("model")
         assertThat(createEmbeddingResponse.usage())
             .isEqualTo(

--- a/openai-java-core/src/test/kotlin/com/openai/models/EmbeddingTest.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/models/EmbeddingTest.kt
@@ -2,6 +2,7 @@
 
 package com.openai.models
 
+import java.util.Optional
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -9,9 +10,18 @@ class EmbeddingTest {
 
     @Test
     fun createEmbedding() {
-        val embedding = Embedding.builder().addEmbedding(0.0).index(0L).build()
+        val embedding =
+            Embedding.builder()
+                .addEmbedding(
+                    EmbeddingValue(
+                        floatEmbedding = Optional.of(mutableListOf(0.0)),
+                        base64Embedding = Optional.empty(),
+                    )
+                )
+                .build()
         assertThat(embedding).isNotNull
-        assertThat(embedding.embedding()).containsExactly(0.0)
+        //        assertThat(embedding.embedding()).containsExactly(0.0)
+        assertThat(embedding.embedding().floatEmbedding).containsSame(mutableListOf(0.0))
         assertThat(embedding.index()).isEqualTo(0L)
     }
 }


### PR DESCRIPTION
This commit includes the fix described in Issue #211.

* Addressed the issue where Base64 encoding could not be handled.
* Improved performance by using Base64 encoding by default.

## Detail 
This pull request to `openai-java-core` includes significant changes to the `Embedding` model to support both float and Base64 representations of embedding vectors. The most important changes include the introduction of a new `EmbeddingValue` class, updates to the `Embedding` class to use this new type, and modifications to the associated deserialization and test files.

Changes to `Embedding` model:

* [`openai-java-core/src/main/kotlin/com/openai/models/Embedding.kt`](diffhunk://#diff-77c4f9ed05c5d8e0680c26cfe25833a1a8ecff01b6732048f41da78a19de16b7L28-R29): Changed the type of `embedding` from `JsonField<List<Double>>` to `JsonField<EmbeddingValue>`, updated methods to return `EmbeddingValue` instead of `List<Double>`, and modified the builder to handle `EmbeddingValue`. [[1]](diffhunk://#diff-77c4f9ed05c5d8e0680c26cfe25833a1a8ecff01b6732048f41da78a19de16b7L28-R29) [[2]](diffhunk://#diff-77c4f9ed05c5d8e0680c26cfe25833a1a8ecff01b6732048f41da78a19de16b7L38-R39) [[3]](diffhunk://#diff-77c4f9ed05c5d8e0680c26cfe25833a1a8ecff01b6732048f41da78a19de16b7L50-R53) [[4]](diffhunk://#diff-77c4f9ed05c5d8e0680c26cfe25833a1a8ecff01b6732048f41da78a19de16b7L95-R112) [[5]](diffhunk://#diff-77c4f9ed05c5d8e0680c26cfe25833a1a8ecff01b6732048f41da78a19de16b7L113-R148) [[6]](diffhunk://#diff-77c4f9ed05c5d8e0680c26cfe25833a1a8ecff01b6732048f41da78a19de16b7L166-R187)

Introduction of `EmbeddingValue` class:

* [`openai-java-core/src/main/kotlin/com/openai/models/EmbeddingValue.kt`](diffhunk://#diff-016268ad360b173960634c3413d5d491e134eb3298eb820f510766c309a83506R1-R81): Added a new class `EmbeddingValue` to represent embedding vectors, supporting both float and Base64 representations.

Deserialization updates:

* [`openai-java-core/src/main/kotlin/com/openai/models/EmbeddingValueDeserializer.kt`](diffhunk://#diff-dca4c9e622d208e626a025bbdcf7efdd05de0a4972058a70424e6b7787bdffa8R1-R32): Added a new deserializer `EmbeddingValueDeserializer` to handle JSON deserialization for `EmbeddingValue`.

Default encoding format change:

* [`openai-java-core/src/main/kotlin/com/openai/models/EmbeddingCreateParams.kt`](diffhunk://#diff-11b78e3312089a418f7d10add8115e044cd01e41592710a144111faa85c51f8cL274-R276): Set the default `EncodingFormat` value to `BASE64` for performance improvements.

Test updates:

* [`openai-java-core/src/test/kotlin/com/openai/models/CreateEmbeddingResponseTest.kt`](diffhunk://#diff-3632177d5646ef27a52246fc21e76890012285c3786df30ba615014a6780708eR5-R44): Updated tests to use `EmbeddingValue` instead of `List<Double>`.
* [`openai-java-core/src/test/kotlin/com/openai/models/EmbeddingTest.kt`](diffhunk://#diff-a1583a448362ff4c53e0d7b78f19c3c19007e0faea88e211aae8a8f97cd4420fR5-R24): Updated tests to verify the new `EmbeddingValue` structure.