### PR TITLE
feat(core): expose request IDs on streaming responses

### DIFF
--- a/openai-java-core/src/main/kotlin/com/openai/core/handlers/StreamHandler.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/core/handlers/StreamHandler.kt
@@ -8,6 +8,7 @@ import com.openai.core.http.PhantomReachableClosingStreamResponse
 import com.openai.core.http.StreamResponse
 import com.openai.errors.OpenAIIoException
 import java.io.IOException
+import java.util.Optional
 import java.util.stream.Stream
 import kotlin.streams.asStream
 
@@ -18,6 +19,7 @@ internal fun <T> streamHandler(
     object : Handler<StreamResponse<T>> {
 
         override fun handle(response: HttpResponse): StreamResponse<T> {
+            val requestId = response.requestId()
             val reader = response.body().bufferedReader()
             val sequence =
                 // Wrap in a `CloseableSequence` to avoid performing a read on the `reader`
@@ -39,6 +41,8 @@ internal fun <T> streamHandler(
 
             return PhantomReachableClosingStreamResponse(
                 object : StreamResponse<T> {
+
+                    override fun requestId(): Optional<String> = requestId
 
                     override fun stream(): Stream<T> = sequence.asStream()
 

--- a/openai-java-core/src/main/kotlin/com/openai/core/http/AsyncStreamResponse.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/core/http/AsyncStreamResponse.kt
@@ -1,8 +1,11 @@
 package com.openai.core.http
 
 import com.openai.core.http.AsyncStreamResponse.Handler
+import com.openai.errors.OpenAIServiceException
 import java.util.Optional
+import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionException
 import java.util.concurrent.Executor
 import java.util.concurrent.atomic.AtomicReference
 
@@ -12,6 +15,14 @@ import java.util.concurrent.atomic.AtomicReference
  * full response.
  */
 interface AsyncStreamResponse<T> {
+
+    /**
+     * Returns the value of the `x-request-id` header, or an empty [Optional] if it's unavailable.
+     *
+     * This method does not wait for response headers. Its result is empty until those headers are
+     * available, and may remain empty if the response has no `x-request-id` header.
+     */
+    fun requestId(): Optional<String> = Optional.empty()
 
     /**
      * Registers [handler] to be called for events of this stream.
@@ -76,6 +87,19 @@ internal fun <T> CompletableFuture<StreamResponse<T>>.toAsync(streamHandlerExecu
                     // `onCompleteFuture` even if `subscribe` has not been called.
                     error?.let(onCompleteFuture::completeExceptionally)
                 }
+            }
+
+            override fun requestId(): Optional<String> {
+                val streamResponse =
+                    try {
+                        this@toAsync.getNow(null)
+                    } catch (error: CompletionException) {
+                        return requestIdFromError(error)
+                    } catch (_: CancellationException) {
+                        return Optional.empty()
+                    }
+
+                return streamResponse?.requestId() ?: Optional.empty()
             }
 
             override fun subscribe(handler: Handler<T>): AsyncStreamResponse<T> =
@@ -149,6 +173,14 @@ internal fun <T> CompletableFuture<StreamResponse<T>>.toAsync(streamHandlerExecu
             }
         }
     )
+
+private tailrec fun requestIdFromError(error: Throwable): Optional<String> =
+    when {
+        error is CompletionException && error.cause != null -> requestIdFromError(error.cause!!)
+        error is OpenAIServiceException ->
+            Optional.ofNullable(error.headers().values("x-request-id").firstOrNull())
+        else -> Optional.empty()
+    }
 
 private enum class State {
     NEW,

--- a/openai-java-core/src/main/kotlin/com/openai/core/http/PhantomReachableClosingAsyncStreamResponse.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/core/http/PhantomReachableClosingAsyncStreamResponse.kt
@@ -25,6 +25,8 @@ internal class PhantomReachableClosingAsyncStreamResponse<T>(
         closeWhenPhantomReachable(reachabilityTracker, asyncStreamResponse::close)
     }
 
+    override fun requestId(): Optional<String> = asyncStreamResponse.requestId()
+
     override fun subscribe(handler: Handler<T>): AsyncStreamResponse<T> = apply {
         asyncStreamResponse.subscribe(TrackedHandler(handler, reachabilityTracker))
     }

--- a/openai-java-core/src/main/kotlin/com/openai/core/http/PhantomReachableClosingStreamResponse.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/core/http/PhantomReachableClosingStreamResponse.kt
@@ -1,6 +1,7 @@
 package com.openai.core.http
 
 import com.openai.core.closeWhenPhantomReachable
+import java.util.Optional
 import java.util.stream.Stream
 
 /**
@@ -14,6 +15,8 @@ internal class PhantomReachableClosingStreamResponse<T>(
     init {
         closeWhenPhantomReachable(this, streamResponse)
     }
+
+    override fun requestId(): Optional<String> = streamResponse.requestId()
 
     override fun stream(): Stream<T> = streamResponse.stream()
 

--- a/openai-java-core/src/main/kotlin/com/openai/core/http/StreamResponse.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/core/http/StreamResponse.kt
@@ -1,8 +1,14 @@
 package com.openai.core.http
 
+import java.util.Optional
 import java.util.stream.Stream
 
 interface StreamResponse<T> : AutoCloseable {
+
+    /**
+     * Returns the value of the `x-request-id` header, or an empty [Optional] if it's unavailable.
+     */
+    fun requestId(): Optional<String> = Optional.empty()
 
     fun stream(): Stream<T>
 
@@ -13,6 +19,8 @@ interface StreamResponse<T> : AutoCloseable {
 @JvmSynthetic
 internal fun <T, R> StreamResponse<T>.map(transform: (T) -> R): StreamResponse<R> =
     object : StreamResponse<R> {
+        override fun requestId(): Optional<String> = this@map.requestId()
+
         override fun stream(): Stream<R> = this@map.stream().map(transform)
 
         override fun close() = this@map.close()

--- a/openai-java-core/src/test/kotlin/com/openai/core/handlers/StreamHandlerTest.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/core/handlers/StreamHandlerTest.kt
@@ -23,6 +23,22 @@ internal class StreamHandlerTest {
     }
 
     @Test
+    fun streamHandler_exposesRequestIdAfterClose() {
+        val handler = streamHandler { _, lines -> yieldAll(lines) }
+        val streamResponse =
+            handler.handle(
+                httpResponse(
+                    "a\n".byteInputStream(),
+                    Headers.builder().put("x-request-id", "req_123").build(),
+                )
+            )
+
+        assertThat(streamResponse.requestId()).contains("req_123")
+        streamResponse.close()
+        assertThat(streamResponse.requestId()).contains("req_123")
+    }
+
+    @Test
     fun streamHandler_whenClosedEarly_stopsYielding() {
         val handler = streamHandler { _, lines -> yieldAll(lines) }
         val streamResponse = handler.handle(httpResponse("a\nbb\nccc\ndddd".byteInputStream()))
@@ -68,12 +84,15 @@ internal class StreamHandlerTest {
         assertThat(e).isSameAs(ioException)
     }
 
-    private fun httpResponse(body: InputStream): HttpResponse =
+    private fun httpResponse(
+        body: InputStream,
+        headers: Headers = Headers.builder().build(),
+    ): HttpResponse =
         object : HttpResponse {
 
             override fun statusCode(): Int = 0
 
-            override fun headers(): Headers = Headers.builder().build()
+            override fun headers(): Headers = headers
 
             override fun body(): InputStream = body
 

--- a/openai-java-core/src/test/kotlin/com/openai/core/http/AsyncStreamResponseTest.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/core/http/AsyncStreamResponseTest.kt
@@ -1,7 +1,9 @@
 package com.openai.core.http
 
+import com.openai.errors.BadRequestException
 import java.util.*
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionException
 import java.util.concurrent.Executor
 import java.util.stream.Stream
 import kotlin.streams.asStream
@@ -44,6 +46,78 @@ internal class AsyncStreamResponseTest {
                 .execute(any())
         }
     private val handler = mock<AsyncStreamResponse.Handler<String>>()
+
+    @Test
+    fun requestId_whenStreamFutureIsIncomplete_isEmpty() {
+        val asyncStreamResponse = CompletableFuture<StreamResponse<String>>().toAsync(executor)
+
+        assertThat(asyncStreamResponse.requestId()).isEmpty
+    }
+
+    @Test
+    fun requestId_whenStreamFutureCompletes_isAvailable() {
+        val future = CompletableFuture<StreamResponse<String>>()
+        val asyncStreamResponse = future.toAsync(executor)
+        doReturn(Optional.of("req_123")).whenever(streamResponse).requestId()
+
+        future.complete(streamResponse)
+
+        assertThat(asyncStreamResponse.requestId()).contains("req_123")
+    }
+
+    @Test
+    fun requestId_whenHandlerRuns_isAvailable() {
+        val future = CompletableFuture<StreamResponse<String>>()
+        val asyncStreamResponse = future.toAsync(executor)
+        val requestIds = mutableListOf<Optional<String>>()
+        doReturn(Optional.of("req_123")).whenever(streamResponse).requestId()
+        asyncStreamResponse.subscribe { requestIds.add(asyncStreamResponse.requestId()) }
+
+        future.complete(streamResponse)
+
+        assertThat(requestIds).containsOnly(Optional.of("req_123"))
+    }
+
+    @Test
+    fun requestId_whenStreamFutureFailsWithServiceException_isAvailableInExceptionally() {
+        val future = CompletableFuture<StreamResponse<String>>()
+        val asyncStreamResponse = future.toAsync(executor)
+        val requestIds = mutableListOf<Optional<String>>()
+        val error =
+            BadRequestException.builder()
+                .headers(Headers.builder().put("x-request-id", "req_error").build())
+                .build()
+        val assertion =
+            asyncStreamResponse.onCompleteFuture().exceptionally {
+                requestIds.add(asyncStreamResponse.requestId())
+                null
+            }
+
+        future.completeExceptionally(CompletionException(error))
+
+        assertion.join()
+        assertThat(requestIds).containsExactly(Optional.of("req_error"))
+    }
+
+    @Test
+    fun requestId_whenStreamFutureFailsBeforeResponse_isEmpty() {
+        val future = CompletableFuture<StreamResponse<String>>()
+        val asyncStreamResponse = future.toAsync(executor)
+
+        future.completeExceptionally(ERROR)
+
+        assertThat(asyncStreamResponse.requestId()).isEmpty
+    }
+
+    @Test
+    fun requestId_whenStreamFutureIsCancelled_isEmpty() {
+        val future = CompletableFuture<StreamResponse<String>>()
+        val asyncStreamResponse = future.toAsync(executor)
+
+        future.cancel(false)
+
+        assertThat(asyncStreamResponse.requestId()).isEmpty
+    }
 
     @Test
     fun subscribe_whenAlreadySubscribed_throws() {

--- a/openai-java-core/src/test/kotlin/com/openai/core/http/StreamResponseTest.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/core/http/StreamResponseTest.kt
@@ -1,0 +1,36 @@
+package com.openai.core.http
+
+import java.util.Optional
+import java.util.stream.Stream
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+internal class StreamResponseTest {
+
+    @Test
+    fun requestId_byDefault_isEmpty() {
+        val response = streamResponse()
+
+        assertThat(response.requestId()).isEmpty
+    }
+
+    @Test
+    fun map_preservesRequestId() {
+        val response = streamResponse(Optional.of("req_123"))
+
+        val mappedResponse = response.map(String::length).map(Int::toString)
+
+        assertThat(mappedResponse.requestId()).contains("req_123")
+    }
+
+    private fun streamResponse(
+        requestId: Optional<String> = Optional.empty()
+    ): StreamResponse<String> =
+        object : StreamResponse<String> {
+            override fun requestId(): Optional<String> = requestId
+
+            override fun stream(): Stream<String> = Stream.empty()
+
+            override fun close() {}
+        }
+}

--- a/openai-java-core/src/test/kotlin/com/openai/services/StreamingRequestIdTest.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/services/StreamingRequestIdTest.kt
@@ -1,0 +1,109 @@
+package com.openai.services
+
+import com.github.tomakehurst.wiremock.client.WireMock.anyUrl
+import com.github.tomakehurst.wiremock.client.WireMock.ok
+import com.github.tomakehurst.wiremock.client.WireMock.post
+import com.github.tomakehurst.wiremock.client.WireMock.status
+import com.github.tomakehurst.wiremock.client.WireMock.stubFor
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo
+import com.github.tomakehurst.wiremock.junit5.WireMockTest
+import com.openai.client.OpenAIClient
+import com.openai.client.OpenAIClientAsync
+import com.openai.client.okhttp.OpenAIOkHttpClient
+import com.openai.client.okhttp.OpenAIOkHttpClientAsync
+import com.openai.models.completions.CompletionCreateParams
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.ResourceLock
+
+@WireMockTest
+@ResourceLock("https://github.com/wiremock/wiremock/issues/169")
+internal class StreamingRequestIdTest {
+
+    private lateinit var blockingClient: OpenAIClient
+    private lateinit var asyncClient: OpenAIClientAsync
+
+    @BeforeEach
+    fun beforeEach(wmRuntimeInfo: WireMockRuntimeInfo) {
+        blockingClient =
+            OpenAIOkHttpClient.builder()
+                .baseUrl(wmRuntimeInfo.httpBaseUrl)
+                .apiKey("My API Key")
+                .build()
+        asyncClient =
+            OpenAIOkHttpClientAsync.builder()
+                .baseUrl(wmRuntimeInfo.httpBaseUrl)
+                .apiKey("My API Key")
+                .build()
+    }
+
+    @Test
+    fun requestId_isAvailableOnBlockingStream() {
+        stubStreamingResponse("req_blocking")
+
+        val response = blockingClient.completions().createStreaming(params())
+
+        response.use {
+            assertThat(response.requestId()).contains("req_blocking")
+            assertThat(response.stream().count()).isEqualTo(1L)
+        }
+    }
+
+    @Test
+    fun requestId_isAvailableInAsyncHandler() {
+        stubStreamingResponse("req_async")
+        val response = asyncClient.completions().createStreaming(params())
+        val requestIds = mutableListOf<String>()
+
+        response.subscribe { response.requestId().ifPresent(requestIds::add) }
+        response.onCompleteFuture().join()
+
+        assertThat(requestIds).containsExactly("req_async")
+        assertThat(response.requestId()).contains("req_async")
+    }
+
+    @Test
+    fun requestId_isAvailableForHttpErrors() {
+        stubFor(
+            post(anyUrl())
+                .willReturn(
+                    status(400)
+                        .withHeader("Content-Type", "application/json")
+                        .withHeader("x-request-id", "req_error")
+                        .withBody("""{"error":{"message":"bad request"}}""")
+                )
+        )
+        val response = asyncClient.completions().createStreaming(params())
+        val requestIds = mutableListOf<String>()
+        val assertion =
+            response.onCompleteFuture().exceptionally {
+                response.requestId().ifPresent(requestIds::add)
+                null
+            }
+
+        assertion.join()
+        assertThat(requestIds).containsExactly("req_error")
+    }
+
+    private fun stubStreamingResponse(requestId: String) {
+        stubFor(
+            post(anyUrl())
+                .willReturn(
+                    ok()
+                        .withHeader("Content-Type", "text/event-stream")
+                        .withHeader("x-request-id", requestId)
+                        .withBody(
+                            "data: {\"id\":\"id\",\"choices\":[],\"created\":0,\"model\":\"model\"}\n\n" +
+                                "data: [DONE]\n\n"
+                        )
+                )
+        )
+    }
+
+    private fun params(): CompletionCreateParams =
+        CompletionCreateParams.builder()
+            .model(CompletionCreateParams.Model.GPT_3_5_TURBO_INSTRUCT)
+            .prompt("This is a test.")
+            .build()
+}


### PR DESCRIPTION
## Summary

- expose `x-request-id` through `StreamResponse.requestId()` and `AsyncStreamResponse.requestId()`
- preserve request metadata across stream mapping and resource-closing wrappers, including after the underlying response is closed
- keep async access non-blocking and retain request IDs from HTTP error responses for `exceptionally` handlers

## Compatibility

The new interface methods default to `Optional.empty()` and compile to Java 8 default methods, so existing third-party implementations remain binary compatible.

## Validation

- `./scripts/lint`
- `./scripts/build`
- `JAVA_TOOL_OPTIONS="-XX:+EnableDynamicAgentLoading" ./scripts/test`
- targeted unit and WireMock tests for blocking, async callback, completion, HTTP error, cancellation, mapping, and close paths

Closes #593
