### PR TITLE
docs(CONTRIBUTING): clarify Java/JDK toolchain; capitalize terms; tidy code block

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Setting up the environment
 
-This repository uses [Gradle](https://gradle.org/) with Kotlin DSL for building and dependency management. The SDK requires Java 8, but development requires JDK 21 for the Kotlin toolchain.
+This repository uses [Gradle](https://gradle.org/) with Kotlin DSL for building and dependency management. The SDK requires Java 8 for runtime, but development requires JDK 21 for the Kotlin toolchain.
 
 ## Project structure
 
@@ -103,7 +103,6 @@ Then run the tests:
 
 ```sh
 $ ./scripts/test
-
 ```
 
 ### Test configuration
@@ -184,7 +183,7 @@ the changes aren't made through the automated pipeline, you may want to make rel
 
 ### Publish with a GitHub workflow
 
-You can release to package managers by using [the `Publish Sonatype` GitHub action](https://www.github.com/openai/openai-java/actions/workflows/publish-sonatype.yml). This requires setup organization or repository secrets to be configured.
+You can release to package managers by using [the `Publish Sonatype` GitHub Action](https://www.github.com/openai/openai-java/actions/workflows/publish-sonatype.yml). This requires setup organization or repository secrets to be configured.
 
 ### Publish manually
 
@@ -203,7 +202,7 @@ This requires the following environment variables to be set:
 
 ## Development tools
 
-### Available gradle tasks
+### Available Gradle tasks
 
 Some useful Gradle tasks:
 


### PR DESCRIPTION
Summary
Update CONTRIBUTING.md to improve clarity and consistency. Docs-only; no code or CI changes.

Changes (line refs based on commit 9da5ff00dfcb80bdc4553842b697d9b92b79f376)
- L5: Reword environment sentence
  "The SDK requires Java 8, but development requires JDK 21 for the Kotlin toolchain."
  -> "The SDK requires Java 8 for runtime, but development requires JDK 21 for the Kotlin toolchain."
  Permalink: https://github.com/deshkaustubh/openai-java/blob/169195c547693bff17fb97b243bb4bbd81650f66/CONTRIBUTING.md#L5

- L187: Capitalize “GitHub Action”
  "### GitHub action]"
-> "### GitHub Action]"
  Permalink: https://github.com/deshkaustubh/openai-java/blob/169195c547693bff17fb97b243bb4bbd81650f66/CONTRIBUTING.md#L187

- L206: Capitalize “Gradle” in section heading
  "### Available gradle tasks"
  -> "### Available Gradle tasks"
  Permalink: https://github.com/deshkaustubh/openai-java/blob/169195c547693bff17fb97b243bb4bbd81650f66/CONTRIBUTING.md#L206

- L106: Remove stray blank line inside the code block under “Then run the tests”
  Before:
    ```sh
    $ ./scripts/test

    ```
  After:
    ```sh
    $ ./scripts/test
    ```
  Permalink: https://github.com/deshkaustubh/openai-java/blob/169195c547693bff17fb97b243bb4bbd81650f66/CONTRIBUTING.md#L106

Rationale
- Clarifies Java runtime vs. development toolchain
- Ensures consistent capitalization
- Cleans up minor Markdown formatting

Scope/Impact
- Documentation only
- No behavioral, build, or release changes

Checklist
- [x] Markdown renders correctly
- [x] Docs-only change; no tests required
- [x] No changelog/release note needed