### PR TITLE
build(deps): update palantir-java-format to 2.96.0

### DIFF
--- a/buildSrc/src/main/kotlin/openai.java.gradle.kts
+++ b/buildSrc/src/main/kotlin/openai.java.gradle.kts
@@ -49,7 +49,7 @@ tasks.withType<Test>().configureEach {
 
 val palantir by configurations.creating
 dependencies {
-    palantir("com.palantir.javaformat:palantir-java-format:2.89.0")
+    palantir("com.palantir.javaformat:palantir-java-format:2.96.0")
 }
 
 fun registerPalantir(


### PR DESCRIPTION
## Summary

- update the build-only Palantir Java formatter from 2.89.0 to the latest stable release, 2.96.0
- move the formatter's isolated Jackson tool classpath from 2.21.0 to 2.21.4
- address the 2.21.x formatter paths behind Dependabot alerts 59, 92, 95, 97, 99, 102, and 103

## Compatibility

This dependency is used only by the custom `palantir` configuration in `buildSrc` to format Java source. It is not present in the SDK's API, runtime, POMs, or Gradle publication metadata. The SDK's Java 8 source and bytecode compatibility and its published dependency versions are unchanged.

The formatter's upstream changes since 2.89.0 are fixes for method-reference formatting, Markdown doc-comment wrapping, Spotless integration, and plugin publishing. Running 2.96.0 over the repository produced no source changes.

This PR intentionally does not add an independent Jackson override. Palantir 2.96.0 declares Jackson 2.21.4, so the separate advisory requiring 2.21.5 remains for a follow-up remediation.

## Validation

- `./scripts/lint`
- `./scripts/build`
- `./scripts/test`
- `./scripts/detect-breaking-changes origin/main`
- generated POM and Gradle module metadata for all published modules and verified the formatter is absent
- resolved the `palantir` configuration and verified Palantir 2.96.0 with Jackson 2.21.4
- ran the upgraded formatter in place and verified the only repository diff is the dependency version
