### PR TITLE
fix(deps): update Azure Identity to 1.18.4

### DIFF
--- a/openai-java-example/build.gradle.kts
+++ b/openai-java-example/build.gradle.kts
@@ -9,7 +9,7 @@ repositories {
 
 dependencies {
     implementation(project(":openai-java"))
-    implementation("com.azure:azure-identity:1.15.0")
+    implementation("com.azure:azure-identity:1.18.4")
 }
 
 tasks.withType<JavaCompile>().configureEach {


### PR DESCRIPTION
## Summary

- update the example-only `com.azure:azure-identity` dependency from 1.15.0 to the latest stable release, 1.18.4
- pick up Azure's supported transitive stack: Netty 4.1.135.Final and Reactor Netty 1.2.18
- remove the vulnerable Nimbus JOSE JWT and json-smart path that was present through the older MSAL dependency graph

This is expected to close 33 open Dependabot alerts after GitHub rescans the default branch: 36, 37, 38, 47, 48, 50, 51, 53, 55, 61, 62, 68, and 70 through 90.

## Compatibility

This dependency is declared only by `openai-java-example`, which does not apply `openai.publish` and has no publishing tasks. It is not present in the POM or runtime graph of any published OpenAI Java artifact, so this update cannot change downstream consumers' dependency resolution.

The example uses only `AuthenticationUtil.getBearerTokenSupplier(TokenCredential, String...)` and `new DefaultAzureCredentialBuilder().build()`. Those public binary signatures are identical in 1.15.0 and 1.18.4, the example compiles unchanged, and both Azure Identity artifacts target Java 8 bytecode.

The upstream 1.17.0 release removed the deprecated `SharedTokenCacheCredential` from the default credential chain. That can affect a developer running this source-tree example only if it relied solely on that retired local credential; it does not affect the published SDK or this example's source/API linkage.

## Validation

- `env JAVA_HOME=/opt/homebrew/opt/openjdk@21 ./scripts/test`
- `env JAVA_HOME=/opt/homebrew/opt/openjdk@21 ./scripts/lint`
- `env JAVA_HOME=/opt/homebrew/opt/openjdk@21 ./scripts/build`
- clean `:openai-java-example:compileJava`
- Gradle `dependencyInsight` and runtime graph review for Azure Identity, Azure Core HTTP Netty, Netty, Reactor Netty, Nimbus JOSE JWT, and json-smart
- publication review confirming `openai-java-example` has no publishing tasks
