### PR TITLE
[codex] Harden GitHub Actions permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ on:
       - 'stl-preview-head/**'
       - 'stl-preview-base/**'
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     timeout-minutes: 15
@@ -23,6 +26,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Java
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
@@ -42,14 +47,18 @@ jobs:
   build:
     timeout-minutes: 30
     name: build
-    permissions:
-      contents: read
-      id-token: write
     runs-on: ${{ github.repository == 'stainless-sdks/openai-java' && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
-    if: (github.event_name == 'push' || github.event.pull_request.head.repo.fork) && (github.event_name != 'push' || github.event.head_commit.message != 'codegen metadata')
+    if: |-
+      (github.event_name == 'push' || github.event.pull_request.head.repo.fork) &&
+      (github.event_name != 'push' || github.event.head_commit.message != 'codegen metadata') &&
+      !(github.repository == 'stainless-sdks/openai-java' &&
+        github.event_name == 'push' &&
+        !startsWith(github.ref, 'refs/heads/stl/'))
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Java
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
@@ -69,10 +78,43 @@ jobs:
           GRADLE_OPTS: "-Dkotlin.compiler.execution.strategy=in-process"
         run: ./scripts/build
 
-      - name: Build and upload Maven artifacts
-        if: |-
-          github.repository == 'stainless-sdks/openai-java' &&
-          !startsWith(github.ref, 'refs/heads/stl/')
+  upload-maven-artifacts:
+    timeout-minutes: 30
+    name: build-and-upload-maven-artifacts
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: depot-ubuntu-24.04
+    if: |-
+      github.repository == 'stainless-sdks/openai-java' &&
+      github.event_name == 'push' &&
+      github.event.head_commit.message != 'codegen metadata' &&
+      !startsWith(github.ref, 'refs/heads/stl/')
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Java
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        with:
+          distribution: temurin
+          java-version: |
+            8
+            21
+          cache: gradle
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@0b6dd653ba04f4f93bf581ec31e66cbd7dcb644d # v4
+
+      - name: Build SDK
+        # disable gradle daemon in CI because it is flakey
+        env:
+          GRADLE_OPTS: "-Dkotlin.compiler.execution.strategy=in-process"
+        run: ./scripts/build
+
+      - name: Upload Maven artifacts
         env:
           URL: https://pkg.stainless.com/s
           SHA: ${{ github.sha }}
@@ -121,6 +163,8 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.fork
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Java
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
@@ -141,10 +185,12 @@ jobs:
     name: examples
     environment: CI
     runs-on: ${{ github.repository == 'stainless-sdks/openai-java' && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
-    if: github.repository == 'openai/openai-java' && (github.event_name == 'push' || github.event.pull_request.head.repo.fork) && (github.event_name != 'push' || github.event.head_commit.message != 'codegen metadata')
+    if: github.repository == 'openai/openai-java' && github.event_name == 'push' && github.ref == 'refs/heads/main' && github.event.head_commit.message != 'codegen metadata'
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Java
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   release:
     name: release
@@ -17,6 +20,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - uses: stainless-api/trigger-release-please@bb6677c5a04578eec1ccfd9e1913b5b78ed64c61 # v1.4.0
         id: release
@@ -33,6 +38,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Java
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5

--- a/.github/workflows/detect-breaking-changes.yml
+++ b/.github/workflows/detect-breaking-changes.yml
@@ -5,6 +5,9 @@ on:
       - main
       - next
 
+permissions:
+  contents: read
+
 jobs:
   detect_breaking_changes:
     runs-on: 'ubuntu-latest'
@@ -19,6 +22,7 @@ jobs:
         with:
           # Ensure we can check out the pull request base in the script below.
           fetch-depth: ${{ env.FETCH_DEPTH }}
+          persist-credentials: false
 
       - name: Set up Java
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5

--- a/.github/workflows/publish-sonatype.yml
+++ b/.github/workflows/publish-sonatype.yml
@@ -4,6 +4,9 @@ name: Publish Sonatype
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     name: publish
@@ -12,6 +15,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Java
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5

--- a/buildSrc/src/main/kotlin/openai.java.gradle.kts
+++ b/buildSrc/src/main/kotlin/openai.java.gradle.kts
@@ -34,6 +34,10 @@ tasks.named<Jar>("jar") {
 tasks.withType<Test>().configureEach {
     useJUnitPlatform()
 
+    // Mockito/Byte Buddy can attach a test-time Java agent. Keep JVM warnings about that out of
+    // stderr so output-sensitive tests can assert application logs exactly.
+    jvmArgs("-XX:+EnableDynamicAgentLoading")
+
     // Run tests in parallel to some degree.
     maxParallelForks = (Runtime.getRuntime().availableProcessors() / 2).coerceAtLeast(1)
     forkEvery = 100

--- a/openai-java-core/build.gradle.kts
+++ b/openai-java-core/build.gradle.kts
@@ -88,7 +88,8 @@ if (project.hasProperty("graalvmAgent")) {
     tasks.test {
         maxParallelForks = 1
         forkEvery = 0
-        jvmArgs =
-            listOf("-agentlib:native-image-agent=config-output-dir=src/main/resources/META-INF/native-image")
+        jvmArgs(
+            "-agentlib:native-image-agent=config-output-dir=src/main/resources/META-INF/native-image"
+        )
     }
 }


### PR DESCRIPTION
## Summary
- Add explicit read-only `contents: read` defaults to all GitHub Actions workflows.
- Stop persisting `GITHUB_TOKEN` credentials in checkout steps.
- Keep OIDC isolated to a trusted Stainless push-only build-and-upload job.
- Restrict the secret-backed examples job to trusted `main` pushes.
- Suppress Mockito/Byte Buddy dynamic-agent warnings in test JVMs so stderr-sensitive logging tests are stable on Java 21.

## Why
The repository currently has write-capable default workflow permissions, so jobs without explicit `permissions:` blocks inherit broader `GITHUB_TOKEN` access than they need. The previous CI build job also granted OIDC to the whole job while running pull request code, even though only the artifact upload path needed it.

The prior PR run also failed in `LoggingHttpClientTest.debugLevel_logsRequestBody(false)` because JVM dynamic-agent warnings from Mockito/Byte Buddy were written to stderr and polluted exact log assertions. Enabling dynamic agent loading for test JVMs removes that warning at the source while preserving the assertion behavior.

## Validation
- Fetched latest `origin/main` and rebased this branch cleanly on `2935d47e753fcbef81a6a0d720eedb3ac559ac73`.
- Parsed all four workflow YAML files with Ruby `YAML.load_file`.
- Ran `git diff --check`.
- Re-scanned workflows for tag-pinned actions, broad write permissions, persisted checkout credentials, `pull_request_target`, `workflow_run`, and `secrets: inherit`.
- Inspected the failed GitHub Actions test log and confirmed the failure was stderr pollution from Byte Buddy dynamic-agent warnings.

Local Gradle execution is blocked on this machine because the default JDK is Java 25.0.2, which this Gradle/Kotlin stack cannot parse during build-script compilation. GitHub Actions uses Java 21 and is the authoritative validation for the test fix.

## Follow-up outside this PR
The repo-level Actions setting should still be flipped from default workflow permission `write` to `read`, and "Allow GitHub Actions to create and approve pull requests" should be disabled in repository settings. Those are admin settings rather than repository files.