### PR TITLE
build(deps): update test Handlebars to 4.5.3

### DIFF
--- a/openai-java-client-okhttp/build.gradle.kts
+++ b/openai-java-client-okhttp/build.gradle.kts
@@ -11,4 +11,11 @@ dependencies {
     testImplementation(kotlin("test"))
     testImplementation("org.assertj:assertj-core:3.27.7")
     testImplementation("com.github.tomakehurst:wiremock-jre8:2.35.2")
+
+    constraints {
+        // Keep handlebars-helpers at 4.3.1: WireMock 2 links helper classes moved in 4.5.x.
+        testImplementation("com.github.jknack:handlebars:4.5.3") {
+            because("WireMock's transitive 4.3.1 dependency is affected by CVE-2026-55760")
+        }
+    }
 }

--- a/openai-java-core/build.gradle.kts
+++ b/openai-java-core/build.gradle.kts
@@ -55,6 +55,13 @@ dependencies {
     testImplementation("org.mockito:mockito-core:5.14.2")
     testImplementation("org.mockito:mockito-junit-jupiter:5.14.2")
     testImplementation("org.mockito.kotlin:mockito-kotlin:4.1.0")
+
+    constraints {
+        // Keep handlebars-helpers at 4.3.1: WireMock 2 links helper classes moved in 4.5.x.
+        testImplementation("com.github.jknack:handlebars:4.5.3") {
+            because("WireMock's transitive 4.3.1 dependency is affected by CVE-2026-55760")
+        }
+    }
 }
 
 // Re-run the compiled tests against the Jackson version consumers receive by default. Service tests

--- a/openai-java-core/src/test/kotlin/com/openai/core/WireMockHandlebarsCompatibilityTest.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/core/WireMockHandlebarsCompatibilityTest.kt
@@ -1,0 +1,44 @@
+package com.openai.core
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
+import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemplateTransformer
+import java.net.HttpURLConnection
+import java.net.URL
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+internal class WireMockHandlebarsCompatibilityTest {
+
+    @Test
+    fun rendersResponseTemplate() {
+        val server =
+            WireMockServer(
+                wireMockConfig().dynamicPort().extensions(ResponseTemplateTransformer(false))
+            )
+        server.start()
+
+        try {
+            server.stubFor(
+                get(urlEqualTo("/greeting"))
+                    .willReturn(
+                        aResponse()
+                            .withTransformers("response-template")
+                            .withBody("Hello {{request.headers.X-Name}}!")
+                    )
+            )
+
+            val connection =
+                URL("${server.baseUrl()}/greeting").openConnection() as HttpURLConnection
+            connection.setRequestProperty("X-Name", "SDK")
+
+            assertThat(connection.inputStream.bufferedReader().use { it.readText() })
+                .isEqualTo("Hello SDK!")
+        } finally {
+            server.stop()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- constrain the WireMock 2 test graphs in openai-java-core and openai-java-client-okhttp to Handlebars core 4.5.3
- add an end-to-end WireMock response-template test that exercises Handlebars through a real HTTP stub
- address Dependabot alert 91 for CVE-2026-55760 / GHSA-r4gv-qr8j-p3pg

## Version choice

Handlebars 4.5.2 is the first release containing the FileTemplateLoader path-traversal fix. This uses 4.5.3 because it also includes the follow-on SpringTemplateLoader arbitrary-file-read fix.

handlebars-helpers intentionally remains at WireMock's requested 4.3.1. WireMock 2.35.2 links helper classes under com.github.jknack.handlebars.helper, while helpers 4.5.3 moved those classes to a different package; aligning both artifacts breaks response templating with NoClassDefFoundError. The vulnerable artifact is Handlebars core, and the new integration test proves the narrow mixed-version graph preserves WireMock's template behavior.

## Compatibility

This change affects test configurations only. Handlebars and WireMock are absent from the generated Maven POMs and Gradle module metadata. Published SDK classes remain Java 8 bytecode (class-file major version 52), and no public API, runtime dependency, or Jackson compatibility floor changes. Handlebars 4.5.3 itself requires Java 17, but it runs only in this repository's JDK 21 test toolchain and is never exposed to consumers.

## Validation

- dependencyInsight for both modules' test runtime classpaths and the core published-Jackson runtime
- focused response-template test with Jackson 2.14.0 and 2.18.9
- full Gradle check suite with the repository mock server, including ProGuard and R8 checks
- scripts/lint
- scripts/build
- scripts/detect-breaking-changes origin/main
- generated Maven POM and Gradle module metadata inspection
- published core and OkHttp JAR bytecode inspection

Addresses https://github.com/openai/openai-java/security/dependabot/91