### PR TITLE
Proposal for more intuitive usage of `AzureUrlPathMode` configuration value.

### DIFF
--- a/openai-java-core/src/main/kotlin/com/openai/azure/AzureUrlCategory.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/azure/AzureUrlCategory.kt
@@ -23,22 +23,23 @@ internal enum class AzureUrlCategory {
         fun categorizeBaseUrl(baseUrl: String, pathMode: AzureUrlPathMode): AzureUrlCategory {
             val trimmedBaseUrl = baseUrl.trim().trimEnd('/')
             val host = URI.create(trimmedBaseUrl).host
-            return when {
-                // Azure OpenAI resource URL with the old schema.
-                host.endsWith(".openai.azure.com", ignoreCase = true) ||
-                    // Azure OpenAI resource URL with the OpenAI unified schema.
-                    host.endsWith(".services.ai.azure.com", ignoreCase = true) ||
-                    // Azure OpenAI resource URL, but with a schema different to the known ones.
-                    host.endsWith(".azure-api.net", ignoreCase = true) ||
-                    host.endsWith(".cognitiveservices.azure.com", ignoreCase = true) ->
-                    when (pathMode) {
-                        AzureUrlPathMode.LEGACY -> AZURE_LEGACY
-                        AzureUrlPathMode.UNIFIED ->
-                            if (trimmedBaseUrl.endsWith("/openai/v1")) AZURE_UNIFIED
-                            else AZURE_LEGACY
-                    }
 
-                else -> NON_AZURE
+            return when (pathMode) {
+                AzureUrlPathMode.LEGACY -> AZURE_LEGACY
+                AzureUrlPathMode.UNIFIED -> AZURE_UNIFIED
+                AzureUrlPathMode.AUTO ->
+                    when {
+                        host.endsWith(".openai.azure.com", ignoreCase = true) ||
+                            // Azure OpenAI resource URL with the OpenAI unified schema.
+                            host.endsWith(".services.ai.azure.com", ignoreCase = true) ||
+                            // Azure OpenAI resource URL, but with a schema different to the known ones.
+                            host.endsWith(".azure-api.net", ignoreCase = true) ||
+                            host.endsWith(".cognitiveservices.azure.com", ignoreCase = true) ->
+                                if (trimmedBaseUrl.endsWith("/openai/v1")) AZURE_UNIFIED
+                                else AZURE_LEGACY
+
+                        else -> NON_AZURE
+                    }
             }
         }
     }

--- a/openai-java-core/src/main/kotlin/com/openai/azure/AzureUrlPathMode.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/azure/AzureUrlPathMode.kt
@@ -7,4 +7,5 @@ package com.openai.azure
 enum class AzureUrlPathMode {
     LEGACY,
     UNIFIED,
+    AUTO
 }

--- a/openai-java-core/src/main/kotlin/com/openai/azure/AzureUrlPathMode.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/azure/AzureUrlPathMode.kt
@@ -1,8 +1,10 @@
 package com.openai.azure
 
 /**
- * To force the deployment or model named to be part of the URL path for Azure OpenAI requests, use
- * [AzureUrlPathMode.LEGACY]. The default is [AzureUrlPathMode.UNIFIED].
+ * For Azure OpenAI endpoints, this enum configures the client to:
+ * - [AzureUrlPathMode.LEGACY]: forces the deployment or model name into the path.
+ * - [AzureUrlPathMode.UNIFIED]: matches the behaviour of OpenAI, meaning the [AzureOpenAIServiceVersion] is optional and the model is passed in the request object).
+ * - [AzureUrlPathMode.AUTO]: automatically detects the path mode based on the base URL. This is the default value.
  */
 enum class AzureUrlPathMode {
     LEGACY,

--- a/openai-java-core/src/main/kotlin/com/openai/core/ClientOptions.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/core/ClientOptions.kt
@@ -166,7 +166,7 @@ private constructor(
         private var maxRetries: Int = 2
         private var credential: Credential? = null
         private var azureServiceVersion: AzureOpenAIServiceVersion? = null
-        private var azureUrlPathMode: AzureUrlPathMode = AzureUrlPathMode.UNIFIED
+        private var azureUrlPathMode: AzureUrlPathMode = AzureUrlPathMode.AUTO
         private var organization: String? = null
         private var project: String? = null
         private var webhookSecret: String? = null

--- a/openai-java-core/src/test/kotlin/com/openai/azure/AzureUrlCategoryTest.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/azure/AzureUrlCategoryTest.kt
@@ -13,208 +13,299 @@ internal class AzureUrlCategoryTest {
     }
 
     @Test
-    fun categorizeBaseUrl() {
+    fun categorizeBaseUrl_knownHosts() {
+        // known legacy endpoint - no trailing slash - force configuration
         assertThat(
-                AzureUrlCategory.categorizeBaseUrl(
-                    "https://region.openai.azure.com",
-                    AzureUrlPathMode.LEGACY,
-                )
+            AzureUrlCategory.categorizeBaseUrl(
+                "https://region.openai.azure.com",
+                AzureUrlPathMode.LEGACY,
             )
-            .isEqualTo(AzureUrlCategory.AZURE_LEGACY)
-        assertThat(
-                AzureUrlCategory.categorizeBaseUrl(
-                    "https://region.openai.azure.com",
-                    AzureUrlPathMode.UNIFIED,
-                )
-            )
-            .isEqualTo(AzureUrlCategory.AZURE_LEGACY)
-        assertThat(
-                AzureUrlCategory.categorizeBaseUrl(
-                    "https://region.openai.azure.com/",
-                    AzureUrlPathMode.LEGACY,
-                )
-            )
-            .isEqualTo(AzureUrlCategory.AZURE_LEGACY)
-        assertThat(
-                AzureUrlCategory.categorizeBaseUrl(
-                    "https://region.openai.azure.com/",
-                    AzureUrlPathMode.UNIFIED,
-                )
-            )
-            .isEqualTo(AzureUrlCategory.AZURE_LEGACY)
-        assertThat(
-                AzureUrlCategory.categorizeBaseUrl(
-                    "https://region.openai.azure.com/openai/v1",
-                    AzureUrlPathMode.LEGACY,
-                )
-            )
-            .isEqualTo(AzureUrlCategory.AZURE_LEGACY)
-        assertThat(
-                AzureUrlCategory.categorizeBaseUrl(
-                    "https://region.openai.azure.com/openai/v1",
-                    AzureUrlPathMode.UNIFIED,
-                )
-            )
-            .isEqualTo(AzureUrlCategory.AZURE_UNIFIED)
+        ).isEqualTo(AzureUrlCategory.AZURE_LEGACY)
 
         assertThat(
-                AzureUrlCategory.categorizeBaseUrl(
-                    "https://region.services.ai.azure.com",
-                    AzureUrlPathMode.LEGACY,
-                )
+            AzureUrlCategory.categorizeBaseUrl(
+                "https://region.openai.azure.com",
+                AzureUrlPathMode.UNIFIED,
             )
-            .isEqualTo(AzureUrlCategory.AZURE_LEGACY)
-        assertThat(
-                AzureUrlCategory.categorizeBaseUrl(
-                    "https://region.services.ai.azure.com",
-                    AzureUrlPathMode.UNIFIED,
-                )
-            )
-            .isEqualTo(AzureUrlCategory.AZURE_LEGACY)
-        assertThat(
-                AzureUrlCategory.categorizeBaseUrl(
-                    "https://region.services.ai.azure.com/",
-                    AzureUrlPathMode.LEGACY,
-                )
-            )
-            .isEqualTo(AzureUrlCategory.AZURE_LEGACY)
-        assertThat(
-                AzureUrlCategory.categorizeBaseUrl(
-                    "https://region.services.ai.azure.com/",
-                    AzureUrlPathMode.UNIFIED,
-                )
-            )
-            .isEqualTo(AzureUrlCategory.AZURE_LEGACY)
-        assertThat(
-                AzureUrlCategory.categorizeBaseUrl(
-                    "https://region.services.ai.azure.com/openai/v1",
-                    AzureUrlPathMode.LEGACY,
-                )
-            )
-            .isEqualTo(AzureUrlCategory.AZURE_LEGACY)
-        assertThat(
-                AzureUrlCategory.categorizeBaseUrl(
-                    "https://region.services.ai.azure.com/openai/v1",
-                    AzureUrlPathMode.UNIFIED,
-                )
-            )
-            .isEqualTo(AzureUrlCategory.AZURE_UNIFIED)
+        ).isEqualTo(AzureUrlCategory.AZURE_UNIFIED)
 
         assertThat(
-                AzureUrlCategory.categorizeBaseUrl(
-                    "https://region.azure-api.net",
-                    AzureUrlPathMode.LEGACY,
-                )
+            AzureUrlCategory.categorizeBaseUrl(
+                "https://region.openai.azure.com",
+                AzureUrlPathMode.AUTO,
             )
-            .isEqualTo(AzureUrlCategory.AZURE_LEGACY)
-        assertThat(
-                AzureUrlCategory.categorizeBaseUrl(
-                    "https://region.azure-api.net",
-                    AzureUrlPathMode.UNIFIED,
-                )
-            )
-            .isEqualTo(AzureUrlCategory.AZURE_LEGACY)
-        assertThat(
-                AzureUrlCategory.categorizeBaseUrl(
-                    "https://region.azure-api.net/",
-                    AzureUrlPathMode.LEGACY,
-                )
-            )
-            .isEqualTo(AzureUrlCategory.AZURE_LEGACY)
-        assertThat(
-                AzureUrlCategory.categorizeBaseUrl(
-                    "https://region.azure-api.net/",
-                    AzureUrlPathMode.UNIFIED,
-                )
-            )
-            .isEqualTo(AzureUrlCategory.AZURE_LEGACY)
-        assertThat(
-                AzureUrlCategory.categorizeBaseUrl(
-                    "https://region.azure-api.net/openai/v1",
-                    AzureUrlPathMode.LEGACY,
-                )
-            )
-            .isEqualTo(AzureUrlCategory.AZURE_LEGACY)
-        assertThat(
-                AzureUrlCategory.categorizeBaseUrl(
-                    "https://region.azure-api.net/openai/v1",
-                    AzureUrlPathMode.UNIFIED,
-                )
-            )
-            .isEqualTo(AzureUrlCategory.AZURE_UNIFIED)
+        ).isEqualTo(AzureUrlCategory.AZURE_LEGACY)
 
+        // known legacy endpoint - trailing slash - force configuration
         assertThat(
-                AzureUrlCategory.categorizeBaseUrl(
-                    "https://region.cognitiveservices.azure.com",
-                    AzureUrlPathMode.LEGACY,
-                )
+            AzureUrlCategory.categorizeBaseUrl(
+                "https://region.openai.azure.com/",
+                AzureUrlPathMode.LEGACY,
             )
-            .isEqualTo(AzureUrlCategory.AZURE_LEGACY)
+        ).isEqualTo(AzureUrlCategory.AZURE_LEGACY)
         assertThat(
-                AzureUrlCategory.categorizeBaseUrl(
-                    "https://region.cognitiveservices.azure.com",
-                    AzureUrlPathMode.UNIFIED,
-                )
+            AzureUrlCategory.categorizeBaseUrl(
+                "https://region.openai.azure.com/",
+                AzureUrlPathMode.UNIFIED,
             )
-            .isEqualTo(AzureUrlCategory.AZURE_LEGACY)
+        ).isEqualTo(AzureUrlCategory.AZURE_UNIFIED)
         assertThat(
-                AzureUrlCategory.categorizeBaseUrl(
-                    "https://region.cognitiveservices.azure.com/",
-                    AzureUrlPathMode.LEGACY,
-                )
+            AzureUrlCategory.categorizeBaseUrl(
+                "https://region.openai.azure.com/",
+                AzureUrlPathMode.AUTO,
             )
-            .isEqualTo(AzureUrlCategory.AZURE_LEGACY)
-        assertThat(
-                AzureUrlCategory.categorizeBaseUrl(
-                    "https://region.cognitiveservices.azure.com/",
-                    AzureUrlPathMode.UNIFIED,
-                )
-            )
-            .isEqualTo(AzureUrlCategory.AZURE_LEGACY)
-        assertThat(
-                AzureUrlCategory.categorizeBaseUrl(
-                    "https://region.cognitiveservices.azure.com/openai/v1",
-                    AzureUrlPathMode.LEGACY,
-                )
-            )
-            .isEqualTo(AzureUrlCategory.AZURE_LEGACY)
-        assertThat(
-                AzureUrlCategory.categorizeBaseUrl(
-                    "https://region.cognitiveservices.azure.com/openai/v1",
-                    AzureUrlPathMode.UNIFIED,
-                )
-            )
-            .isEqualTo(AzureUrlCategory.AZURE_UNIFIED)
+        ).isEqualTo(AzureUrlCategory.AZURE_LEGACY)
 
+        // known unified endpoint -  forced into legacy - no trailing slash
+        assertThat(
+            AzureUrlCategory.categorizeBaseUrl(
+                "https://region.openai.azure.com/openai/v1",
+                AzureUrlPathMode.LEGACY,
+            )
+        ).isEqualTo(AzureUrlCategory.AZURE_LEGACY)
+        assertThat(
+            AzureUrlCategory.categorizeBaseUrl(
+                "https://region.openai.azure.com/openai/v1",
+                AzureUrlPathMode.UNIFIED,
+            )
+        ).isEqualTo(AzureUrlCategory.AZURE_UNIFIED)
+        assertThat(
+            AzureUrlCategory.categorizeBaseUrl(
+                "https://region.openai.azure.com/openai/v1",
+                AzureUrlPathMode.AUTO,
+            )
+        ).isEqualTo(AzureUrlCategory.AZURE_UNIFIED)
+
+        // known legacy endpoint - forced into unified - no trailing slash
+        assertThat(
+            AzureUrlCategory.categorizeBaseUrl(
+                "https://region.services.ai.azure.com",
+                AzureUrlPathMode.LEGACY,
+            )
+        ).isEqualTo(AzureUrlCategory.AZURE_LEGACY)
+        assertThat(
+            AzureUrlCategory.categorizeBaseUrl(
+                "https://region.services.ai.azure.com",
+                AzureUrlPathMode.UNIFIED,
+            )
+        ).isEqualTo(AzureUrlCategory.AZURE_UNIFIED)
+        assertThat(
+            AzureUrlCategory.categorizeBaseUrl(
+                "https://region.services.ai.azure.com",
+                AzureUrlPathMode.AUTO,
+            )
+        ).isEqualTo(AzureUrlCategory.AZURE_LEGACY)
+
+        // known legacy endpoint - forced into unified - trailing slash
+        assertThat(
+            AzureUrlCategory.categorizeBaseUrl(
+                "https://region.services.ai.azure.com/",
+                AzureUrlPathMode.LEGACY,
+            )
+        ).isEqualTo(AzureUrlCategory.AZURE_LEGACY)
+        assertThat(
+            AzureUrlCategory.categorizeBaseUrl(
+                "https://region.services.ai.azure.com/",
+                AzureUrlPathMode.UNIFIED,
+            )
+        ).isEqualTo(AzureUrlCategory.AZURE_UNIFIED)
+        assertThat(
+            AzureUrlCategory.categorizeBaseUrl(
+                "https://region.services.ai.azure.com/",
+                AzureUrlPathMode.AUTO,
+            )
+        ).isEqualTo(AzureUrlCategory.AZURE_LEGACY)
+
+        // known unified endpoint - forced into legacy - no trailing slash
+        assertThat(
+            AzureUrlCategory.categorizeBaseUrl(
+                "https://region.services.ai.azure.com/openai/v1",
+                AzureUrlPathMode.LEGACY,
+            )
+        ).isEqualTo(AzureUrlCategory.AZURE_LEGACY)
+        assertThat(
+            AzureUrlCategory.categorizeBaseUrl(
+                "https://region.services.ai.azure.com/openai/v1",
+                AzureUrlPathMode.UNIFIED,
+            )
+        ).isEqualTo(AzureUrlCategory.AZURE_UNIFIED)
+        assertThat(
+            AzureUrlCategory.categorizeBaseUrl(
+                "https://region.services.ai.azure.com/openai/v1",
+                AzureUrlPathMode.AUTO,
+            )
+        ).isEqualTo(AzureUrlCategory.AZURE_UNIFIED)
+
+        // known legacy endpoint - no trailing slash
+        assertThat(
+            AzureUrlCategory.categorizeBaseUrl(
+                "https://region.azure-api.net",
+                AzureUrlPathMode.LEGACY,
+            )
+        ).isEqualTo(AzureUrlCategory.AZURE_LEGACY)
+        assertThat(
+            AzureUrlCategory.categorizeBaseUrl(
+                "https://region.azure-api.net",
+                AzureUrlPathMode.UNIFIED,
+            )
+        ).isEqualTo(AzureUrlCategory.AZURE_UNIFIED)
+        assertThat(
+            AzureUrlCategory.categorizeBaseUrl(
+                "https://region.azure-api.net",
+                AzureUrlPathMode.AUTO,
+            )
+        ).isEqualTo(AzureUrlCategory.AZURE_LEGACY)
+
+        // known legacy endpoint - trailing slash
+        assertThat(
+            AzureUrlCategory.categorizeBaseUrl(
+                "https://region.azure-api.net/",
+                AzureUrlPathMode.LEGACY,
+            )
+        ).isEqualTo(AzureUrlCategory.AZURE_LEGACY)
+        assertThat(
+            AzureUrlCategory.categorizeBaseUrl(
+                "https://region.azure-api.net/",
+                AzureUrlPathMode.UNIFIED,
+            )
+        ).isEqualTo(AzureUrlCategory.AZURE_UNIFIED)
+        assertThat(
+            AzureUrlCategory.categorizeBaseUrl(
+                "https://region.azure-api.net/",
+                AzureUrlPathMode.AUTO,
+            )
+        ).isEqualTo(AzureUrlCategory.AZURE_LEGACY)
+
+        // known unified endpoint - no trailing slash
+        assertThat(
+            AzureUrlCategory.categorizeBaseUrl(
+                "https://region.azure-api.net/openai/v1",
+                AzureUrlPathMode.LEGACY,
+            )
+        ).isEqualTo(AzureUrlCategory.AZURE_LEGACY)
+        assertThat(
+            AzureUrlCategory.categorizeBaseUrl(
+                "https://region.azure-api.net/openai/v1",
+                AzureUrlPathMode.UNIFIED,
+            )
+        ).isEqualTo(AzureUrlCategory.AZURE_UNIFIED)
+        assertThat(
+            AzureUrlCategory.categorizeBaseUrl(
+                "https://region.azure-api.net/openai/v1",
+                AzureUrlPathMode.AUTO,
+            )
+        ).isEqualTo(AzureUrlCategory.AZURE_UNIFIED)
+
+        // known legacy endpoint - no trailing slash
+        assertThat(
+            AzureUrlCategory.categorizeBaseUrl(
+                "https://region.cognitiveservices.azure.com",
+                AzureUrlPathMode.LEGACY,
+            )
+        ).isEqualTo(AzureUrlCategory.AZURE_LEGACY)
+        assertThat(
+            AzureUrlCategory.categorizeBaseUrl(
+                "https://region.cognitiveservices.azure.com",
+                AzureUrlPathMode.UNIFIED,
+            )
+        ).isEqualTo(AzureUrlCategory.AZURE_UNIFIED)
+        assertThat(
+            AzureUrlCategory.categorizeBaseUrl(
+                "https://region.cognitiveservices.azure.com",
+                AzureUrlPathMode.AUTO,
+            )
+        ).isEqualTo(AzureUrlCategory.AZURE_LEGACY)
+
+        // known unified endpoint - trailing slash
+        assertThat(
+            AzureUrlCategory.categorizeBaseUrl(
+                "https://region.cognitiveservices.azure.com/",
+                AzureUrlPathMode.LEGACY,
+            )
+        ).isEqualTo(AzureUrlCategory.AZURE_LEGACY)
+        assertThat(
+            AzureUrlCategory.categorizeBaseUrl(
+                "https://region.cognitiveservices.azure.com/",
+                AzureUrlPathMode.UNIFIED,
+            )
+        )
+            .isEqualTo(AzureUrlCategory.AZURE_UNIFIED)
+        assertThat(
+            AzureUrlCategory.categorizeBaseUrl(
+                "https://region.cognitiveservices.azure.com/",
+                AzureUrlPathMode.AUTO,
+            )
+        ).isEqualTo(AzureUrlCategory.AZURE_LEGACY)
+
+        // known unified endpoint - no trailing slash
+        assertThat(
+            AzureUrlCategory.categorizeBaseUrl(
+                "https://region.cognitiveservices.azure.com/openai/v1",
+                AzureUrlPathMode.LEGACY,
+            )
+        ).isEqualTo(AzureUrlCategory.AZURE_LEGACY)
+        assertThat(
+            AzureUrlCategory.categorizeBaseUrl(
+                "https://region.cognitiveservices.azure.com/openai/v1",
+                AzureUrlPathMode.UNIFIED,
+            )
+        ).isEqualTo(AzureUrlCategory.AZURE_UNIFIED)
+        assertThat(
+            AzureUrlCategory.categorizeBaseUrl(
+                "https://region.cognitiveservices.azure.com/openai/v1",
+                AzureUrlPathMode.AUTO,
+            )
+        ).isEqualTo(AzureUrlCategory.AZURE_UNIFIED)
+    }
+
+    @Test
+    fun categorizeBaseUrl_otherUrls() {
         assertThat(
                 AzureUrlCategory.categorizeBaseUrl("https://example.com", AzureUrlPathMode.LEGACY)
             )
-            .isEqualTo(AzureUrlCategory.NON_AZURE)
+            .isEqualTo(AzureUrlCategory.AZURE_LEGACY)
         assertThat(
                 AzureUrlCategory.categorizeBaseUrl("https://example.com", AzureUrlPathMode.UNIFIED)
             )
+            .isEqualTo(AzureUrlCategory.AZURE_UNIFIED)
+        assertThat(
+            AzureUrlCategory.categorizeBaseUrl("https://example.com", AzureUrlPathMode.AUTO)
+        )
             .isEqualTo(AzureUrlCategory.NON_AZURE)
+
         assertThat(
                 AzureUrlCategory.categorizeBaseUrl("https://example.com/", AzureUrlPathMode.LEGACY)
             )
-            .isEqualTo(AzureUrlCategory.NON_AZURE)
+            .isEqualTo(AzureUrlCategory.AZURE_LEGACY)
         assertThat(
                 AzureUrlCategory.categorizeBaseUrl("https://example.com/", AzureUrlPathMode.UNIFIED)
             )
+            .isEqualTo(AzureUrlCategory.AZURE_UNIFIED)
+        assertThat(
+            AzureUrlCategory.categorizeBaseUrl("https://example.com/", AzureUrlPathMode.AUTO)
+        )
             .isEqualTo(AzureUrlCategory.NON_AZURE)
+
         assertThat(
                 AzureUrlCategory.categorizeBaseUrl(
                     "https://example.com/openai/v1",
                     AzureUrlPathMode.LEGACY,
                 )
             )
-            .isEqualTo(AzureUrlCategory.NON_AZURE)
+            .isEqualTo(AzureUrlCategory.AZURE_LEGACY)
         assertThat(
                 AzureUrlCategory.categorizeBaseUrl(
                     "https://example.com/openai/v1",
                     AzureUrlPathMode.UNIFIED,
                 )
             )
+            .isEqualTo(AzureUrlCategory.AZURE_UNIFIED)
+        assertThat(
+            AzureUrlCategory.categorizeBaseUrl(
+                "https://example.com/openai/v1",
+                AzureUrlPathMode.AUTO,
+            )
+        )
             .isEqualTo(AzureUrlCategory.NON_AZURE)
     }
 }


### PR DESCRIPTION
### Changes

Adresses #581 

The main changes:
- Introduced new variant of `AzureUrlPathMode.AUTO` to encapsulate the old behaviour (we attempt an educated guess to determined whether a baseURL `isAzure` and if it corresponds to `AZURE_LEGACY` or `AZURE_UNIFIED`
- We made the entry for this flag in `ClientOptions` default to the new `AzureUrlPathMode.AUTO` variant.
- `AzureUrlPathMode.LEGACY` and `AzureUrlPathMode.UNIFIED` are now configuration values for users to manually force their clients to behave the way they want. We don't attempt any guesses, we assume users know what they are doing.

### Why?

We are currently checking the `baseUrl` to match a few known hosts to determine whether `isAzure` is true. Considering the possibility that users could (and do) use proxies, the list of known hosts to be Azure is too limited. 

Providing users with the means to declare that their `baseUrl` corresponds to an Azure OpenAI instance, enables them to move forward.