### PR TITLE
build: Use publish environment for release job

### DIFF
--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -11,6 +11,7 @@ jobs:
     name: release
     if: github.ref == 'refs/heads/main' && github.repository == 'openai/openai-java'
     runs-on: ubuntu-latest
+    environment: publish
     outputs:
       releases_created: ${{ steps.release.outputs.releases_created }}
 


### PR DESCRIPTION
## Summary

- Adds `environment: publish` to the `release` job in the `Create releases` workflow.
- Allows the release job to read the gated `publish` environment secret `STAINLESS_API_KEY` before invoking `stainless-api/trigger-release-please`.

## Root Cause

The `release` job was passing `${{ secrets.STAINLESS_API_KEY }}` to the Stainless release action, but that secret exists as a `publish` environment secret rather than a repo-level Actions secret. Because the job did not declare `environment: publish`, GitHub resolved the secret to an empty value and the action failed with `Missing stainless-api-key input`.

## Validation

- Verified repo environments and secret names with GitHub Actions metadata.
- Confirmed the workflow diff is limited to the release job environment declaration.
- Ran `git diff --check`.