### PR TITLE
fix: tolerate post-completion stream events in ResponseAccumulator

### DIFF
--- a/openai-java-core/src/main/kotlin/com/openai/helpers/ResponseAccumulator.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/helpers/ResponseAccumulator.kt
@@ -116,7 +116,13 @@ class ResponseAccumulator private constructor() {
      *   accumulated. A [ResponseAccumulator] can only be used to accumulate a single [Response].
      */
     fun accumulate(event: ResponseStreamEvent): ResponseStreamEvent {
-        check(response == null) { "Response has already been completed." }
+        // The API may send non-terminal events (e.g. `response.rate_limits.updated`) after a
+        // terminal event (`response.completed`, `response.failed`, `response.incomplete`).
+        // These events do not carry response data and are safe to ignore. Throwing here would
+        // break callers that pass every streamed event to the accumulator.
+        if (response != null) {
+            return event
+        }
 
         event.accept(
             object : ResponseStreamEvent.Visitor<Unit> {

--- a/openai-java-core/src/test/kotlin/com/openai/helpers/ResponseAccumulatorTest.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/helpers/ResponseAccumulatorTest.kt
@@ -62,16 +62,17 @@ internal class ResponseAccumulatorTest {
     }
 
     @Test
-    fun accumulateAfterCompleted() {
+    fun accumulateAfterCompletedIgnoresPostCompletionEvents() {
         val accumulator = ResponseAccumulator.create()
 
         accumulator.accumulate(ResponseStreamEvent.ofCompleted(responseCompletedEvent()))
 
-        assertThatThrownBy {
-                accumulator.accumulate(ResponseStreamEvent.ofCompleted(responseCompletedEvent()))
-            }
-            .isExactlyInstanceOf(IllegalStateException::class.java)
-            .hasMessage("Response has already been completed.")
+        // Post-completion events (e.g. `response.rate_limits.updated`) should be silently
+        // ignored rather than throwing. The original response should remain intact.
+        assertThatNoException().isThrownBy {
+            accumulator.accumulate(ResponseStreamEvent.ofCreated(responseCreatedEvent()))
+        }
+        assertThat(accumulator.response().id()).isEqualTo("response-id")
     }
 
     @Test


### PR DESCRIPTION
## Summary

The Responses API sends `response.rate_limits.updated` events after the terminal `response.completed` event. `ResponseAccumulator.accumulate()` throws `IllegalStateException("Response has already been completed.")` on any event received after a terminal event, which crashes callers that pass every streamed event through it.

This replaces the hard `check` with an early `return` so post-completion events are silently ignored and the accumulated response remains intact.

## Reproduction

```bash
curl https://api.openai.com/v1/responses \
  -H "Authorization: Bearer $OPENAI_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{
    "input": "What is the weather in San Francisco?",
    "model": "gpt-4.1",
    "tools": [{
      "name": "get_weather",
      "type": "function",
      "description": "Get weather",
      "parameters": {"type":"object","properties":{"location":{"type":"string"}},"required":["location"]}
    }],
    "stream": true
  }'
```

The stream ends with:
```
event: response.completed
data: {"type":"response.completed", ...}

event: response.rate_limits.updated
data: {"type":"response.rate_limits.updated", ...}
```

Passing these events to `ResponseAccumulator` throws:
```
java.lang.IllegalStateException: Response has already been completed.
    at com.openai.helpers.ResponseAccumulator.accumulate(ResponseAccumulator.kt:119)
```

## Test plan
- Updated `accumulateAfterCompleted` test to assert post-completion events are ignored rather than throwing
- Verified accumulated response remains intact after receiving post-completion events
- All existing `ResponseAccumulatorTest` tests pass