### PR TITLE
build(deps): update test JSONPath to 2.10.0

### DIFF
--- a/openai-java-client-okhttp/build.gradle.kts
+++ b/openai-java-client-okhttp/build.gradle.kts
@@ -17,6 +17,9 @@ dependencies {
         testImplementation("commons-io:commons-io:2.22.0") {
             because("WireMock's transitive Commons IO version has a resource-exhaustion vulnerability")
         }
+        testImplementation("com.jayway.jsonpath:json-path:2.10.0") {
+            because("WireMock's transitive JSONPath version has a stack-overflow vulnerability")
+        }
     }
 
     api(project(":openai-java-core"))

--- a/openai-java-core/build.gradle.kts
+++ b/openai-java-core/build.gradle.kts
@@ -50,6 +50,9 @@ dependencies {
         testImplementation("commons-io:commons-io:2.22.0") {
             because("WireMock's transitive Commons IO version has a resource-exhaustion vulnerability")
         }
+        testImplementation("com.jayway.jsonpath:json-path:2.10.0") {
+            because("WireMock's transitive JSONPath version has a stack-overflow vulnerability")
+        }
     }
 
     api("com.fasterxml.jackson.core:jackson-core:$jacksonPublishedVersion")

--- a/openai-java-spring-boot-starter/build.gradle.kts
+++ b/openai-java-spring-boot-starter/build.gradle.kts
@@ -12,6 +12,13 @@ dependencies {
         testImplementation("org.xmlunit:xmlunit-core:2.11.0") {
             because("2.10.0 fixes CVE-2024-31573 in this test-only dependency")
         }
+        testImplementation("com.jayway.jsonpath:json-path:2.10.0") {
+            because("Spring Boot's transitive JSONPath version has a stack-overflow vulnerability")
+        }
+        testImplementation("org.slf4j:slf4j-api") {
+            version { strictly("1.7.36") }
+            because("Spring Boot 2.7 and Logback 1.2 require SLF4J 1.7 at test runtime")
+        }
     }
 
     api(project(":openai-java"))

--- a/openai-java-spring-boot-starter/src/test/kotlin/com/openai/springboot/SpringBootLoggingCompatibilityTest.kt
+++ b/openai-java-spring-boot-starter/src/test/kotlin/com/openai/springboot/SpringBootLoggingCompatibilityTest.kt
@@ -1,0 +1,25 @@
+// File generated from our OpenAPI spec by Stainless.
+
+package com.openai.springboot
+
+import com.openai.client.OpenAIClient
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.boot.SpringBootConfiguration
+import org.springframework.boot.WebApplicationType
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration
+import org.springframework.boot.builder.SpringApplicationBuilder
+
+internal class SpringBootLoggingCompatibilityTest {
+
+    @Test
+    fun springApplicationStartsWithBootLogging() {
+        SpringApplicationBuilder(TestApplication::class.java)
+            .web(WebApplicationType.NONE)
+            .properties("openai.api-key=test")
+            .run()
+            .use { context -> assertThat(context.getBean(OpenAIClient::class.java)).isNotNull() }
+    }
+
+    @SpringBootConfiguration @EnableAutoConfiguration internal open class TestApplication
+}


### PR DESCRIPTION
## Summary

- constrain test-only JSONPath from 2.7.0 to 2.10.0 in the WireMock graphs for `openai-java-core` and `openai-java-client-okhttp`, and the Spring Boot starter test graph
- remediate [Dependabot alert 28](https://github.com/openai/openai-java/security/dependabot/28) (GHSA-pfh2-hfmq-phg5 / CVE-2023-51074)
- move those graphs from vulnerable json-smart 2.4.7/2.4.8 to 2.6.0, addressing their [Dependabot alert 10](https://github.com/openai/openai-java/security/dependabot/10) paths
- leave WireMock 2.35.2, Spring Boot 2.7.18, and the Jackson 2.14.0 compatibility floor unchanged

[JSONPath 2.10.0](https://github.com/json-path/JsonPath/releases/tag/json-path-2.10.0) is the latest stable release on the Java 8-compatible 2.x line; JSONPath 3.0.0 requires Java 17. Both JSONPath 2.10.0 and its json-smart 2.6.0 dependency have Java 8 classfile level 52.

Alert #37's separate json-smart 2.5.1 path comes from Azure Identity in the example module, not JSONPath. It is outside this PR's scope and is already addressed by #779.

## Downstream compatibility

This is limited to `testImplementation` constraints. Generated Maven POMs and Gradle module metadata for all three affected published modules contain neither JSONPath nor json-smart. There are no production source, bytecode, public API, runtime dependency, Java baseline, or release-version changes for SDK consumers.

A japicmp comparison of JSONPath 2.7.0 and 2.10.0 found no public binary or source incompatibilities. The reported changes are additions and a visibility widening.

## Validation

- dependency insight for core, okhttp, Spring Boot starter, and core's published-Jackson runtime resolves JSONPath to 2.10.0's Java 8 variant
- all affected runtime graphs resolve json-smart and accessors-smart to 2.6.0
- WireMock's `matchingJsonPath` integration passes under Jackson 2.14.0 and 2.18.9
- focused okhttp and Spring Boot starter tests pass
- all repository test tasks, ProGuard/R8 checks, `testJacksonPublished`, and the published-Jackson WireMock check pass (external generated-API mock-server tests skipped locally)
- `./scripts/build --no-configuration-cache`
- `./scripts/lint`
- `./scripts/detect-breaking-changes origin/main`
- generated Maven POM and Gradle module metadata inspection for all three affected modules
- all-resolvable-configuration scan for remaining JSONPath/json-smart versions
- Java 8 classfile inspection for JSONPath and json-smart
