### PR TITLE
build(deps): update test SnakeYAML to 2.6

### DIFF
--- a/openai-java-spring-boot-starter/build.gradle.kts
+++ b/openai-java-spring-boot-starter/build.gradle.kts
@@ -14,4 +14,10 @@ dependencies {
 
     testImplementation("org.springframework.boot:spring-boot-starter-test:2.7.18")
     testImplementation("org.assertj:assertj-core:3.27.7")
+
+    constraints {
+        testImplementation("org.yaml:snakeyaml:2.6") {
+            because("avoid known vulnerabilities in Spring Boot's test dependency")
+        }
+    }
 }

--- a/openai-java-spring-boot-starter/src/test/kotlin/com/openai/springboot/OpenAIClientAutoConfigurationTest.kt
+++ b/openai-java-spring-boot-starter/src/test/kotlin/com/openai/springboot/OpenAIClientAutoConfigurationTest.kt
@@ -3,11 +3,14 @@
 package com.openai.springboot
 
 import com.openai.client.OpenAIClient
+import java.nio.charset.StandardCharsets
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.getBean
 import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.env.YamlPropertySourceLoader
 import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.core.io.ByteArrayResource
 
 internal class OpenAIClientAutoConfigurationTest {
 
@@ -34,6 +37,36 @@ internal class OpenAIClientAutoConfigurationTest {
                 assertThat(properties.organization).isEqualTo("My Organization")
                 assertThat(properties.project).isEqualTo("My Project")
                 assertThat(properties.webhookSecret).isEqualTo("My Webhook Secret")
+            }
+    }
+
+    @Test
+    fun yamlProperties() {
+        val resource =
+            ByteArrayResource(
+                """
+                openai:
+                  base-url: https://api.openai.com/v1
+                  api-key: YAML API Key
+                  org-id: YAML Organization
+                """
+                    .trimIndent()
+                    .toByteArray(StandardCharsets.UTF_8)
+            )
+        val propertySources = YamlPropertySourceLoader().load("test", resource)
+
+        contextRunner
+            .withInitializer { context ->
+                propertySources.reversed().forEach {
+                    context.environment.propertySources.addFirst(it)
+                }
+            }
+            .run { context ->
+                val properties = context.getBean<OpenAIClientProperties>()
+                assertThat(properties.baseUrl).isEqualTo("https://api.openai.com/v1")
+                assertThat(properties.apiKey).isEqualTo("YAML API Key")
+                assertThat(properties.organization).isEqualTo("YAML Organization")
+                context.getBean<OpenAIClient>()
             }
     }
 


### PR DESCRIPTION
## Summary

- constrain the Spring Boot starter's test-only transitive SnakeYAML dependency from 1.30 to 2.6
- keep Spring Boot 2.7.18 and every published dependency unchanged
- exercise Spring Boot's real YAML loader, configuration binding, and auto-configured client in a compatibility test

This addresses Dependabot alerts [#1](https://github.com/openai/openai-java/security/dependabot/1), [#2](https://github.com/openai/openai-java/security/dependabot/2), [#3](https://github.com/openai/openai-java/security/dependabot/3), [#4](https://github.com/openai/openai-java/security/dependabot/4), [#5](https://github.com/openai/openai-java/security/dependabot/5), [#7](https://github.com/openai/openai-java/security/dependabot/7), and [#8](https://github.com/openai/openai-java/security/dependabot/8). Alert #8 requires SnakeYAML 2.0 or newer.

## Compatibility analysis

- Maven Central identifies 2.6 as the current stable release. Its published POM targets Java 8, its manifest requires JavaSE 1.8, and its base classes use Java 8 bytecode (class-file major version 52).
- Spring Boot added SnakeYAML 2.x loader compatibility in its 2.7.10 line; this module remains on 2.7.18. The new test verifies 2.7.18 with 2.6 by parsing YAML through `YamlPropertySourceLoader`, adding it to an `ApplicationContextRunner`, binding `OpenAIClientProperties`, and constructing `OpenAIClient`.
- The constraint exists only on `testImplementation`. `runtimeClasspath` contains no SnakeYAML, and the generated published POM contains no SnakeYAML dependency or constraint.
- Against an `origin/main` publication baseline, the generated POM and sources JAR are byte-identical. Every file inside the main JAR is byte-identical. Normalized Gradle module metadata has identical variants and dependencies; raw archive checksums differ only because a fresh JAR rebuild records new ZIP timestamps.
- There are no production source, public API, runtime dependency, or consumer metadata changes. This is patch-level release material and does not require a minor or major version bump.

References: [SnakeYAML Maven metadata](https://repo1.maven.org/maven2/org/yaml/snakeyaml/maven-metadata.xml), [SnakeYAML 2.6 POM](https://repo1.maven.org/maven2/org/yaml/snakeyaml/2.6/snakeyaml-2.6.pom), [Spring Boot 2.7 compatibility fix](https://github.com/spring-projects/spring-boot/commit/86c988d6533d58f9c1beb5ff53e81d8fdf35a73e).

## Verification

- `:openai-java-spring-boot-starter:dependencyInsight --configuration testRuntimeClasspath --dependency org.yaml:snakeyaml` (selects 2.6)
- `:openai-java-spring-boot-starter:dependencyInsight --configuration runtimeClasspath --dependency org.yaml:snakeyaml` (no match)
- targeted Spring Boot YAML/config binding compatibility test
- `./scripts/lint`
- `./scripts/build`
- `./scripts/test` (including ProGuard and R8)
- `./scripts/detect-breaking-changes origin/main`
- local publication comparison against `origin/main`
