### PR TITLE
Add HTTP Client option to disable SSL verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,24 @@ See this table for the available options:
 > Don't create more than one client in the same application. Each client has a connection pool and
 > thread pools, which are more efficient to share between requests.
 
+### Disabling SSL verification
+
+For testing purposes, you can disable SSL certificate verification when connecting to local mock servers or development environments with self-signed certificates:
+
+```java
+import com.openai.client.OpenAIClient;
+import com.openai.client.okhttp.OpenAIOkHttpClient;
+
+OpenAIClient client = OpenAIOkHttpClient.builder()
+    .baseUrl("https://localhost:8443/v1") // Your local mock server
+    .apiKey("test-api-key")
+    .disableSslVerification(true) // Disable SSL verification
+    .build();
+```
+
+> [!WARNING]
+> **Only use this for testing and development environments.** Never disable SSL verification in production as it makes your application vulnerable to man-in-the-middle attacks.
+
 ### Modifying configuration
 
 To temporarily use a modified client configuration, while reusing the same connection and thread pools, call `withOptions()` on any client or service:

--- a/openai-java-client-okhttp/src/main/kotlin/com/openai/client/okhttp/OpenAIOkHttpClient.kt
+++ b/openai-java-client-okhttp/src/main/kotlin/com/openai/client/okhttp/OpenAIOkHttpClient.kt
@@ -34,6 +34,7 @@ class OpenAIOkHttpClient private constructor() {
         private var clientOptions: ClientOptions.Builder = ClientOptions.builder()
         private var timeout: Timeout = Timeout.default()
         private var proxy: Proxy? = null
+        private var disableSslVerification: Boolean = false
 
         fun baseUrl(baseUrl: String) = apply { clientOptions.baseUrl(baseUrl) }
 
@@ -184,6 +185,10 @@ class OpenAIOkHttpClient private constructor() {
         fun webhookSecret(webhookSecret: Optional<String>) =
             webhookSecret(webhookSecret.getOrNull())
 
+        fun disableSslVerification(disable: Boolean = true) = apply { 
+            this.disableSslVerification = disable 
+        }
+
         fun fromEnv() = apply { clientOptions.fromEnv() }
 
         /**
@@ -194,7 +199,13 @@ class OpenAIOkHttpClient private constructor() {
         fun build(): OpenAIClient =
             OpenAIClientImpl(
                 clientOptions
-                    .httpClient(OkHttpClient.builder().timeout(timeout).proxy(proxy).build())
+                    .httpClient(
+                        OkHttpClient.builder()
+                            .timeout(timeout)
+                            .proxy(proxy)
+                            .disableSslVerification(disableSslVerification)
+                            .build()
+                    )
                     .build()
             )
     }


### PR DESCRIPTION
## Description 

The current OkHTTPClient do not have an option to disable SSL verification. This makes it hard to use this library to test with local mock clients. The PR add a new HttpClient builder option called `disableSslVerification(true)` to disable SSL verification. 

Fixes #540 