### PR TITLE
build(deps): migrate test WireMock to Jetty 12

### DIFF
--- a/openai-java-client-okhttp/build.gradle.kts
+++ b/openai-java-client-okhttp/build.gradle.kts
@@ -3,6 +3,27 @@ plugins {
     id("openai.publish")
 }
 
+listOf(configurations.testCompileClasspath, configurations.testRuntimeClasspath).forEach {
+    it.configure {
+        attributes.attribute(
+            org.gradle.api.attributes.java.TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE,
+            17,
+        )
+    }
+}
+
+configurations.testRuntimeClasspath.configure {
+    resolutionStrategy.eachDependency {
+        if (
+            requested.group == "com.fasterxml.jackson" ||
+                requested.group.startsWith("com.fasterxml.jackson.")
+        ) {
+            useVersion("2.18.9")
+            because("tests must exercise the SDK's secure published Jackson release")
+        }
+    }
+}
+
 dependencies {
     constraints {
         testImplementation("com.google.guava:guava:33.6.0-jre") {
@@ -31,11 +52,11 @@ dependencies {
 
     testImplementation(kotlin("test"))
     testImplementation("org.assertj:assertj-core:3.27.7")
-    testImplementation(platform("org.eclipse.jetty:jetty-bom:9.4.58.v20250814"))
-    testImplementation("com.github.tomakehurst:wiremock-jre8:2.35.2")
+    testImplementation(platform("org.eclipse.jetty:jetty-bom:12.0.33"))
+    testImplementation(platform("org.eclipse.jetty.ee10:jetty-ee10-bom:12.0.33"))
+    testImplementation("org.wiremock:wiremock-jetty12:3.13.2")
 
     constraints {
-        // Keep handlebars-helpers at 4.3.1: WireMock 2 links helper classes moved in 4.5.x.
         testImplementation("com.github.jknack:handlebars:4.5.3") {
             because("WireMock's transitive 4.3.1 dependency is affected by CVE-2026-55760")
         }

--- a/openai-java-core/build.gradle.kts
+++ b/openai-java-core/build.gradle.kts
@@ -4,21 +4,47 @@ plugins {
     id("openai.publish")
 }
 
+listOf(configurations.testCompileClasspath, configurations.testRuntimeClasspath).forEach {
+    it.configure {
+        attributes.attribute(
+            org.gradle.api.attributes.java.TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE,
+            17,
+        )
+    }
+}
+
 val jacksonCompatibilityVersion = "2.14.0"
 val jacksonPublishedVersion = "2.18.9"
 
-// Runtime classpath for `testJacksonPublished`: the same dependencies as `testRuntimeClasspath`,
-// but exempt from the compatibility-version force below so Jackson resolves to the version that
-// consumers receive by default.
-val jacksonPublishedRuntime by configurations.creating {
+// Runtime classpath for `testJacksonCompatibility`: the same dependencies as
+// `testRuntimeClasspath`, but forced to the older Jackson version that the SDK supports.
+val jacksonCompatibilityRuntime by configurations.creating {
     extendsFrom(configurations.testRuntimeClasspath.get())
     isCanBeConsumed = false
     isCanBeResolved = true
+    attributes.attribute(
+        org.gradle.api.attributes.java.TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE,
+        17,
+    )
 }
 
-// Palantir and Dokka are isolated build tools with independently aligned Jackson classpaths.
+// Keep the normal test runtime on the same secure Jackson release that consumers receive. WireMock
+// 3 requires newer Jackson APIs, so compatibility testing runs separately below.
+configurations.testRuntimeClasspath.configure {
+    resolutionStrategy.eachDependency {
+        if (
+            requested.group == "com.fasterxml.jackson" ||
+                requested.group.startsWith("com.fasterxml.jackson.")
+        ) {
+            useVersion(jacksonPublishedVersion)
+            because("tests must exercise the SDK's secure published Jackson release")
+        }
+    }
+}
+
+// Palantir, Dokka, and the normal test runtime have independently aligned Jackson classpaths.
 configurations.matching {
-    it.name != jacksonPublishedRuntime.name &&
+    it.name != configurations.testRuntimeClasspath.get().name &&
         it.name != "palantir" &&
         !it.name.startsWith("dokka")
 }.configureEach {
@@ -73,8 +99,9 @@ dependencies {
 
     testImplementation(kotlin("test"))
     testImplementation(project(":openai-java-client-okhttp"))
-    testImplementation(platform("org.eclipse.jetty:jetty-bom:9.4.58.v20250814"))
-    testImplementation("com.github.tomakehurst:wiremock-jre8:2.35.2")
+    testImplementation(platform("org.eclipse.jetty:jetty-bom:12.0.33"))
+    testImplementation(platform("org.eclipse.jetty.ee10:jetty-ee10-bom:12.0.33"))
+    testImplementation("org.wiremock:wiremock-jetty12:3.13.2")
     testImplementation("org.assertj:assertj-core:3.27.7")
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.3")
     testImplementation("org.junit.jupiter:junit-jupiter-params:5.9.3")
@@ -84,32 +111,34 @@ dependencies {
     testImplementation("org.mockito.kotlin:mockito-kotlin:4.1.0")
 
     constraints {
-        // Keep handlebars-helpers at 4.3.1: WireMock 2 links helper classes moved in 4.5.x.
         testImplementation("com.github.jknack:handlebars:4.5.3") {
             because("WireMock's transitive 4.3.1 dependency is affected by CVE-2026-55760")
         }
     }
 }
 
-// Re-run the compiled tests against the Jackson version consumers receive by default. Service tests
-// exercise HTTP plumbing and the mock server rather than Jackson compatibility, so the second pass
-// focuses on the core and model tests that cover serialization behavior.
-val testJacksonPublished by tasks.registering(Test::class) {
+// Re-run the core and model tests against the older supported Jackson version. Service and
+// WireMock-specific tests exercise HTTP plumbing and the mock server rather than Jackson
+// compatibility, and WireMock 3 requires newer Jackson APIs.
+val testJacksonCompatibility by tasks.registering(Test::class) {
     group = "verification"
-    description = "Runs tests against the published Jackson version."
+    description = "Runs core and model tests against the older supported Jackson version."
     testClassesDirs = sourceSets.test.get().output.classesDirs
-    classpath = sourceSets.test.get().output + sourceSets.main.get().output + jacksonPublishedRuntime
+    classpath =
+        sourceSets.test.get().output + sourceSets.main.get().output + jacksonCompatibilityRuntime
     shouldRunAfter(tasks.test)
     exclude("**/services/**")
+    exclude("**/RetryingHttpClientTest*")
+    exclude("**/WireMockHandlebarsCompatibilityTest*")
     systemProperty("junit.jupiter.execution.parallel.enabled", false)
-    systemProperty("expected.jackson.version", jacksonPublishedVersion)
-}
-
-tasks.test {
     systemProperty("expected.jackson.version", jacksonCompatibilityVersion)
 }
 
-tasks.check { dependsOn(testJacksonPublished) }
+tasks.test {
+    systemProperty("expected.jackson.version", jacksonPublishedVersion)
+}
+
+tasks.check { dependsOn(testJacksonCompatibility) }
 
 if (project.hasProperty("graalvmAgent")) {
     java {

--- a/openai-java-core/src/test/kotlin/com/openai/core/WireMockHandlebarsCompatibilityTest.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/core/WireMockHandlebarsCompatibilityTest.kt
@@ -5,7 +5,6 @@ import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.get
 import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
-import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemplateTransformer
 import java.net.HttpURLConnection
 import java.net.URL
 import org.assertj.core.api.Assertions.assertThat
@@ -15,10 +14,7 @@ internal class WireMockHandlebarsCompatibilityTest {
 
     @Test
     fun rendersResponseTemplate() {
-        val server =
-            WireMockServer(
-                wireMockConfig().dynamicPort().extensions(ResponseTemplateTransformer(false))
-            )
+        val server = WireMockServer(wireMockConfig().dynamicPort())
         server.start()
 
         try {


### PR DESCRIPTION
## Summary

- migrate the test-only mock server from `wiremock-jre8` 2.35.2 / Jetty 9.4 to `wiremock-jetty12` 3.13.2
- align Jetty core and EE10 modules on 12.0.33, addressing Dependabot alerts [#67](https://github.com/openai/openai-java/security/dependabot/67) and [#32](https://github.com/openai/openai-java/security/dependabot/32)
- scope the Java 17 requirement to resolvable test classpaths; published SDK variants remain Java 8
- run the normal test suites on the secure published Jackson 2.18.9 release while retaining a separate Jackson 2.14 compatibility pass for core and model behavior
- update the Handlebars response-templating compatibility test for WireMock 3's built-in transformer

## Why

WireMock 2 pins the end-of-life Jetty 9.4 line. There is no patched Jetty 9.4 release for the request-smuggling advisory, so clearing the remaining Jetty alerts requires moving the test server to WireMock's Jetty 12 integration. WireMock 3 also requires Java 17 and newer Jackson APIs, which previously conflicted with the repository's Java 8 publication target and Jackson 2.14 compatibility runtime.

## Impact

This changes test and build configuration only. It does not change published dependencies or public APIs, and the produced SDK JARs still use Java 8 bytecode.

## Validation

- `./scripts/lint`
- `./scripts/build --no-daemon --console plain`
- `./scripts/test --no-daemon --console plain` with the real local OpenAPI mock server
- forced no-cache `:openai-java-client-okhttp:test`
- WireMock-specific tests plus the complete `testJacksonCompatibility` pass
- dependency insight confirms Jetty 12.0.33 across core, EE10, HTTP/2, and servlet modules
- dependency insight confirms normal tests use Jackson 2.18.9 and compatibility tests use Jackson 2.14.0
- verified the core JAR remains Java 8 bytecode (`major version 52`)