### PR TITLE
fix(deps): update ProGuard to 7.9.1

### DIFF
--- a/openai-java-proguard-test/build.gradle.kts
+++ b/openai-java-proguard-test/build.gradle.kts
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath("com.guardsquare:proguard-gradle:7.4.2")
+        classpath("com.guardsquare:proguard-gradle:7.9.1")
         classpath("com.android.tools:r8:8.3.37")
 
         constraints {


### PR DESCRIPTION
## Summary

- Update the build-only ProGuard Gradle dependency from 7.4.2 to 7.9.1, the current stable release.
- Move ProGuard’s transitive `org.json:json` from `20220924` to `20231013`.
- Keep the R8 version, shrinker configuration, and SDK keep rules unchanged.

## Security coverage

This addresses both open `org.json` alerts rooted through ProGuard:

- Dependabot #11 / CVE-2022-45688: fixed in `20230227`.
- Dependabot #20 / CVE-2023-5072: fixed in `20231013`.

The resolved `org.json` version is `20231013`, satisfying both fixed-version floors. This PR does not claim the separately tracked Log4j remediation.

## Compatibility analysis

- `proguard-gradle` is used only on the `openai-java-proguard-test` buildscript classpath. It is not a dependency of a published source set, Maven POM, SDK API, or consumer runtime.
- ProGuard 7.9.1 runs successfully with this repository’s Gradle 8.12 and JDK 21 setup. The ProGuard plugin and engine artifacts remain Java 8 bytecode (class-file major version 52).
- A clean ProGuard pass succeeds with the existing keep rules, preserves the embedded `META-INF/proguard/openai-java-core.pro` resource, and produces a Java 8-compatible test artifact. The full client-construction and Jackson serialization round-trip test passes from that processed artifact.
- The unchanged R8 control pass also succeeds and produces a Java 8-compatible artifact.
- The diff changes one buildscript version only. All four published Maven POMs generate successfully and no SDK source, public API, output target, or publication metadata changes.

Upstream release notes: https://github.com/Guardsquare/proguard/releases/tag/v7.9.1

## Validation

- `./scripts/lint`
- `./scripts/build --no-daemon`
- `./scripts/test --no-daemon`
- `./gradlew :openai-java-proguard-test:clean :openai-java-proguard-test:test --no-daemon --stacktrace`
- `./gradlew :openai-java-proguard-test:buildEnvironment --no-daemon`
- `./gradlew generatePomFileForMavenPublication --no-daemon`
- `git diff --check origin/main...HEAD`
