### PR TITLE
build(deps): update test XMLUnit to 2.11.0

### DIFF
--- a/openai-java-client-okhttp/build.gradle.kts
+++ b/openai-java-client-okhttp/build.gradle.kts
@@ -11,6 +11,9 @@ dependencies {
         testImplementation("commons-fileupload:commons-fileupload:1.6.0") {
             because("WireMock's transitive 1.4 release has known denial-of-service vulnerabilities")
         }
+        testImplementation("org.xmlunit:xmlunit-core:2.11.0") {
+            because("2.10.0 fixes CVE-2024-31573 in this test-only dependency")
+        }
     }
 
     api(project(":openai-java-core"))

--- a/openai-java-core/build.gradle.kts
+++ b/openai-java-core/build.gradle.kts
@@ -39,6 +39,9 @@ dependencies {
         testImplementation("commons-fileupload:commons-fileupload:1.6.0") {
             because("WireMock's transitive 1.4 release has known denial-of-service vulnerabilities")
         }
+        testImplementation("org.xmlunit:xmlunit-core:2.11.0") {
+            because("2.10.0 fixes CVE-2024-31573 in this test-only dependency")
+        }
     }
 
     api("com.fasterxml.jackson.core:jackson-core:$jacksonPublishedVersion")

--- a/openai-java-spring-boot-starter/build.gradle.kts
+++ b/openai-java-spring-boot-starter/build.gradle.kts
@@ -8,6 +8,12 @@ repositories {
 }
 
 dependencies {
+    constraints {
+        testImplementation("org.xmlunit:xmlunit-core:2.11.0") {
+            because("2.10.0 fixes CVE-2024-31573 in this test-only dependency")
+        }
+    }
+
     api(project(":openai-java"))
     implementation("org.springframework.boot:spring-boot-autoconfigure:2.7.18")
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor:2.7.18")


### PR DESCRIPTION
## Summary

- Constrain `org.xmlunit:xmlunit-core` to 2.11.0 in the core WireMock, OkHttp WireMock, and Spring starter test graphs.
- Keep WireMock at 2.35.2 and Spring Boot at 2.7.18.
- Address Dependabot alert #27 / CVE-2024-31573 without changing any published dependency.

## Version choice

The advisory is fixed in XMLUnit 2.10.0. XMLUnit 2.11.0 is the safest current 2.x target for these graphs: upstream states its `xmlunit-core` is identical to 2.10.4, while the newer 2.12.0 release explicitly documents a backward-incompatible DTD parsing default.

Upstream release notes: https://github.com/xmlunit/xmlunit/releases/tag/v2.11.0

## Compatibility analysis

- All constraints are on `testImplementation`; XMLUnit is not used by SDK production code or exposed to consumers.
- The 2.11.0 core jar targets Java 7 bytecode, preserving this SDK’s Java 8 consumer baseline.
- A public/protected API comparison from the existing 2.9.1 core jar to 2.11.0 found no removed classes, methods, or fields; changes are additive.
- Dependency insight confirms 2.11.0 in core, OkHttp, Spring, and the core published-Jackson test runtime.
- WireMock and Spring tests pass without changing their parent dependency versions.
- Both Jackson compatibility lines remain verified: 2.14.0 and the published 2.18.9 line.
- Generated POMs for all published modules contain no XMLUnit dependency or constraint.

## Validation

- `./scripts/test --rerun-tasks --no-daemon`
- `./gradlew :openai-java-core:testJacksonPublished --rerun-tasks --no-daemon`
- `./scripts/lint`
- `./scripts/build --no-daemon`
- `./scripts/detect-breaking-changes origin/main`
- `./gradlew generatePomFileForMavenPublication --no-daemon`
- Dependency insight for core, OkHttp, Spring, and `jacksonPublishedRuntime`
- `git diff --check`
