### PR TITLE
fix(audio): add missing speech voice constants

### DIFF
--- a/openai-java-core/src/main/kotlin/com/openai/models/audio/speech/SpeechCreateParams.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/models/audio/speech/SpeechCreateParams.kt
@@ -1227,6 +1227,12 @@ private constructor(
 
                 @JvmField val ECHO = of("echo")
 
+                @JvmField val FABLE = of("fable")
+
+                @JvmField val ONYX = of("onyx")
+
+                @JvmField val NOVA = of("nova")
+
                 @JvmField val SAGE = of("sage")
 
                 @JvmField val SHIMMER = of("shimmer")
@@ -1247,6 +1253,9 @@ private constructor(
                 BALLAD,
                 CORAL,
                 ECHO,
+                FABLE,
+                ONYX,
+                NOVA,
                 SAGE,
                 SHIMMER,
                 VERSE,
@@ -1269,6 +1278,9 @@ private constructor(
                 BALLAD,
                 CORAL,
                 ECHO,
+                FABLE,
+                ONYX,
+                NOVA,
                 SAGE,
                 SHIMMER,
                 VERSE,
@@ -1295,6 +1307,9 @@ private constructor(
                     BALLAD -> Value.BALLAD
                     CORAL -> Value.CORAL
                     ECHO -> Value.ECHO
+                    FABLE -> Value.FABLE
+                    ONYX -> Value.ONYX
+                    NOVA -> Value.NOVA
                     SAGE -> Value.SAGE
                     SHIMMER -> Value.SHIMMER
                     VERSE -> Value.VERSE
@@ -1319,6 +1334,9 @@ private constructor(
                     BALLAD -> Known.BALLAD
                     CORAL -> Known.CORAL
                     ECHO -> Known.ECHO
+                    FABLE -> Known.FABLE
+                    ONYX -> Known.ONYX
+                    NOVA -> Known.NOVA
                     SAGE -> Known.SAGE
                     SHIMMER -> Known.SHIMMER
                     VERSE -> Known.VERSE

--- a/openai-java-core/src/test/kotlin/com/openai/models/audio/speech/SpeechCreateParamsTest.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/models/audio/speech/SpeechCreateParamsTest.kt
@@ -65,4 +65,14 @@ internal class SpeechCreateParamsTest {
                 SpeechCreateParams.Voice.ofUnionMember1(SpeechCreateParams.Voice.UnionMember1.ALLOY)
             )
     }
+
+    @Test
+    fun voiceKnownValuesIncludeSupportedSpeechVoices() {
+        assertThat(SpeechCreateParams.Voice.UnionMember1.FABLE.known())
+            .isEqualTo(SpeechCreateParams.Voice.UnionMember1.Known.FABLE)
+        assertThat(SpeechCreateParams.Voice.UnionMember1.ONYX.known())
+            .isEqualTo(SpeechCreateParams.Voice.UnionMember1.Known.ONYX)
+        assertThat(SpeechCreateParams.Voice.UnionMember1.NOVA.known())
+            .isEqualTo(SpeechCreateParams.Voice.UnionMember1.Known.NOVA)
+    }
 }


### PR DESCRIPTION
Fixes #642.

Summary:
- add `fable`, `onyx`, and `nova` as known `SpeechCreateParams.Voice.UnionMember1` values
- wire the new values through `Known`, `Value`, `value()`, and `known()`
- add regression coverage for the missing known speech voices

Validation:
- `./gradlew :openai-java-core:test --tests com.openai.models.audio.speech.SpeechCreateParamsTest --stacktrace` could not run locally because the installed JDK is Temurin 25.0.2 and the repo's Kotlin/Gradle DSL stack fails while parsing that Java version string (`java.lang.IllegalArgumentException: 25.0.2`).