### PR TITLE
Generate the GraalVM metadata file(s) when releasing the project

### DIFF
--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Set up Java
         if: ${{ steps.release.outputs.releases_created }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: |
@@ -35,6 +35,37 @@ jobs:
       - name: Set up Gradle
         if: ${{ steps.release.outputs.releases_created }}
         uses: gradle/gradle-build-action@v2
+
+      - name: Compile the openai-java-core project
+        run: |
+          ./gradlew :openai-java-core:compileJava :openai-java-core:compileTestJava -x test
+
+      - name: Run the Prism server
+        run: |
+          ./scripts/mock --daemon
+
+      - name: Setup GraalVM
+        uses: graalvm/setup-graalvm@v1
+        with:
+          java-version: 21
+          distribution: 'graalvm-community'
+          cache: gradle
+
+      - name: Run tests on the openai-java-core project with the GraalVM native-image agent
+        run: |
+          ./gradlew :openai-java-core:test -x compileJava -x compileTestJava -x compileKotlin -x compileTestKotlin -Pagent
+
+      - name: Check generated GraalVM file
+        run: |
+          echo "Checking for GraalVM agent metadata files..."
+          DIRECTORY=openai-java-core/src/main/resources/META-INF/native-image
+          if [ -d "$DIRECTORY" ] && [ "$(ls -A $DIRECTORY)" ]; then
+            echo "Files found in $DIRECTORY:"
+            ls -l $DIRECTORY
+          else
+            echo "No files found in $DIRECTORY"
+            exit 1
+          fi
 
       - name: Publish to Sonatype
         if: ${{ steps.release.outputs.releases_created }}

--- a/openai-java-core/build.gradle.kts
+++ b/openai-java-core/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
+    id("java")
     id("openai.kotlin")
     id("openai.publish")
 }
@@ -42,4 +43,20 @@ dependencies {
     testImplementation("org.mockito:mockito-core:5.14.2")
     testImplementation("org.mockito:mockito-junit-jupiter:5.14.2")
     testImplementation("org.mockito.kotlin:mockito-kotlin:4.1.0")
+}
+
+if (project.hasProperty("agent")) {
+    java {
+        toolchain {
+            languageVersion.set(JavaLanguageVersion.of(21))
+            vendor.set(JvmVendorSpec.GRAAL_VM)
+        }
+    }
+
+    tasks.test {
+        maxParallelForks = 1
+        forkEvery = 0
+        jvmArgs =
+            listOf("-agentlib:native-image-agent=config-output-dir=src/main/resources/META-INF/native-image")
+    }
 }


### PR DESCRIPTION
This adds support for generating the GraalVM metadata when releasing the project, as mentioned in #522

The setup is a bit complex because:

- The current build of Kotlin doesn't work with a recent Java version (Java 24)
- But the GraalVM native image needs a recent version for licensing issues (you need a commercial license for version 17)

So the way this is done here is:

- Compile the module with Java 17, so it works fine with Kotlin
- Run the tests over the compiled code with GraalVM 21 (it won't work with 24, and 21 doesn't require a commercial license)

At some point this will all need to migrate to Java 24: at that moment, please note that GraalVM will have a new file format, and will generate only one file instead of several (but always in the same directory, so this code should still work OK).

I'm keeping the full "publish to Sonatype" task, to have everything fully compiled and tested for the release. That means the tests will run twice - this could be fixed by adding `-x test` to that task.

Another way to achieve this would be to use the GraalVM Gradle task instead of adding the agent library like we do here as a JVM argument: this seems more elegant, but that approach cannot work currently as it would require to import that task (the task only run when the "agent" profile is set up, but the import would always be there as they can't be conditionally imported). And as that task cannot run with Java 17, that would make the Kotlin build fail. This is something that could be improved later, when the project will work with Java 24.