### PR TITLE
fix(deps): update Jackson to 2.18.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -1499,7 +1499,7 @@ public class OpenAIConfig {
 
 ## Jackson
 
-The SDK depends on [Jackson](https://github.com/FasterXML/jackson) for JSON serialization/deserialization. It is compatible with version 2.13.4 or higher, but depends on version 2.18.2 by default.
+The SDK depends on [Jackson](https://github.com/FasterXML/jackson) for JSON serialization/deserialization. It is compatible with version 2.13.4 or higher, but depends on version 2.18.9 by default.
 
 The SDK throws an exception if it detects an incompatible Jackson version at runtime (e.g. if the default version was overridden in your Maven or Gradle config).
 

--- a/openai-java-core/build.gradle.kts
+++ b/openai-java-core/build.gradle.kts
@@ -4,31 +4,43 @@ plugins {
     id("openai.publish")
 }
 
-configurations.all {
+val jacksonCompatibilityVersion = "2.14.0"
+val jacksonPublishedVersion = "2.18.9"
+
+// Runtime classpath for `testJacksonPublished`: the same dependencies as `testRuntimeClasspath`,
+// but exempt from the compatibility-version force below so Jackson resolves to the version that
+// consumers receive by default.
+val jacksonPublishedRuntime by configurations.creating {
+    extendsFrom(configurations.testRuntimeClasspath.get())
+    isCanBeConsumed = false
+    isCanBeResolved = true
+}
+
+configurations.matching { it.name != jacksonPublishedRuntime.name }.configureEach {
     resolutionStrategy {
         // Compile and test against a lower Jackson version to ensure we're compatible with it. Note that
         // we generally support 2.13.4, but test against 2.14.0 because 2.13.4 has some annoying (but
         // niche) bugs (users should upgrade if they encounter them). We publish with a higher version
         // (see below) to ensure users depend on a secure version by default.
-        force("com.fasterxml.jackson.core:jackson-core:2.14.0")
-        force("com.fasterxml.jackson.core:jackson-databind:2.14.0")
-        force("com.fasterxml.jackson.core:jackson-annotations:2.14.0")
-        force("com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.14.0")
-        force("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.14.0")
-        force("com.fasterxml.jackson.module:jackson-module-kotlin:2.14.0")
+        force("com.fasterxml.jackson.core:jackson-core:$jacksonCompatibilityVersion")
+        force("com.fasterxml.jackson.core:jackson-databind:$jacksonCompatibilityVersion")
+        force("com.fasterxml.jackson.core:jackson-annotations:$jacksonCompatibilityVersion")
+        force("com.fasterxml.jackson.datatype:jackson-datatype-jdk8:$jacksonCompatibilityVersion")
+        force("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonCompatibilityVersion")
+        force("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonCompatibilityVersion")
     }
 }
 
 dependencies {
-    api("com.fasterxml.jackson.core:jackson-core:2.18.2")
-    api("com.fasterxml.jackson.core:jackson-databind:2.18.2")
+    api("com.fasterxml.jackson.core:jackson-core:$jacksonPublishedVersion")
+    api("com.fasterxml.jackson.core:jackson-databind:$jacksonPublishedVersion")
     api("com.google.errorprone:error_prone_annotations:2.33.0")
     api("io.swagger.core.v3:swagger-annotations:2.2.31")
 
-    implementation("com.fasterxml.jackson.core:jackson-annotations:2.18.2")
-    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.18.2")
-    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.18.2")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.18.2")
+    implementation("com.fasterxml.jackson.core:jackson-annotations:$jacksonPublishedVersion")
+    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jdk8:$jacksonPublishedVersion")
+    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonPublishedVersion")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonPublishedVersion")
     implementation("com.github.victools:jsonschema-generator:4.38.0")
     implementation("com.github.victools:jsonschema-module-jackson:4.38.0")
     implementation("com.github.victools:jsonschema-module-swagger-2:4.38.0")
@@ -44,6 +56,26 @@ dependencies {
     testImplementation("org.mockito:mockito-junit-jupiter:5.14.2")
     testImplementation("org.mockito.kotlin:mockito-kotlin:4.1.0")
 }
+
+// Re-run the compiled tests against the Jackson version consumers receive by default. Service tests
+// exercise HTTP plumbing and the mock server rather than Jackson compatibility, so the second pass
+// focuses on the core and model tests that cover serialization behavior.
+val testJacksonPublished by tasks.registering(Test::class) {
+    group = "verification"
+    description = "Runs tests against the published Jackson version."
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().output + sourceSets.main.get().output + jacksonPublishedRuntime
+    shouldRunAfter(tasks.test)
+    exclude("**/services/**")
+    systemProperty("junit.jupiter.execution.parallel.enabled", false)
+    systemProperty("expected.jackson.version", jacksonPublishedVersion)
+}
+
+tasks.test {
+    systemProperty("expected.jackson.version", jacksonCompatibilityVersion)
+}
+
+tasks.check { dependsOn(testJacksonPublished) }
 
 if (project.hasProperty("graalvmAgent")) {
     java {

--- a/openai-java-core/src/test/kotlin/com/openai/core/JacksonVersionTest.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/core/JacksonVersionTest.kt
@@ -1,0 +1,33 @@
+package com.openai.core
+
+import com.fasterxml.jackson.annotation.JacksonAnnotation
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+internal class JacksonVersionTest {
+
+    @Test
+    fun runtimeJacksonVersionsMatchExpectedVersion() {
+        val expectedVersion = checkNotNull(System.getProperty("expected.jackson.version"))
+        val runtimeVersions =
+            mapOf(
+                "jackson-annotations" to
+                    JacksonAnnotation::class.java.`package`.implementationVersion,
+                "jackson-core" to com.fasterxml.jackson.core.json.PackageVersion.VERSION.toString(),
+                "jackson-databind" to
+                    com.fasterxml.jackson.databind.cfg.PackageVersion.VERSION.toString(),
+                "jackson-datatype-jdk8" to
+                    com.fasterxml.jackson.datatype.jdk8.PackageVersion.VERSION.toString(),
+                "jackson-datatype-jsr310" to
+                    com.fasterxml.jackson.datatype.jsr310.PackageVersion.VERSION.toString(),
+                "jackson-module-kotlin" to
+                    com.fasterxml.jackson.module.kotlin.PackageVersion.VERSION.toString(),
+            )
+
+        runtimeVersions.forEach { (module, runtimeVersion) ->
+            assertThat(runtimeVersion)
+                .describedAs("%s runtime version", module)
+                .isEqualTo(expectedVersion)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- update the SDK's published Jackson dependencies from 2.18.2 to 2.18.9
- preserve the existing Jackson 2.14.0 compatibility test floor
- add a second test pass against the Jackson version consumers receive by default
- assert that all six Jackson modules resolve to the expected version
- update the README's documented default

## Why

Jackson 2.18.9 is a patch release in the existing 2.18 LTS line and contains security fixes needed by the current dependency graph. This keeps the SDK on the same Jackson minor line, does not change the public API, and does not raise the documented minimum supported Jackson version.

Addresses #768.

This should be released as a patch version of openai-java.

## Validation

- `./scripts/lint`
- `./gradlew :openai-java-core:testJacksonPublished` — 5,613 tests, zero failures
- `SKIP_MOCK_TESTS=true ./gradlew :openai-java-core:check` — dual-version lifecycle passed serially
- generated Maven POM and Gradle module metadata; all six published Jackson modules resolve to 2.18.9
- full build, ProGuard/R8, and mock-server contract tests passed

A parallel compatibility-test run reproduced the existing Mockito/ByteBuddy stderr-capture race in two logging assertions; the serial lifecycle passed, and the new published-version task runs with JUnit parallelism disabled.