### PR TITLE
perf(json): cache JsonMapper instance in jsonMapper()

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,4 +1,0 @@
-## 2024-04-10 - Optimizing jsonMapper() creation
-**Learning:** `jsonMapper()` is a global function in `com.openai.core.ObjectMappers` that calls `JsonMapper.builder()...build()` every time it's invoked. This is a very expensive operation in Jackson, as module registration and builder construction are slow. This method is called in many places like parsing exceptions, initializing clients, tests, and webhooks. Jackson documentation recommends configuring `ObjectMapper` (or `JsonMapper`) once and reusing it.
-
-**Action:** Convert `jsonMapper()` to return a single lazily-initialized or statically-initialized `JsonMapper` instance. Or, change it to a lazy property like `val jsonMapper: JsonMapper by lazy { ... }` (but since it's an API, keep `fun jsonMapper(): JsonMapper` and back it with a private constant).

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,4 @@
+## 2024-04-10 - Optimizing jsonMapper() creation
+**Learning:** `jsonMapper()` is a global function in `com.openai.core.ObjectMappers` that calls `JsonMapper.builder()...build()` every time it's invoked. This is a very expensive operation in Jackson, as module registration and builder construction are slow. This method is called in many places like parsing exceptions, initializing clients, tests, and webhooks. Jackson documentation recommends configuring `ObjectMapper` (or `JsonMapper`) once and reusing it.
+
+**Action:** Convert `jsonMapper()` to return a single lazily-initialized or statically-initialized `JsonMapper` instance. Or, change it to a lazy property like `val jsonMapper: JsonMapper by lazy { ... }` (but since it's an API, keep `fun jsonMapper(): JsonMapper` and back it with a private constant).

--- a/openai-java-core/src/main/kotlin/com/openai/core/ObjectMappers.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/core/ObjectMappers.kt
@@ -29,7 +29,10 @@ import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoField
 
-fun jsonMapper(): JsonMapper =
+// Cache the Jackson JsonMapper instance to avoid the massive performance overhead of
+// registering modules and building the mapper on every single invocation.
+// This single lazily-initialized instance is thread-safe and can be reused globally.
+private val JSON_MAPPER: JsonMapper by lazy {
     JsonMapper.builder()
         .addModule(kotlinModule())
         .addModule(Jdk8Module())
@@ -112,6 +115,9 @@ fun jsonMapper(): JsonMapper =
         .disable(MapperFeature.AUTO_DETECT_IS_GETTERS)
         .disable(MapperFeature.AUTO_DETECT_SETTERS)
         .build()
+}
+
+fun jsonMapper(): JsonMapper = JSON_MAPPER
 
 /** A serializer that serializes [InputStream] to bytes. */
 private object InputStreamSerializer : BaseSerializer<InputStream>(InputStream::class) {


### PR DESCRIPTION
## Summary

This PR optimizes `jsonMapper()` by returning a single lazily initialized and cached `JsonMapper` instance instead of building a new mapper on every call.

## What changed

* replaced per-call `JsonMapper.builder()...build()` construction with a cached singleton-style mapper
* kept mapper configuration unchanged while ensuring initialization happens only once

## Why

Building a Jackson mapper is relatively expensive because it registers modules and applies configuration during construction. Since `jsonMapper()` can be called frequently across parsing and serialization paths, recreating the mapper on every invocation adds unnecessary CPU and allocation overhead.

## Impact

* reduces repeated mapper construction cost
* lowers CPU and memory allocation overhead for repeated `jsonMapper()` calls
* preserves behavior while improving efficiency

## Notes

Jackson `ObjectMapper` / `JsonMapper` instances are thread-safe after configuration, so reusing a single initialized instance is safe here.

## Verification

* reviewed the refactor to confirm mapper configuration is preserved
* confirmed initialization now occurs only once
* expected performance gains are concentrated in code paths that call `jsonMapper()` repeatedly
