### PR TITLE
Fix AutoPagerAsync hang when first-page handler throws

### DIFF
--- a/openai-java-core/src/main/kotlin/com/openai/core/AutoPagerAsync.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/core/AutoPagerAsync.kt
@@ -45,23 +45,29 @@ private constructor(private val firstPage: PageAsync<T>, private val defaultExec
             else CompletableFuture.completedFuture(null)
         }
 
-        executor.execute {
-            firstPage.handle().whenComplete { _, error ->
-                val actualError =
-                    if (error is CompletionException && error.cause != null) error.cause else error
+        fun complete(error: Throwable?) {
+            val actualError =
+                if (error is CompletionException && error.cause != null) error.cause else error
+            try {
+                handler.onComplete(Optional.ofNullable(actualError))
+            } finally {
                 try {
-                    handler.onComplete(Optional.ofNullable(actualError))
-                } finally {
-                    try {
-                        if (actualError == null) {
-                            onCompleteFuture.complete(null)
-                        } else {
-                            onCompleteFuture.completeExceptionally(actualError)
-                        }
-                    } finally {
-                        close()
+                    if (actualError == null) {
+                        onCompleteFuture.complete(null)
+                    } else {
+                        onCompleteFuture.completeExceptionally(actualError)
                     }
+                } finally {
+                    close()
                 }
+            }
+        }
+
+        executor.execute {
+            try {
+                firstPage.handle().whenComplete { _, error -> complete(error) }
+            } catch (error: Throwable) {
+                complete(error)
             }
         }
     }

--- a/openai-java-core/src/test/kotlin/com/openai/core/AutoPagerAsyncTest.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/core/AutoPagerAsyncTest.kt
@@ -14,6 +14,7 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.clearInvocations
 import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
@@ -144,6 +145,38 @@ internal class AutoPagerAsyncTest {
             verify(handler, times(1)).onNext("chunk4")
             verify(handler, times(1)).onComplete(Optional.empty())
         }
+    }
+
+    @Test
+    fun subscribe_whenHandlerOnNextThrowsOnFirstPage_callsOnComplete() {
+        val page = PageAsyncImpl(listOf("chunk1", "chunk2"), hasNext = false)
+        val autoPagerAsync = AutoPagerAsync.from(page, executor)
+        doThrow(ERROR).whenever(handler).onNext("chunk1")
+
+        autoPagerAsync.subscribe(handler)
+
+        verify(handler, times(1)).onNext("chunk1")
+        verify(handler, never()).onNext("chunk2")
+        verify(handler, times(1)).onComplete(Optional.of(ERROR))
+        assertThat(autoPagerAsync.onCompleteFuture()).isCompletedExceptionally
+    }
+
+    @Test
+    fun subscribe_whenHandlerOnNextThrowsOnNextPage_callsOnComplete() {
+        val page = PageAsyncImpl(listOf("chunk1"))
+        val autoPagerAsync = AutoPagerAsync.from(page, executor)
+        doThrow(ERROR).whenever(handler).onNext("chunk2")
+
+        autoPagerAsync.subscribe(handler)
+        page.nextPageFuture.complete(PageAsyncImpl(listOf("chunk2", "chunk3"), hasNext = false))
+
+        inOrder(handler) {
+            verify(handler, times(1)).onNext("chunk1")
+            verify(handler, times(1)).onNext("chunk2")
+            verify(handler, times(1)).onComplete(Optional.of(ERROR))
+        }
+        verify(handler, never()).onNext("chunk3")
+        assertThat(autoPagerAsync.onCompleteFuture()).isCompletedExceptionally
     }
 
     @Test


### PR DESCRIPTION
## Summary
- catch synchronous exceptions thrown while handling the first page in `AutoPagerAsync.subscribe`
- still call `handler.onComplete(...)`, complete `onCompleteFuture()` exceptionally, and close the pager
- add regression coverage for `onNext()` throwing on the first page and a later page

## Why
If `handler.onNext()` throws while iterating the first page, `firstPage.handle()` throws before it can return a `CompletableFuture`. That skips the existing `whenComplete` path, so `onComplete` never runs and `onCompleteFuture()` can remain unresolved.

## Validation
- `env JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home PATH=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home/bin:$PATH ./gradlew :openai-java-core:test --tests com.openai.core.AutoPagerAsyncTest`
- `env JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home PATH=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home/bin:$PATH ./gradlew :openai-java-core:lintKotlin`