### PR TITLE
build(deps): update test Guava to 33.6.0

### DIFF
--- a/openai-java-client-okhttp/build.gradle.kts
+++ b/openai-java-client-okhttp/build.gradle.kts
@@ -4,6 +4,12 @@ plugins {
 }
 
 dependencies {
+    constraints {
+        testImplementation("com.google.guava:guava:33.6.0-jre") {
+            because("WireMock's transitive Guava 31.1-jre has known temporary-file vulnerabilities")
+        }
+    }
+
     api(project(":openai-java-core"))
 
     implementation("com.squareup.okhttp3:okhttp:4.12.0")

--- a/openai-java-core/build.gradle.kts
+++ b/openai-java-core/build.gradle.kts
@@ -32,6 +32,12 @@ configurations.matching { it.name != jacksonPublishedRuntime.name }.configureEac
 }
 
 dependencies {
+    constraints {
+        testImplementation("com.google.guava:guava:33.6.0-jre") {
+            because("WireMock's transitive Guava 31.1-jre has known temporary-file vulnerabilities")
+        }
+    }
+
     api("com.fasterxml.jackson.core:jackson-core:$jacksonPublishedVersion")
     api("com.fasterxml.jackson.core:jackson-databind:$jacksonPublishedVersion")
     api("com.google.errorprone:error_prone_annotations:2.33.0")


### PR DESCRIPTION
## Summary

- constrain WireMock 2.35.2's test-only Guava dependency from 31.1-jre to 33.6.0-jre in both `openai-java-core` and `openai-java-client-okhttp`
- remediate [Dependabot alert 18](https://github.com/openai/openai-java/security/dependabot/18) (GHSA-7g45-4rm6-3mm3 / CVE-2023-2976) and [Dependabot alert 19](https://github.com/openai/openai-java/security/dependabot/19) (GHSA-5mg8-w23w-74h3 / CVE-2020-8908)
- leave WireMock 2.35.2 and the Jackson 2.14.0 compatibility floor unchanged

Guava 33.6.0-jre is the current stable JRE release. Gradle selects its Java 8 runtime variant, and WireMock's referenced public Guava classes remain present.

## Downstream compatibility

This is limited to `testImplementation` constraints. Generated Maven POMs and Gradle module metadata for both published modules contain neither Guava nor WireMock. There are no production source, bytecode, public API, runtime dependency, or Java baseline changes for SDK consumers.

## Validation

- dependency insight for both `testRuntimeClasspath` graphs and core's `jacksonPublishedRuntime` resolves Guava to 33.6.0-jre
- all repository test tasks, ProGuard/R8 checks, and `testJacksonPublished` pass (external generated-API mock-server tests skipped locally)
- `./scripts/build --no-configuration-cache`
- `./scripts/lint`
- `./scripts/detect-breaking-changes origin/main`
- generated Maven POM and Gradle module metadata inspection for both affected modules
- `jdeps` verification that WireMock 2.35.2 has no missing Guava class references against 33.6.0-jre
