### PR TITLE
Improved docs and error message when "properties" empty

### DIFF
--- a/openai-java-core/src/main/kotlin/com/openai/core/JsonSchemaValidator.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/core/JsonSchemaValidator.kt
@@ -19,6 +19,9 @@ import com.openai.core.JsonSchemaValidator.Companion.UNRESTRICTED_ENUM_VALUES_LI
 internal class JsonSchemaValidator private constructor() {
 
     companion object {
+        private const val NO_PROPERTIES_DOC =
+            "https://github.com/openai/openai-java/blob/main/README.md#defining-json-schema-properties"
+
         // The names of the supported schema keywords. All other keywords will be rejected.
         private const val SCHEMA = "\$schema"
         private const val ID = "\$id"
@@ -409,7 +412,10 @@ internal class JsonSchemaValidator private constructor() {
         verify(
             properties != null && properties.isObject && !properties.isEmpty,
             path,
-            { "'$PROPS' field is missing, empty or not an object." },
+            {
+                "'$PROPS' field is missing, empty or not an object. " +
+                    "At least one named property must be defined. See: $NO_PROPERTIES_DOC"
+            },
         ) {
             return
         }

--- a/openai-java-core/src/test/kotlin/com/openai/core/StructuredOutputsTest.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/core/StructuredOutputsTest.kt
@@ -84,7 +84,7 @@ internal class StructuredOutputsTest {
         // AI. It can only reply with values to _named_ properties, so there must be at least one.
         assertThat(validator.errors()).hasSize(1)
         assertThat(validator.errors()[0])
-            .isEqualTo("#: 'properties' field is missing, empty or not an object.")
+            .startsWith("#: 'properties' field is missing, empty or not an object.")
     }
 
     @Test
@@ -98,15 +98,15 @@ internal class StructuredOutputsTest {
         // no named `"properties"` and no `"required"` array. Only the first problem is reported.
         assertThat(validator.errors()).hasSize(1)
         assertThat(validator.errors()[0])
-            .isEqualTo("#/properties/m: 'properties' field is missing, empty or not an object.")
+            .startsWith("#/properties/m: 'properties' field is missing, empty or not an object.")
 
         // Do this check of `toString()` once for a validation failure, but do not repeat it in
         // other tests.
         assertThat(validator.toString())
-            .isEqualTo(
+            .startsWith(
                 "JsonSchemaValidator{isValidationComplete=true, totalStringLength=1, " +
                     "totalObjectProperties=1, totalEnumValues=0, errors=[" +
-                    "#/properties/m: 'properties' field is missing, empty or not an object.]}"
+                    "#/properties/m: 'properties' field is missing, empty or not an object."
             )
     }
 
@@ -700,7 +700,7 @@ internal class StructuredOutputsTest {
         // be allowed and the AI model will have nothing it can populate.
         assertThat(validator.errors()).hasSize(1)
         assertThat(validator.errors()[0])
-            .isEqualTo("#: 'properties' field is missing, empty or not an object.")
+            .startsWith("#: 'properties' field is missing, empty or not an object.")
     }
 
     @Test
@@ -721,7 +721,7 @@ internal class StructuredOutputsTest {
 
         assertThat(validator.errors()).hasSize(1)
         assertThat(validator.errors()[0])
-            .isEqualTo("#: 'properties' field is missing, empty or not an object.")
+            .startsWith("#: 'properties' field is missing, empty or not an object.")
     }
 
     @Test
@@ -742,7 +742,7 @@ internal class StructuredOutputsTest {
 
         assertThat(validator.errors()).hasSize(1)
         assertThat(validator.errors()[0])
-            .isEqualTo("#: 'properties' field is missing, empty or not an object.")
+            .startsWith("#: 'properties' field is missing, empty or not an object.")
     }
 
     @Test

--- a/openai-java-core/src/test/kotlin/com/openai/models/responses/StructuredResponseOutputItemTest.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/models/responses/StructuredResponseOutputItemTest.kt
@@ -60,7 +60,8 @@ internal class StructuredResponseOutputItemTest {
             ResponseCodeInterpreterToolCall.builder()
                 .id(STRING)
                 .code(STRING)
-                .addLogsResult(STRING)
+                .containerId(STRING)
+                .outputs(listOf())
                 .status(ResponseCodeInterpreterToolCall.Status.COMPLETED)
                 .build()
         private val IMAGE_GENERATION_CALL =


### PR DESCRIPTION
To address issue #504 and any similar reports requesting clarity: added new documentation on how fields and getter methods are included/excluded from JSON schemas and added the URL to those docs to the error message that is reported when a JSON schema has an empty `"properties"` field.