### PR TITLE
fix(deps): update plexus-utils to 4.0.3

### DIFF
--- a/openai-java-proguard-test/build.gradle.kts
+++ b/openai-java-proguard-test/build.gradle.kts
@@ -11,6 +11,12 @@ buildscript {
     dependencies {
         classpath("com.guardsquare:proguard-gradle:7.4.2")
         classpath("com.android.tools:r8:8.3.37")
+
+        constraints {
+            classpath("org.codehaus.plexus:plexus-utils:4.0.3") {
+                because("4.0.3 fixes CVE-2025-67030 in Shadow's build-time dependency")
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- constrain Shadow's transitive `plexus-utils` build dependency to 4.0.3
- retain Shadow 8.3.8 and the existing Gradle, Java, ProGuard, and R8 behavior
- remediate [Dependabot alert 63](https://github.com/openai/openai-java/security/dependabot/63) / CVE-2025-67030

## Why this approach

Shadow 8.3.8 resolves `plexus-utils` 4.0.2, which is vulnerable to directory traversal during archive extraction. The latest Shadow 8.3.x release still declares 4.0.2, while Shadow 9.x is a documented breaking rewrite. A buildscript constraint is therefore the smallest safe change: Gradle selects the patched 4.0.3 release for Shadow without changing the plugin version or unrelated dependencies.

## Compatibility

The constraint is scoped to the `openai-java-proguard-test` buildscript classpath. That project is an unpublished compatibility-test module, so this dependency cannot enter SDK runtime classpaths, public APIs, or consumer POMs. Generated POMs for all four published artifacts contain no Plexus, Shadow, ProGuard, or R8 dependency.

The 4.0.2-to-4.0.3 comparison reports no binary-incompatible API changes, and both artifacts use Java 8 bytecode. Gradle 8.12 resolution confirms Shadow's request is selected as 4.0.3.

## Validation

- full repository test suite with the pinned local mock server
- full repository lint suite
- clean `shadowJar`, ProGuard JAR execution, and R8 JAR execution
- all published Maven POM generation and dependency inspection
- final post-rebase buildscript resolution, compatibility-test, and lint pass
