### PR TITLE
build(deps): align Palantir Jackson to 2.21.5

### DIFF
--- a/buildSrc/src/main/kotlin/openai.java.gradle.kts
+++ b/buildSrc/src/main/kotlin/openai.java.gradle.kts
@@ -49,6 +49,9 @@ tasks.withType<Test>().configureEach {
 
 val palantir by configurations.creating
 dependencies {
+    // Palantir is an isolated build tool and must use the internally aligned Jackson line it was
+    // built against. This does not affect any published or runtime dependency configuration.
+    palantir(platform("com.fasterxml.jackson:jackson-bom:2.21.5"))
     palantir("com.palantir.javaformat:palantir-java-format:2.96.0")
 }
 

--- a/openai-java-core/build.gradle.kts
+++ b/openai-java-core/build.gradle.kts
@@ -16,7 +16,10 @@ val jacksonPublishedRuntime by configurations.creating {
     isCanBeResolved = true
 }
 
-configurations.matching { it.name != jacksonPublishedRuntime.name }.configureEach {
+// Palantir is an isolated build tool with its own aligned Jackson BOM.
+configurations.matching {
+    it.name != jacksonPublishedRuntime.name && it.name != "palantir"
+}.configureEach {
     resolutionStrategy {
         // Compile and test against a lower Jackson version to ensure we're compatible with it. Note that
         // we generally support 2.13.4, but test against 2.14.0 because 2.13.4 has some annoying (but


### PR DESCRIPTION
## Summary

- align the Jackson family used only by the Palantir Java formatter to the fixed 2.21.5 BOM
- exempt only the isolated `palantir` configuration from the core module's Jackson 2.14 compatibility-test force
- address [Dependabot alert #101](https://github.com/openai/openai-java/security/dependabot/101) without changing SDK runtime dependencies

This PR is intentionally stacked on #784, which updates `palantir-java-format` to 2.96.0. It should be reviewed and merged after #784.

## Compatibility

This is build-tool-only configuration. Dependency inspection confirms:

- Palantir resolves `jackson-databind` and its Jackson modules at 2.21.5
- the SDK compatibility test runtime remains on Jackson 2.14.0
- the published-runtime test remains on Jackson 2.18.9
- generated Maven POMs contain neither Palantir nor Jackson 2.21.5; the published core POM still declares Jackson 2.18.9
- no SDK source, generated model, public API, or runtime configuration changes

## Validation

- `./scripts/lint`
- `./scripts/build`
- `./scripts/test`
- `./scripts/detect-breaking-changes b00633be16fdb678b3adce953c9429e1cabd0216`
- `./gradlew publishAllPublicationsToLocalFileSystemRepository -PpublishLocal`
- regenerated and inspected every published Maven POM after rebasing onto the current parent
- Gradle `dependencyInsight` checks for the Palantir, compatibility-test, and published-runtime Jackson graphs

