### PR TITLE
Add CodeQL analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,49 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  analyze:
+    name: Analyze Java and Kotlin
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Java
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: gradle
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@0b6dd653ba04f4f93bf581ec31e66cbd7dcb644d # v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
+        with:
+          languages: java-kotlin
+          build-mode: manual
+
+      - name: Build SDK
+        env:
+          GRADLE_OPTS: -Dkotlin.compiler.execution.strategy=in-process
+        run: ./scripts/build
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4


### PR DESCRIPTION
## Summary

- add CodeQL analysis for Java and Kotlin
- run analysis on pushes to `main`, pull requests targeting `main`, and manual dispatches
- compile the project with the existing Gradle build so CodeQL can trace generated JVM bytecode

## Why

This adds code-scanning coverage for the SDK while keeping the workflow scoped to the repository's primary branch and language toolchain.

## Validation

- parsed the workflow as YAML
- ran `git diff --check`
- matched the CodeQL build step to the repository's existing `./scripts/build` CI command

The build could not be completed locally because the workstation has Java 25 while the project and workflow use Java 21.
