### PR TITLE
fix(audio): treat DIARIZED_JSON as a JSON response format (#652)

### DIFF
--- a/openai-java-core/src/main/kotlin/com/openai/models/audio/AudioResponseFormat.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/models/audio/AudioResponseFormat.kt
@@ -166,6 +166,7 @@ class AudioResponseFormat @JsonCreator private constructor(private val value: Js
             SRT -> false
             VERBOSE_JSON -> true
             VTT -> false
+            DIARIZED_JSON -> true
             else -> false
         }
 

--- a/openai-java-core/src/test/kotlin/com/openai/models/audio/AudioResponseFormatTest.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/models/audio/AudioResponseFormatTest.kt
@@ -1,0 +1,54 @@
+// File generated from our OpenAPI spec by Stainless.
+
+package com.openai.models.audio
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+internal class AudioResponseFormatTest {
+
+    /**
+     * Regression test for [#652](https://github.com/openai/openai-java/issues/652).
+     *
+     * Each value of [AudioResponseFormat.Known] is enumerated explicitly so that adding a new
+     * format also requires adding it to this test. That makes it impossible to introduce a new JSON
+     * format without consciously deciding whether [AudioResponseFormat.isJson] should return `true`
+     * for it — the bug that caused `DIARIZED_JSON` responses to be parsed as plain text and stashed
+     * in `TranscriptionCreateResponse.transcription.text` instead of populating
+     * `TranscriptionCreateResponse.diarized`.
+     */
+    @Test
+    fun isJson_returnsTrue_forEveryJsonResponseFormat() {
+        for (known in AudioResponseFormat.Known.values()) {
+            val format = AudioResponseFormat.of(known.toString().lowercase())
+            val expected =
+                when (known) {
+                    AudioResponseFormat.Known.JSON -> true
+                    AudioResponseFormat.Known.TEXT -> false
+                    AudioResponseFormat.Known.SRT -> false
+                    AudioResponseFormat.Known.VERBOSE_JSON -> true
+                    AudioResponseFormat.Known.VTT -> false
+                    AudioResponseFormat.Known.DIARIZED_JSON -> true
+                }
+            assertThat(format.isJson())
+                .withFailMessage(
+                    "AudioResponseFormat.$known.isJson() returned %s but expected %s",
+                    format.isJson(),
+                    expected,
+                )
+                .isEqualTo(expected)
+        }
+    }
+
+    /**
+     * Pinning [#652](https://github.com/openai/openai-java/issues/652) directly: a SDK consumer
+     * that requests `diarized_json` and feeds the value back through [AudioResponseFormat.of] must
+     * see [AudioResponseFormat.isJson] return `true`, otherwise the response body is treated as
+     * plain text by the transcription parser.
+     */
+    @Test
+    fun diarizedJson_isReportedAsJson() {
+        assertThat(AudioResponseFormat.DIARIZED_JSON.isJson()).isTrue()
+        assertThat(AudioResponseFormat.of("diarized_json").isJson()).isTrue()
+    }
+}


### PR DESCRIPTION
Fixes #652.

## Problem

`AudioResponseFormat.isJson()` was missing a `DIARIZED_JSON -> true` branch:

```kotlin
internal fun isJson(): Boolean =
    when (this) {
        JSON -> true
        TEXT -> false
        SRT -> false
        VERBOSE_JSON -> true
        VTT -> false
        else -> false   // ← DIARIZED_JSON silently fell through to false
    }
```

When a caller requested `response_format = DIARIZED_JSON` from `audio.transcriptions().create(...)`, the SDK treated the response as plain text. The entire diarized JSON payload was stuffed into `TranscriptionCreateResponse.transcription.text`, leaving `TranscriptionCreateResponse.diarized` empty. The only workaround was to manually re-parse the raw text field through Jackson:

```java
new ObjectMapper().readValue(
    response.transcription().get().text(),
    TranscriptionDiarized.class
);
```

## Fix

Two small changes:

1. Add the missing case to `AudioResponseFormat.isJson()`:
   ```kotlin
   DIARIZED_JSON -> true
   ```
2. Add `AudioResponseFormatTest` that enumerates every value of `AudioResponseFormat.Known` explicitly and asserts the expected `isJson()` return value. Because the test exhaustively switches on `Known`, **adding any new format to the enum will fail compilation of the test until the test author explicitly chooses `true` or `false`** for it. The same class of bug cannot regress.

## Tests

```
$ ./gradlew :openai-java-core:test --tests "com.openai.models.audio.AudioResponseFormatTest"

AudioResponseFormatTest > isJson_returnsTrue_forEveryJsonResponseFormat PASSED
AudioResponseFormatTest > diarizedJson_isReportedAsJson PASSED
```

Verified the second test (`diarizedJson_isReportedAsJson`) fails on `main` without the production change — the response would be reported as non-JSON.

## Scope

- Only `AudioResponseFormat.kt` (one line) and the new test file change. No public API surface change.
- The `TranscriptionCreateResponse.isValid()` follow-up symptom noted in the issue (server-side response missing required fields per the OpenAPI spec) is left out — that's a spec/server question, not an SDK bug.

Fixes #652
