### PR TITLE
fix(logging): redact Azure api-key header in HttpLoggingInterceptor

### DIFF
--- a/openai-java-client-okhttp/src/main/kotlin/com/openai/client/okhttp/OkHttpClient.kt
+++ b/openai-java-client-okhttp/src/main/kotlin/com/openai/client/okhttp/OkHttpClient.kt
@@ -95,7 +95,10 @@ internal constructor(@JvmSynthetic internal val okHttpClient: okhttp3.OkHttpClie
             }
         if (logLevel != null) {
             clientBuilder.addNetworkInterceptor(
-                HttpLoggingInterceptor().setLevel(logLevel).apply { redactHeader("Authorization") }
+                HttpLoggingInterceptor().setLevel(logLevel).apply {
+                    redactHeader("Authorization")
+                    redactHeader("api-key")
+                }
             )
         }
 


### PR DESCRIPTION
## Summary

This PR prevents Azure API keys from being exposed in application logs by redacting the `api-key` header in `HttpLoggingInterceptor`.

## What changed

* added `redactHeader("api-key")`
* kept the existing `redactHeader("Authorization")`
* applied the change in the OkHttp logging interceptor configuration

## Why

When request logging is enabled, the Azure `api-key` header may otherwise be written to logs in plaintext. This creates a risk of credential leakage during debugging or in downstream log systems.

## Impact

* improves protection of sensitive credentials in logs
* does not change request behavior
* only affects logging output

## Verification

* reviewed the interceptor configuration to confirm both sensitive headers are redacted
* change uses standard OkHttp `HttpLoggingInterceptor` API
* local Gradle verification was limited by command timeout, but the modification is straightforward and low risk
