### PR TITLE
docs: add `ImageGenerationExample`

### DIFF
--- a/openai-java-example/src/main/java/com/openai/example/ImageGenerationExample.java
+++ b/openai-java-example/src/main/java/com/openai/example/ImageGenerationExample.java
@@ -1,0 +1,34 @@
+package com.openai.example;
+
+import com.openai.client.OpenAIClient;
+import com.openai.client.okhttp.OpenAIOkHttpClient;
+import com.openai.models.images.Image;
+import com.openai.models.images.ImageGenerateParams;
+import com.openai.models.images.ImageModel;
+import java.io.IOException;
+import java.util.Optional;
+
+public final class ImageGenerationExample {
+    private ImageGenerationExample() {}
+
+    public static void main(String[] args) throws IOException {
+        // Configures using one of:
+        // - The `OPENAI_API_KEY` environment variable
+        // - The `OPENAI_BASE_URL` and `AZURE_OPENAI_KEY` environment variables
+        OpenAIClient client = OpenAIOkHttpClient.fromEnv();
+
+        ImageGenerateParams imageGenerateParams = ImageGenerateParams.builder()
+                .responseFormat(ImageGenerateParams.ResponseFormat.URL)
+                .prompt("Two cats playing ping-pong")
+                .model(ImageModel.DALL_E_2)
+                .size(ImageGenerateParams.Size._512X512)
+                .n(1)
+                .build();
+
+        client.images().generate(imageGenerateParams).data().orElseThrow(IOException::new).stream()
+                .map(Image::url)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .forEach(System.out::println);
+    }
+}

--- a/openai-java-example/src/main/java/com/openai/example/ImageGenerationExample.java
+++ b/openai-java-example/src/main/java/com/openai/example/ImageGenerationExample.java
@@ -2,11 +2,9 @@ package com.openai.example;
 
 import com.openai.client.OpenAIClient;
 import com.openai.client.okhttp.OpenAIOkHttpClient;
-import com.openai.models.images.Image;
 import com.openai.models.images.ImageGenerateParams;
 import com.openai.models.images.ImageModel;
 import java.io.IOException;
-import java.util.Optional;
 
 public final class ImageGenerationExample {
     private ImageGenerationExample() {}
@@ -25,10 +23,8 @@ public final class ImageGenerationExample {
                 .n(1)
                 .build();
 
-        client.images().generate(imageGenerateParams).data().orElseThrow(IOException::new).stream()
-                .map(Image::url)
-                .filter(Optional::isPresent)
-                .map(Optional::get)
+        client.images().generate(imageGenerateParams).data().orElseThrow().stream()
+                .flatMap(image -> image.url().stream())
                 .forEach(System.out::println);
     }
 }


### PR DESCRIPTION
Very simple example on image generation with `client.images()`.

I was about to work on https://github.com/openai/openai-java/issues/453 when I noticed there's no example for image generation itself, so I added it first.