### PR TITLE
build(deps): secure Dokka Jackson classpath

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,8 @@ plugins {
     id("org.jetbrains.dokka") version "2.1.0"
 }
 
+val dokkaJacksonVersion = "2.18.9"
+
 repositories {
     mavenCentral()
 }
@@ -9,6 +11,21 @@ repositories {
 allprojects {
     group = "com.openai"
     version = "4.43.0" // x-release-please-version
+
+    // Dokka 2.1.0 depends on Jackson 2.15.3. Keep its isolated build-tool classpaths on a
+    // secure, internally aligned Jackson release without changing the SDK's published or
+    // compatibility-test dependency versions.
+    configurations.matching { it.name.startsWith("dokka") }.configureEach {
+        resolutionStrategy.eachDependency {
+            if (
+                requested.group == "com.fasterxml.jackson" ||
+                    requested.group.startsWith("com.fasterxml.jackson.")
+            ) {
+                useVersion(dokkaJacksonVersion)
+                because("Dokka's build-only Jackson classpath must use a secure aligned release")
+            }
+        }
+    }
 }
 
 subprojects {

--- a/openai-java-core/build.gradle.kts
+++ b/openai-java-core/build.gradle.kts
@@ -16,9 +16,11 @@ val jacksonPublishedRuntime by configurations.creating {
     isCanBeResolved = true
 }
 
-// Palantir is an isolated build tool with its own aligned Jackson BOM.
+// Palantir and Dokka are isolated build tools with independently aligned Jackson classpaths.
 configurations.matching {
-    it.name != jacksonPublishedRuntime.name && it.name != "palantir"
+    it.name != jacksonPublishedRuntime.name &&
+        it.name != "palantir" &&
+        !it.name.startsWith("dokka")
 }.configureEach {
     resolutionStrategy {
         // Compile and test against a lower Jackson version to ensure we're compatible with it. Note that

--- a/openai-java-core/src/test/kotlin/com/openai/core/http/LoggingHttpClientTest.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/core/http/LoggingHttpClientTest.kt
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.parallel.ResourceLock
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
+import org.slf4j.LoggerFactory
 
 @ResourceLock("stderr")
 internal class LoggingHttpClientTest {
@@ -32,6 +33,9 @@ internal class LoggingHttpClientTest {
 
     @BeforeEach
     fun beforeEach() {
+        // Initialize SLF4J before redirecting stderr so its one-time diagnostics cannot
+        // contaminate these assertions under parallel test execution.
+        LoggerFactory.getILoggerFactory()
         originalErr = System.err
         errContent = ByteArrayOutputStream()
         System.setErr(PrintStream(errContent))


### PR DESCRIPTION
## Summary

- align every Jackson module on Dokka-only Gradle configurations to 2.18.9
- keep the SDK's published Jackson dependency at 2.18.9
- keep the lower 2.14.0 Jackson compatibility test unchanged
- initialize SLF4J before the logging-test fixture captures stderr, preventing unrelated one-time diagnostics from racing with assertions

This follows merged PR #791, which upgrades the build-only Dokka plugin to 2.1.0 while preserving the existing documentation pipeline and links.

## Why

Dokka 2.1.0 declares Jackson 2.15.3. Its Gradle plugin creates Jackson-bearing GFM, HTML, Javadoc, and Jekyll plugin/runtime configurations across the root project and every subproject. In `openai-java-core`, the SDK compatibility rule also previously forced some of those build-tool configurations down to 2.14.0.

The new rule applies only to configuration names beginning with `dokka`. A full configuration scan found 110 Jackson-bearing Dokka configurations; all 110 now resolve the complete Jackson family to 2.18.9 with zero mismatches or resolution failures. SDK compile, test, runtime, and publication configurations are outside this rule.

Fresh CI runs exposed a pre-existing parallel-test race: SLF4J can emit its one-time no-provider diagnostics while `LoggingHttpClientTest` has redirected global stderr. The fixture now initializes SLF4J before redirecting stderr. This change is test-only and does not affect SDK runtime behavior or published artifacts.

This removes Dokka build-classpath paths for Dependabot alerts [58](https://github.com/openai/openai-java/security/dependabot/58), [94](https://github.com/openai/openai-java/security/dependabot/94), [96](https://github.com/openai/openai-java/security/dependabot/96), [98](https://github.com/openai/openai-java/security/dependabot/98), and [100](https://github.com/openai/openai-java/security/dependabot/100). Alerts that also observe the intentional 2.14.0 compatibility-test classpath may remain open; raising that compatibility floor would be a separate downstream-compatibility decision.

## Compatibility

- all four published Maven POMs are byte-for-byte identical to the refreshed #791 parent
- Gradle module metadata is semantically identical; only regenerated artifact checksums differ
- production and source JAR entry contents are identical
- Javadoc JAR entry lists and artifact names are identical
- the 9,691-file aggregate Javadoc tree is byte-for-byte identical
- internal Javadoc link references and targets are unchanged
- every published class remains Java 8 bytecode (class major version 52)
- Dokka and its Jackson classpath remain build-only and do not appear in published metadata
- the added SLF4J initialization is confined to a test fixture

## Validation

- all 110 Jackson-bearing Dokka configurations resolve only Jackson 2.18.9
- `./scripts/lint`
- `./scripts/build`
- `./scripts/test`
- `./scripts/detect-breaking-changes origin/codex/update-dokka`
- `./gradlew clean publish -PpublishLocal --no-configuration-cache`
- `./gradlew :openai-java-core:test --tests com.openai.core.http.LoggingHttpClientTest --rerun-tasks` on JDK 21
- aggregate Dokka Javadoc generation
- GFM, HTML, Javadoc, and Jekyll collector/multimodule classpath resolution
- before/after comparison of POMs, Gradle module metadata, production/source JAR contents, Javadoc entries, aggregate Javadocs, internal links, and class-file versions
