### PR TITLE
build(deps): update test Jetty to 9.4.58

### DIFF
--- a/openai-java-client-okhttp/build.gradle.kts
+++ b/openai-java-client-okhttp/build.gradle.kts
@@ -10,5 +10,6 @@ dependencies {
 
     testImplementation(kotlin("test"))
     testImplementation("org.assertj:assertj-core:3.27.7")
+    testImplementation(platform("org.eclipse.jetty:jetty-bom:9.4.58.v20250814"))
     testImplementation("com.github.tomakehurst:wiremock-jre8:2.35.2")
 }

--- a/openai-java-core/build.gradle.kts
+++ b/openai-java-core/build.gradle.kts
@@ -47,6 +47,7 @@ dependencies {
 
     testImplementation(kotlin("test"))
     testImplementation(project(":openai-java-client-okhttp"))
+    testImplementation(platform("org.eclipse.jetty:jetty-bom:9.4.58.v20250814"))
     testImplementation("com.github.tomakehurst:wiremock-jre8:2.35.2")
     testImplementation("org.assertj:assertj-core:3.27.7")
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.3")


### PR DESCRIPTION
## Summary

- align WireMock 2.35.2's Jetty test runtime on the Jetty 9.4 BOM at `9.4.58.v20250814`
- apply the alignment only to the core and OkHttp test configurations
- keep WireMock 2.35.2, the Java 8 baseline, and both Jackson 2.14.0/2.18.9 compatibility lines unchanged

## Security impact

The BOM upgrades the complete `org.eclipse.jetty` and `org.eclipse.jetty.http2` test graph from `9.4.49.v20220914` to `9.4.58.v20250814`. This addresses Dependabot alerts #12-17, #24-26, #31, #33, #40, and #49.

Three Jetty alerts cannot be fixed on the Java-8-compatible 9.4 line today:

- #32 is only patched in Jetty 12.0.12; moving to Jetty 12 would require a breaking Java and WireMock major-version migration.
- #60 covers Jetty through the latest available 9.4.58 release and has no patched 9.4 version.
- #67 covers Jetty through 9.4.59 and has no patched 9.4 version; 9.4.58 is the latest published Jetty 9.4 release.

Those three alerts remain visible rather than being hidden behind a breaking major upgrade.

## Compatibility

- The change stays within Jetty 9.4, and all WireMock-backed tests pass with WireMock 2.35.2.
- Representative classes from every affected Jetty and HTTP/2 artifact are Java 8 bytecode (`major version 52`).
- Core and OkHttp WireMock tests pass with both the Jackson 2.14.0 compatibility floor and the published Jackson 2.18.9 line.
- The generated Maven POMs for both modules contain no Jetty BOM, Jetty artifact, or WireMock dependency, so downstream dependency resolution and public APIs are unchanged.

## Validation

- `./scripts/lint`
- `./scripts/build`
- `./scripts/test`
- `./scripts/detect-breaking-changes origin/main`
- Jetty `dependencyInsight` for both test runtime classpaths
- targeted WireMock suites under Jackson 2.14.0 and 2.18.9 in both modules
- generated Maven POM inspection for core and OkHttp
