### PR TITLE
build(deps): update test Commons IO to 2.22.0

### DIFF
--- a/openai-java-client-okhttp/build.gradle.kts
+++ b/openai-java-client-okhttp/build.gradle.kts
@@ -14,6 +14,9 @@ dependencies {
         testImplementation("org.xmlunit:xmlunit-core:2.11.0") {
             because("2.10.0 fixes CVE-2024-31573 in this test-only dependency")
         }
+        testImplementation("commons-io:commons-io:2.22.0") {
+            because("WireMock's transitive Commons IO version has a resource-exhaustion vulnerability")
+        }
     }
 
     api(project(":openai-java-core"))

--- a/openai-java-core/build.gradle.kts
+++ b/openai-java-core/build.gradle.kts
@@ -47,6 +47,9 @@ dependencies {
         testImplementation("org.xmlunit:xmlunit-core:2.11.0") {
             because("2.10.0 fixes CVE-2024-31573 in this test-only dependency")
         }
+        testImplementation("commons-io:commons-io:2.22.0") {
+            because("WireMock's transitive Commons IO version has a resource-exhaustion vulnerability")
+        }
     }
 
     api("com.fasterxml.jackson.core:jackson-core:$jacksonPublishedVersion")


### PR DESCRIPTION
## Summary

- constrain WireMock 2.35.2's test-only Commons IO dependency from 2.11.0 to 2.22.0 in both `openai-java-core` and `openai-java-client-okhttp`
- remediate [Dependabot alert 30](https://github.com/openai/openai-java/security/dependabot/30) (GHSA-78wr-2p64-hpwj / CVE-2024-47554)
- leave WireMock 2.35.2 and the Jackson 2.14.0 compatibility floor unchanged

The alert's patched floor is Commons IO 2.14.0. [Commons IO 2.22.0](https://commons.apache.org/proper/commons-io/changes.html) is the current stable release and still requires Java 8. The resolved artifact has Java 8 classfile level 52, and the focused WireMock tests pass with it under both Jackson compatibility lines.

## Downstream compatibility

This is limited to `testImplementation` constraints. Generated Maven POMs and Gradle module metadata for both published modules contain neither Commons IO nor WireMock. There are no production source, bytecode, public API, runtime dependency, or Java baseline changes for SDK consumers.

## Validation

- dependency insight for both `testRuntimeClasspath` graphs and core's `jacksonPublishedRuntime` resolves Commons IO to 2.22.0
- focused WireMock tests in core and okhttp pass under Jackson 2.14.0 and 2.18.9
- all repository test tasks, ProGuard/R8 checks, and `testJacksonPublished` pass (external generated-API mock-server tests skipped locally)
- `./scripts/build --no-configuration-cache`
- `./scripts/lint`
- `./scripts/detect-breaking-changes origin/main`
- generated Maven POM and Gradle module metadata inspection for both affected modules
- Java 8 classfile and WireMock bytecode-reference inspection
