### PR TITLE
build(deps): update test commons-lang3 to 3.18.0

### DIFF
--- a/openai-java-client-okhttp/build.gradle.kts
+++ b/openai-java-client-okhttp/build.gradle.kts
@@ -20,6 +20,9 @@ dependencies {
         testImplementation("com.jayway.jsonpath:json-path:2.10.0") {
             because("WireMock's transitive JSONPath version has a stack-overflow vulnerability")
         }
+        testImplementation("org.apache.commons:commons-lang3:3.18.0") {
+            because("WireMock's transitive 3.12.0 release is vulnerable to uncontrolled recursion")
+        }
     }
 
     api(project(":openai-java-core"))

--- a/openai-java-core/build.gradle.kts
+++ b/openai-java-core/build.gradle.kts
@@ -53,6 +53,9 @@ dependencies {
         testImplementation("com.jayway.jsonpath:json-path:2.10.0") {
             because("WireMock's transitive JSONPath version has a stack-overflow vulnerability")
         }
+        testImplementation("org.apache.commons:commons-lang3:3.18.0") {
+            because("WireMock's transitive 3.12.0 release is vulnerable to uncontrolled recursion")
+        }
     }
 
     api("com.fasterxml.jackson.core:jackson-core:$jacksonPublishedVersion")


### PR DESCRIPTION
## Summary

- constrain WireMock's transitive `commons-lang3` dependency to 3.18.0 in the core and OkHttp test graphs
- use the first patched release for [Dependabot alert 46](https://github.com/openai/openai-java/security/dependabot/46) while leaving WireMock at 2.35.2
- keep the change test-only so published artifacts and consumer dependency graphs are unaffected

## Compatibility analysis

- 3.18.0 is the minimum release that fixes GHSA-j288-q9x7-2f5v / CVE-2025-48924, minimizing behavior drift versus moving to the latest Commons Lang release
- Commons Lang 3.18.0 still requires Java 8, and its artifact bytecode targets Java 8
- WireMock 2.35.2 and Handlebars Helpers linkage to Commons Lang resolves against 3.18.0
- Commons Lang is absent from the core and OkHttp production runtime classpaths and from their generated POM and Gradle module metadata
- the supported Jackson 2.14 compatibility floor and published Jackson 2.18.9 runtime are unchanged

## Validation

- `./scripts/test`
- all 15 WireMock-backed core test classes with the published Jackson 2.18.9 runtime
- OkHttp WireMock tests with the Jackson 2.14.0 compatibility floor
- `./scripts/lint`
- `./scripts/build`
- `./scripts/detect-breaking-changes origin/main`
- dependency insight for both affected test runtime classpaths
- generated Maven POM and Gradle module metadata inspection
- Java 8 bytecode and WireMock/Handlebars linkage inspection

