### PR TITLE
Fix docs: remove duplicate section and code formatting in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,7 +103,6 @@ Then run the tests:
 
 ```sh
 $ ./scripts/test
-
 ```
 
 ### Test configuration
@@ -159,22 +158,6 @@ To build a specific module:
 
 ```sh
 $ ./gradlew :openai-java-core:build
-```
-
-## Adding and running examples
-
-All files in the `openai-java-example/` directory are not modified by the generator and can be freely edited or added to.
-
-```java
-// add an example to openai-java-example/src/main/java/com/openai/example/<YourExample>.java
-
-package com.openai.example;
-
-public class YourExample {
-    public static void main(String[] args) {
-        // ...
-    }
-}
 ```
 
 ## Publishing and releases


### PR DESCRIPTION
Fixes documentation issues in CONTRIBUTING.md by removing the duplicate 'Adding and running examples' section and fixing extra blank line in code fence.