### PR TITLE
chore(deps): secure build-time Log4j dependencies

### DIFF
--- a/openai-java-proguard-test/build.gradle.kts
+++ b/openai-java-proguard-test/build.gradle.kts
@@ -16,6 +16,12 @@ buildscript {
             classpath("org.codehaus.plexus:plexus-utils:4.0.3") {
                 because("4.0.3 fixes CVE-2025-67030 in Shadow's build-time dependency")
             }
+            classpath("org.apache.logging.log4j:log4j-api:2.25.5") {
+                because("avoid vulnerable Log4j versions on the build classpath")
+            }
+            classpath("org.apache.logging.log4j:log4j-core:2.25.5") {
+                because("avoid vulnerable Log4j versions on the build classpath")
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

- constrain the build-only Log4j API and Core dependencies used by the Shadow and ProGuard tooling to 2.25.5
- replace the vulnerable resolved Log4j Core 2.24.1 selection across both tool paths
- address Dependabot alerts #56, #64, #65, and #66

## Why 2.25.5

Dependabot's fixed floors for these alerts are 2.25.3 and 2.25.4. Apache's current [security guidance](https://logging.apache.org/security.html) also documents a follow-on issue whose remaining affected path is fixed in 2.25.5, so this uses the minimum currently safe patch on the same 2.25 release line rather than intentionally stopping at 2.25.4. The [2.25.5 release notes](https://logging.apache.org/log4j/2.x/release-notes.html) describe it as a patch release on top of 2.25.4.

Before this change, the build classpath resolved:

- Shadow's Log4j Core 2.24.1
- ProGuard's Log4j API and Core 2.19.0 to 2.24.1

After this change, both paths resolve Log4j API and Core 2.25.5.

## Compatibility

This is scoped to `openai-java-proguard-test`'s `buildscript` classpath. It does not change an SDK source set, runtime classpath, public API, bytecode target, or published dependency.

- all four published runtime classpaths remain Log4j-free
- generated Maven POMs and Gradle module metadata contain no Log4j or `openai-java-proguard-test` references
- Shadow 8.3.8, ProGuard 7.4.2, and R8 8.3.37 remain unchanged and successfully execute with the aligned Log4j patch
- no package version bump is warranted because downstream artifacts and consumers are unchanged

## Validation

- pre/post buildscript `dependencyInsight` and `buildEnvironment`
- clean Shadow packaging plus `testProGuard` and `testR8`
- `./scripts/build --no-configuration-cache`
- `./scripts/test --no-configuration-cache`
- `./scripts/lint --no-configuration-cache`
- `./scripts/detect-breaking-changes origin/main`
- generated every published POM and Gradle module metadata file and verified no Log4j leakage
- `dependencyInsight` for Log4j Core on every published module's `runtimeClasspath` (no matches)
