### PR TITLE
Protect Maven Central publishing secrets

### DIFF
--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -11,7 +11,8 @@ jobs:
     name: release
     if: github.ref == 'refs/heads/main' && github.repository == 'openai/openai-java'
     runs-on: ubuntu-latest
-    environment: publish
+    outputs:
+      releases_created: ${{ steps.release.outputs.releases_created }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -22,8 +23,17 @@ jobs:
           repo: ${{ github.event.repository.full_name }}
           stainless-api-key: ${{ secrets.STAINLESS_API_KEY }}
 
+  publish:
+    name: publish
+    needs: release
+    if: ${{ needs.release.outputs.releases_created == 'true' }}
+    runs-on: ubuntu-latest
+    environment: publish
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
       - name: Set up Java
-        if: ${{ steps.release.outputs.releases_created }}
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: temurin
@@ -33,7 +43,6 @@ jobs:
           cache: gradle
 
       - name: Set up Gradle
-        if: ${{ steps.release.outputs.releases_created }}
         uses: gradle/gradle-build-action@fe583dc97e032f41ccc310ea5176f2d7306abbc4 # v2
 
       - name: Compile the openai-java-core project
@@ -68,14 +77,13 @@ jobs:
           fi
 
       - name: Publish to Sonatype
-        if: ${{ steps.release.outputs.releases_created }}
         run: |-
           export -- GPG_SIGNING_KEY_ID
           printenv -- GPG_SIGNING_KEY | gpg --batch --passphrase-fd 3 --import 3<<< "$GPG_SIGNING_PASSWORD"
           GPG_SIGNING_KEY_ID="$(gpg --with-colons --list-keys | awk -F : -- '/^pub:/ { getline; print "0x" substr($10, length($10) - 7) }')"
           ./gradlew publishAndReleaseToMavenCentral --stacktrace -PmavenCentralUsername="$SONATYPE_USERNAME" -PmavenCentralPassword="$SONATYPE_PASSWORD" --no-configuration-cache
         env:
-          SONATYPE_USERNAME: ${{ secrets.OPENAI_SONATYPE_USERNAME || secrets.SONATYPE_USERNAME }}
-          SONATYPE_PASSWORD: ${{ secrets.OPENAI_SONATYPE_PASSWORD || secrets.SONATYPE_PASSWORD }}
-          GPG_SIGNING_KEY: ${{ secrets.OPENAI_SONATYPE_GPG_SIGNING_KEY || secrets.GPG_SIGNING_KEY }}
-          GPG_SIGNING_PASSWORD: ${{ secrets.OPENAI_SONATYPE_GPG_SIGNING_PASSWORD || secrets.GPG_SIGNING_PASSWORD }}
+          SONATYPE_USERNAME: ${{ secrets.OPENAI_SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.OPENAI_SONATYPE_PASSWORD }}
+          GPG_SIGNING_KEY: ${{ secrets.OPENAI_SONATYPE_GPG_SIGNING_KEY }}
+          GPG_SIGNING_PASSWORD: ${{ secrets.OPENAI_SONATYPE_GPG_SIGNING_PASSWORD }}

--- a/.github/workflows/publish-sonatype.yml
+++ b/.github/workflows/publish-sonatype.yml
@@ -8,6 +8,7 @@ jobs:
   publish:
     name: publish
     runs-on: ubuntu-latest
+    environment: publish
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -62,7 +63,7 @@ jobs:
           GPG_SIGNING_KEY_ID="$(gpg --with-colons --list-keys | awk -F : -- '/^pub:/ { getline; print "0x" substr($10, length($10) - 7) }')"
           ./gradlew publishAndReleaseToMavenCentral --stacktrace -PmavenCentralUsername="$SONATYPE_USERNAME" -PmavenCentralPassword="$SONATYPE_PASSWORD" --no-configuration-cache
         env:
-          SONATYPE_USERNAME: ${{ secrets.OPENAI_SONATYPE_USERNAME || secrets.SONATYPE_USERNAME }}
-          SONATYPE_PASSWORD: ${{ secrets.OPENAI_SONATYPE_PASSWORD || secrets.SONATYPE_PASSWORD }}
-          GPG_SIGNING_KEY: ${{ secrets.OPENAI_SONATYPE_GPG_SIGNING_KEY || secrets.GPG_SIGNING_KEY }}
-          GPG_SIGNING_PASSWORD: ${{ secrets.OPENAI_SONATYPE_GPG_SIGNING_PASSWORD || secrets.GPG_SIGNING_PASSWORD }}
+          SONATYPE_USERNAME: ${{ secrets.OPENAI_SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.OPENAI_SONATYPE_PASSWORD }}
+          GPG_SIGNING_KEY: ${{ secrets.OPENAI_SONATYPE_GPG_SIGNING_KEY }}
+          GPG_SIGNING_PASSWORD: ${{ secrets.OPENAI_SONATYPE_GPG_SIGNING_PASSWORD }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,21 +184,55 @@ the changes aren't made through the automated pipeline, you may want to make rel
 
 ### Publish with a GitHub workflow
 
-You can release to package managers by using [the `Publish Sonatype` GitHub action](https://www.github.com/openai/openai-java/actions/workflows/publish-sonatype.yml). This requires setup organization or repository secrets to be configured.
+You can release to package managers by using [the `Publish Sonatype` GitHub action](https://www.github.com/openai/openai-java/actions/workflows/publish-sonatype.yml). This requires the GitHub `publish` environment to be configured.
+
+The `publish` environment must have these environment secrets:
+
+- `OPENAI_SONATYPE_USERNAME` - The username from a Central Portal user token
+- `OPENAI_SONATYPE_PASSWORD` - The password from a Central Portal user token
+- `OPENAI_SONATYPE_GPG_SIGNING_KEY` - The ASCII-armored GPG private key used for signing artifacts
+- `OPENAI_SONATYPE_GPG_SIGNING_PASSWORD` - The GPG key passphrase
+
+To rotate credentials, generate a new Central Portal user token and update `OPENAI_SONATYPE_USERNAME` and
+`OPENAI_SONATYPE_PASSWORD`. If rotating the signing key, generate a passphrase-protected GPG key and publish the public
+key:
+
+```sh
+$ gpg --quick-gen-key "OpenAI Maven Central <maintainer@openai.com>" rsa4096 sign 0
+$ gpg --list-secret-keys --keyid-format LONG
+$ gpg --armor --export-secret-keys KEY_ID > openai-sonatype-signing-key.asc
+$ gpg --keyserver keyserver.ubuntu.com --send-keys KEY_ID
+```
+
+The `0` makes the key non-expiring. `KEY_ID` is the value after the slash on the `sec` line from
+`gpg --list-secret-keys`, for example `42B825E73825CCEB` in `sec rsa4096/42B825E73825CCEB`. The GPG email does not need
+to match the Central Portal token account.
+
+```sh
+$ gh secret set OPENAI_SONATYPE_USERNAME --env publish --repo openai/openai-java
+$ gh secret set OPENAI_SONATYPE_PASSWORD --env publish --repo openai/openai-java
+$ gh secret set OPENAI_SONATYPE_GPG_SIGNING_KEY --env publish --repo openai/openai-java < openai-sonatype-signing-key.asc
+$ gh secret set OPENAI_SONATYPE_GPG_SIGNING_PASSWORD --env publish --repo openai/openai-java
+```
+
+After the rotated secrets work, revoke the old Central Portal token and remove any old repository-level copies of the
+`OPENAI_SONATYPE_*` secrets.
 
 ### Publish manually
 
 If you need to manually release a package, you can run:
 
 ```sh
-$ ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
+$ ./gradlew publishAndReleaseToMavenCentral \
+    -PmavenCentralUsername="$SONATYPE_USERNAME" \
+    -PmavenCentralPassword="$SONATYPE_PASSWORD"
 ```
 
 This requires the following environment variables to be set:
 
-- `SONATYPE_USER` - Your Sonatype Central Portal username
-- `SONATYPE_PASSWORD` - Your Sonatype Central Portal password
-- `GPG_SIGNING_KEY` - Your GPG private key for signing artifacts
+- `SONATYPE_USERNAME` - The username from a Central Portal user token
+- `SONATYPE_PASSWORD` - The password from a Central Portal user token
+- `GPG_SIGNING_KEY` - Your ASCII-armored GPG private key for signing artifacts
 - `GPG_SIGNING_PASSWORD` - Your GPG key passphrase
 
 ## Development tools


### PR DESCRIPTION
## Summary

- move Maven Central publishing credentials behind the protected `publish` environment
- split release creation from publishing so Maven Central secrets are only available to the publish job
- keep the existing `OPENAI_SONATYPE_*` secret names and document rotation steps

## Validation

- `actionlint`
- `git diff --check`
- `./gradlew publishAndReleaseToMavenCentral --dry-run --stacktrace -PmavenCentralUsername=dummy -PmavenCentralPassword=dummy --no-configuration-cache` with JDK 21
- `./gradlew :openai-java-core:compileJava :openai-java-core:compileTestJava -x test --no-configuration-cache` with JDK 21
- throwaway GPG workflow-shell import smoke test
- throwaway Gradle `:openai-java-core:signMavenPublication` in-memory signing smoke test
