### PR TITLE
build(deps): update Dokka to 2.1.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("org.jetbrains.dokka") version "2.0.0"
+    id("org.jetbrains.dokka") version "2.1.0"
 }
 
 repositories {

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,10 @@ org.gradle.caching=true
 org.gradle.configuration-cache=true
 org.gradle.parallel=true
 org.gradle.daemon=false
+# Keep the existing Dokka task graph and generated Javadoc links stable. Migrate to Dokka's V2
+# task/aggregation model and K2 analysis as separate documentation-pipeline changes.
+org.jetbrains.dokka.experimental.gradle.pluginMode=V1Enabled
+org.jetbrains.dokka.experimental.tryK2=false
 # These options improve our compilation and test performance. They are inherited by the Kotlin daemon.
 org.gradle.jvmargs=\
   -Xms2g \


### PR DESCRIPTION
## Summary

- upgrade the build-only Dokka Gradle plugin from 2.0.0 to 2.1.0
- retain Dokka's V1 task/aggregation model and K1 analyzer so the existing Javadoc task graph and link layout remain stable
- move Dokka's runtime from Woodstox 6.2.4 to 6.5.1 and Jackson 2.12.7 to 2.15.3

This targets Dependabot alerts #6 (Woodstox), #43 (Jackson Core), and #93 (Jackson Databind).

## Why 2.1.0 instead of 2.2.0

2.2.0 was evaluated first with both K1 and K2 analysis. Its Javadoc renderer generates member-summary links that do not match any anchor in the target page: 76 new invalid anchors with K1 and 184 with K2 in the core artifact. That would regress published documentation links.

2.1.0 resolves the same relevant vulnerable transitives while preserving every existing Javadoc file and internal link target. Moving to Dokka's V2 aggregation model and K2 analysis should be handled as a separate documentation-pipeline change.

## Compatibility

- all four published Maven POMs are byte-for-byte identical
- Gradle module metadata is semantically identical; only regenerated artifact checksums differ
- production and source JAR entry contents are identical before and after
- SDK bytecode remains Java 8 (class major version 52)
- Javadoc JAR entry sets and artifact names are identical
- no internal Javadoc link targets were added, removed, or broken
- Dokka changes generated boilerplate content on 1,624 of 9,682 core Javadoc entries, but preserves their paths and anchors
- Dokka remains a build-only dependency and is not exposed to SDK consumers

Dokka 2.1.0 still resolves Jackson 2.15.3. Newer Jackson advisories affecting that build-tool classpath remain and require a separate Dokka-classpath Jackson alignment change.

## Validation

- `./scripts/lint`
- `./scripts/build`
- `./scripts/test`
- `./scripts/detect-breaking-changes origin/main`
- `./gradlew clean publish -PpublishLocal --no-configuration-cache`
- before/after comparison of all published POMs, Gradle module metadata, production/source JAR contents, Javadoc entries, and internal links
- resolved `dokkaJavadocRuntime` dependency-tree review
