### PR TITLE
build(deps): update test commons-fileupload to 1.6.0

### DIFF
--- a/openai-java-client-okhttp/build.gradle.kts
+++ b/openai-java-client-okhttp/build.gradle.kts
@@ -8,6 +8,9 @@ dependencies {
         testImplementation("com.google.guava:guava:33.6.0-jre") {
             because("WireMock's transitive Guava 31.1-jre has known temporary-file vulnerabilities")
         }
+        testImplementation("commons-fileupload:commons-fileupload:1.6.0") {
+            because("WireMock's transitive 1.4 release has known denial-of-service vulnerabilities")
+        }
     }
 
     api(project(":openai-java-core"))

--- a/openai-java-core/build.gradle.kts
+++ b/openai-java-core/build.gradle.kts
@@ -36,6 +36,9 @@ dependencies {
         testImplementation("com.google.guava:guava:33.6.0-jre") {
             because("WireMock's transitive Guava 31.1-jre has known temporary-file vulnerabilities")
         }
+        testImplementation("commons-fileupload:commons-fileupload:1.6.0") {
+            because("WireMock's transitive 1.4 release has known denial-of-service vulnerabilities")
+        }
     }
 
     api("com.fasterxml.jackson.core:jackson-core:$jacksonPublishedVersion")


### PR DESCRIPTION
## Summary

- constrain WireMock 2.35.2's transitive `commons-fileupload` dependency to 1.6.0 in the core and OkHttp test configurations
- remediate [Dependabot alert 9](https://github.com/openai/openai-java/security/dependabot/9) (CVE-2023-24998) and [Dependabot alert 45](https://github.com/openai/openai-java/security/dependabot/45) (CVE-2025-48976)
- keep the production dependency graph, WireMock version, and Jackson compatibility floor unchanged

Apache identifies 1.6.0 as the first 1.x release that fixes the remaining multipart-header denial of service. It retains the 1.x coordinates and API family, requires Java 8, and adds JApiCmp validation against 1.5.

## Compatibility

This is test-only and has no downstream consumer impact:

- both constraints are scoped to `testImplementation`
- `commons-fileupload` remains absent from both modules' production `runtimeClasspath`
- generated Maven POMs and Gradle module metadata contain neither Commons FileUpload nor WireMock
- WireMock remains on 2.35.2; its FileUpload API references resolve against 1.6.0 and its multipart-backed tests pass
- the Jackson 2.14.0 compatibility floor and published 2.18.9 runtime are unchanged and both were exercised

## Validation

- `./scripts/test`
- complete core suite with WireMock/FileUpload 1.6.0 on Jackson 2.18.9
- OkHttp WireMock suite with Jackson forced to 2.14.0
- `./scripts/lint`
- `./scripts/build`
- `./scripts/detect-breaking-changes origin/main`
- dependency insight for both test and production runtime configurations
- generated Maven POM and Gradle module metadata inspection
- Java 8 bytecode and WireMock-to-FileUpload linkage inspection
