### PR TITLE
Fix: The withOptions method of OpenAIClientImpl cannot modify authentication credentials

### DIFF
--- a/openai-java-core/src/main/kotlin/com/openai/core/ClientOptions.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/core/ClientOptions.kt
@@ -534,19 +534,20 @@ private constructor(
             headers.put("X-Stainless-Runtime-Version", getJavaVersion())
             organization?.let { headers.put("OpenAI-Organization", it) }
             project?.let { headers.put("OpenAI-Project", it) }
-
+         
+            headers.replaceAll(this.headers.build())
             when (credential) {
                 is AzureApiKeyCredential -> {
-                    headers.put("api-key", credential.apiKey())
+                    headers.replace("api-key", credential.apiKey())
                 }
                 is BearerTokenCredential -> {
-                    headers.put("Authorization", "Bearer ${credential.token()}")
+                    headers.replace("Authorization", "Bearer ${credential.token()}")
                 }
                 else -> {
                     throw IllegalArgumentException("Invalid credential type")
                 }
             }
-
+            
             baseUrl?.let {
                 when (AzureUrlCategory.categorizeBaseUrl(it, azureUrlPathMode)) {
                     // Legacy Azure routes will still require an api-version value.
@@ -565,7 +566,6 @@ private constructor(
                 }
             }
 
-            headers.replaceAll(this.headers.build())
             queryParams.replaceAll(this.queryParams.build())
 
             return ClientOptions(


### PR DESCRIPTION
Fix the issuses in https://github.com/openai/openai-java/issues/661 and https://github.com/openai/openai-java/issues/670

When modifying the API key or credentials via OpenAIClient  by calling withOptions() on the client, the temporary client still uses the original client's authentication information.
```
OpenAIClient clientWithOptions = client.withOptions(opt -> {
        opt.apiKey("sk-test111111111111111111111111");
    });

    OpenAIClient clientWithOptions = client.withOptions(opt -> {
        opt.credential(BearerTokenCredential.create("sk-test111111111111111111111111"));
    });
```