### PR TITLE
fix(client): handle response stream keepalive events

### DIFF
--- a/openai-java-core/src/main/kotlin/com/openai/services/ResponseStreamEventValidation.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/services/ResponseStreamEventValidation.kt
@@ -1,0 +1,18 @@
+package com.openai.services
+
+import com.openai.core.JsonValue
+import com.openai.models.responses.ResponseStreamEvent
+import kotlin.jvm.optionals.getOrNull
+
+/**
+ * Validates a Responses API stream event while allowing the transport-level heartbeat emitted for
+ * long-running requests. The heartbeat remains an unknown event for forwards compatibility, but it
+ * must not terminate an otherwise valid stream. All other unknown events retain the existing strict
+ * validation behavior.
+ */
+@JvmSynthetic
+internal fun ResponseStreamEvent.validateForStream(): ResponseStreamEvent =
+    if (_json().getOrNull().isKeepalive()) this else validate()
+
+private fun JsonValue?.isKeepalive(): Boolean =
+    this?.asObject()?.getOrNull()?.get("type")?.asString()?.getOrNull() == "keepalive"

--- a/openai-java-core/src/main/kotlin/com/openai/services/async/ResponseServiceAsyncImpl.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/services/async/ResponseServiceAsyncImpl.kt
@@ -37,6 +37,7 @@ import com.openai.services.async.responses.InputItemServiceAsync
 import com.openai.services.async.responses.InputItemServiceAsyncImpl
 import com.openai.services.async.responses.InputTokenServiceAsync
 import com.openai.services.async.responses.InputTokenServiceAsyncImpl
+import com.openai.services.validateForStream
 import java.util.concurrent.CompletableFuture
 import java.util.function.Consumer
 import kotlin.jvm.optionals.getOrNull
@@ -218,7 +219,7 @@ class ResponseServiceAsyncImpl internal constructor(private val clientOptions: C
                             .let { createStreamingHandler.handle(it) }
                             .let { streamResponse ->
                                 if (requestOptions.responseValidation!!) {
-                                    streamResponse.map { it.validate() }
+                                    streamResponse.map { it.validateForStream() }
                                 } else {
                                     streamResponse
                                 }
@@ -296,7 +297,7 @@ class ResponseServiceAsyncImpl internal constructor(private val clientOptions: C
                             .let { retrieveStreamingHandler.handle(it) }
                             .let { streamResponse ->
                                 if (requestOptions.responseValidation!!) {
-                                    streamResponse.map { it.validate() }
+                                    streamResponse.map { it.validateForStream() }
                                 } else {
                                     streamResponse
                                 }

--- a/openai-java-core/src/main/kotlin/com/openai/services/blocking/ResponseServiceImpl.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/services/blocking/ResponseServiceImpl.kt
@@ -35,6 +35,7 @@ import com.openai.services.blocking.responses.InputItemService
 import com.openai.services.blocking.responses.InputItemServiceImpl
 import com.openai.services.blocking.responses.InputTokenService
 import com.openai.services.blocking.responses.InputTokenServiceImpl
+import com.openai.services.validateForStream
 import java.util.function.Consumer
 import kotlin.jvm.optionals.getOrNull
 
@@ -192,7 +193,7 @@ class ResponseServiceImpl internal constructor(private val clientOptions: Client
                     .let { createStreamingHandler.handle(it) }
                     .let { streamResponse ->
                         if (requestOptions.responseValidation!!) {
-                            streamResponse.map { it.validate() }
+                            streamResponse.map { it.validateForStream() }
                         } else {
                             streamResponse
                         }
@@ -264,7 +265,7 @@ class ResponseServiceImpl internal constructor(private val clientOptions: Client
                     .let { retrieveStreamingHandler.handle(it) }
                     .let { streamResponse ->
                         if (requestOptions.responseValidation!!) {
-                            streamResponse.map { it.validate() }
+                            streamResponse.map { it.validateForStream() }
                         } else {
                             streamResponse
                         }

--- a/openai-java-core/src/test/kotlin/com/openai/services/ResponseStreamEventValidationTest.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/services/ResponseStreamEventValidationTest.kt
@@ -1,0 +1,180 @@
+package com.openai.services
+
+import com.openai.core.ClientOptions
+import com.openai.core.RequestOptions
+import com.openai.core.http.Headers
+import com.openai.core.http.HttpClient
+import com.openai.core.http.HttpRequest
+import com.openai.core.http.HttpResponse
+import com.openai.errors.OpenAIInvalidDataException
+import com.openai.models.ChatModel
+import com.openai.models.responses.ResponseCreateParams
+import com.openai.models.responses.ResponseStreamEvent
+import com.openai.services.async.ResponseServiceAsyncImpl
+import com.openai.services.blocking.ResponseServiceImpl
+import java.io.InputStream
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionException
+import java.util.concurrent.Executor
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+
+internal class ResponseStreamEventValidationTest {
+
+    @ParameterizedTest
+    @EnumSource(StreamingCall::class)
+    fun keepaliveDoesNotBreakValidatedStreams(streamingCall: StreamingCall) {
+        val result = consume(streamingCall, responseValidation = true, middleType = "keepalive")
+
+        assertThat(result.error).isNull()
+        assertThat(result.events.map(::eventType))
+            .containsExactly(
+                "response.output_text.delta",
+                "keepalive",
+                "response.output_text.delta",
+            )
+        assertThat(result.outputTextDeltas()).containsExactly("before", "after")
+    }
+
+    @ParameterizedTest
+    @EnumSource(StreamingCall::class)
+    fun otherUnknownEventsStillFailValidation(streamingCall: StreamingCall) {
+        val result = consume(streamingCall, responseValidation = true, middleType = "future.event")
+
+        assertThat(result.error)
+            .isInstanceOf(OpenAIInvalidDataException::class.java)
+            .hasMessageContaining("Unknown ResponseStreamEvent")
+            .hasMessageContaining("type=future.event")
+        assertThat(result.events.map(::eventType)).containsExactly("response.output_text.delta")
+        assertThat(result.outputTextDeltas()).containsExactly("before")
+    }
+
+    @Test
+    fun validationDisabledRetainsExistingUnknownEventBehavior() {
+        val result =
+            consume(
+                StreamingCall.ASYNC_CREATE,
+                responseValidation = false,
+                middleType = "future.event",
+            )
+
+        assertThat(result.error).isNull()
+        assertThat(result.events.map(::eventType))
+            .containsExactly(
+                "response.output_text.delta",
+                "future.event",
+                "response.output_text.delta",
+            )
+        assertThat(result.outputTextDeltas()).containsExactly("before", "after")
+    }
+
+    private fun consume(
+        streamingCall: StreamingCall,
+        responseValidation: Boolean,
+        middleType: String,
+    ): ConsumeResult {
+        val clientOptions =
+            ClientOptions.builder()
+                .httpClient(FakeSseHttpClient(sseBody(middleType)))
+                .apiKey("test-api-key")
+                .responseValidation(responseValidation)
+                .streamHandlerExecutor(Executor(Runnable::run))
+                .build()
+        val events = mutableListOf<ResponseStreamEvent>()
+        var error: Throwable? = null
+
+        try {
+            when (streamingCall) {
+                StreamingCall.BLOCKING_CREATE ->
+                    ResponseServiceImpl(clientOptions).createStreaming(CREATE_PARAMS).use {
+                        it.stream().forEach(events::add)
+                    }
+                StreamingCall.BLOCKING_RETRIEVE ->
+                    ResponseServiceImpl(clientOptions).retrieveStreaming("response_id").use {
+                        it.stream().forEach(events::add)
+                    }
+                StreamingCall.ASYNC_CREATE -> {
+                    val stream =
+                        ResponseServiceAsyncImpl(clientOptions).createStreaming(CREATE_PARAMS)
+                    stream.subscribe(events::add)
+                    stream.onCompleteFuture().join()
+                }
+                StreamingCall.ASYNC_RETRIEVE -> {
+                    val stream =
+                        ResponseServiceAsyncImpl(clientOptions).retrieveStreaming("response_id")
+                    stream.subscribe(events::add)
+                    stream.onCompleteFuture().join()
+                }
+            }
+        } catch (throwable: Throwable) {
+            error = throwable.unwrapCompletionException()
+        } finally {
+            clientOptions.close()
+        }
+
+        return ConsumeResult(events, error)
+    }
+
+    private class FakeSseHttpClient(private val body: String) : HttpClient {
+
+        override fun execute(request: HttpRequest, requestOptions: RequestOptions): HttpResponse =
+            response()
+
+        override fun executeAsync(
+            request: HttpRequest,
+            requestOptions: RequestOptions,
+        ): CompletableFuture<HttpResponse> = CompletableFuture.completedFuture(response())
+
+        override fun close() {}
+
+        private fun response(): HttpResponse =
+            object : HttpResponse {
+                override fun statusCode(): Int = 200
+
+                override fun headers(): Headers =
+                    Headers.builder().put("Content-Type", "text/event-stream").build()
+
+                override fun body(): InputStream = body.byteInputStream()
+
+                override fun close() {}
+            }
+    }
+
+    private data class ConsumeResult(val events: List<ResponseStreamEvent>, val error: Throwable?) {
+        fun outputTextDeltas(): List<String> =
+            events.filter { it.isOutputTextDelta() }.map { it.asOutputTextDelta().delta() }
+    }
+
+    internal enum class StreamingCall {
+        BLOCKING_CREATE,
+        BLOCKING_RETRIEVE,
+        ASYNC_CREATE,
+        ASYNC_RETRIEVE,
+    }
+
+    private companion object {
+        val CREATE_PARAMS =
+            ResponseCreateParams.builder().input("test").model(ChatModel.GPT_4O_MINI).build()
+
+        fun eventType(event: ResponseStreamEvent): String =
+            event._json().get().asObject().get().getValue("type").asString().get()
+
+        fun Throwable.unwrapCompletionException(): Throwable =
+            if (this is CompletionException && cause != null) cause!! else this
+
+        fun sseBody(middleType: String): String =
+            """
+            data: {"type":"response.output_text.delta","content_index":0,"delta":"before","item_id":"item_1","logprobs":[],"output_index":0,"sequence_number":1}
+
+            data: {"type":"$middleType","sequence_number":2}
+
+            data: {"type":"response.output_text.delta","content_index":0,"delta":"after","item_id":"item_1","logprobs":[],"output_index":0,"sequence_number":3}
+
+            data: [DONE]
+
+            """
+                .trimIndent()
+    }
+}


### PR DESCRIPTION
## Summary

- allow the Responses API transport-level `keepalive` heartbeat through automatic response validation
- preserve the heartbeat as an ordered unknown `ResponseStreamEvent` instead of filtering or remodeling it
- retain strict validation for every other unknown stream event

## Root cause

Long-running Responses streams can emit `{"type":"keepalive",...}`. The SDK correctly preserves that forward-compatible event as an unknown `ResponseStreamEvent`, but when `responseValidation` is enabled the generated streaming services call `validate()` on every event. The default unknown visitor throws, terminating the stream before later deltas arrive.

This follows the compatibility shape used by the corresponding [openai-node fix](https://github.com/openai/openai-node/pull/1965): heartbeat events remain observable and are treated as transport no-ops by higher-level handling.

Fixes #767.

## Backward compatibility

- no public model, visitor, or service API changes
- no filtering, reordering, or event-count changes
- default `responseValidation=false` behavior is unchanged
- only an exact string `type == "keepalive"` bypasses automatic stream validation
- malformed events and all other unknown types still fail when validation is enabled
- the implementation helper is Kotlin-internal and JVM-synthetic

## Test plan

- `./gradlew :openai-java-core:formatKotlin :openai-java-core:lintKotlin :openai-java-core:test --tests 'com.openai.services.ResponseStreamEventValidationTest'`
  - 9 regression cases covering blocking/async create and retrieve streams
  - verifies heartbeat delivery and continuation
  - verifies other unknown events remain strict
  - verifies validation-disabled behavior is unchanged
- `./gradlew build` with JDK 21 and the repository mock server
  - 6,216 core tests executed (20 expected skips)
  - all modules built successfully
  - ProGuard and R8 smoke tests passed
