### PR TITLE
build: Use CI environment for OpenAI API key workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,7 @@ jobs:
   examples:
     timeout-minutes: 20
     name: examples
+    environment: CI
     runs-on: ${{ github.repository == 'stainless-sdks/openai-java' && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
     if: github.repository == 'openai/openai-java' && (github.event_name == 'push' || github.event.pull_request.head.repo.fork) && (github.event_name != 'push' || github.event.head_commit.message != 'codegen metadata')
 


### PR DESCRIPTION
## Summary

- Add the `CI` environment to the `examples` job in `.github/workflows/ci.yml`.
- This lets the job resolve the environment-scoped `OPENAI_API_KEY` secret used when running the examples.

## Validation

- Parsed `.github/workflows/ci.yml` with Ruby YAML loader.
- Ran `git diff --check`.