### PR TITLE
fix: accept quoted numeric strings in OrganizationCostsResult.Amount.value() (#769)

### DIFF
--- a/openai-java-core/src/main/kotlin/com/openai/models/admin/organization/usage/UsageCostsResponse.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/models/admin/organization/usage/UsageCostsResponse.kt
@@ -6677,7 +6677,26 @@ private constructor(
                      * @throws OpenAIInvalidDataException if the JSON field has an unexpected type
                      *   (e.g. if the server responded with an unexpected value).
                      */
-                    fun value(): Optional<Double> = value.getOptional("value")
+                    fun value(): Optional<Double> {
+                        if (value.isMissing() || value.isNull()) return Optional.empty()
+                        val known = value.asKnown()
+                        if (known.isPresent) return known
+                        // The live API returns this field as a quoted numeric string despite the
+                        // schema declaring type:number. Accept valid finite numeric strings for
+                        // compat.
+                        val str =
+                            value.asString().orElseThrow {
+                                OpenAIInvalidDataException("`value` is invalid, received $value")
+                            }
+                        val d =
+                            str.toBigDecimalOrNull()?.toDouble()
+                                ?: throw OpenAIInvalidDataException(
+                                    "`value` is invalid, received $value"
+                                )
+                        if (!d.isFinite())
+                            throw OpenAIInvalidDataException("`value` is invalid, received $value")
+                        return Optional.of(d)
+                    }
 
                     /**
                      * Returns the raw JSON value of [currency].


### PR DESCRIPTION
## Summary

- Fixes GitHub issue #769: `OrganizationCostsResult.Amount.value()` threw `OpenAIInvalidDataException` when the live API returned `amount.value` as a quoted numeric string (e.g. `"0E-6176"`) despite the OpenAPI spec declaring `type: number`
- Root cause: Jackson's `CoercionAction.Fail` for `String→Float` caused `tryDeserialize` to return `null` for quoted numeric strings, leaving a `JsonString` in the `JsonField` which `getOptional()` rejected as invalid
- Fix adds a BigDecimal fallback in `Amount.value()`: if `asKnown()` is absent and the backing field is a `JsonString`, parse via `BigDecimal` → `Double` with an `isFinite()` guard to reject overflow

## Test plan

- [ ] `quoted 0E-6176 zero-cost string returns 0.0` — primary bug reproduction verified locally
- [ ] Valid JSON number path unchanged
- [ ] Non-numeric strings still throw `OpenAIInvalidDataException`
- [ ] Overflow (`"1e309"`) rejected by `isFinite()` guard
- [ ] `validate()` benefits automatically (calls `value()` internally)

Authored-By: Kuntal maity <kuntal.1461@gmail.com>