### PR TITLE
Align WireMock Jackson test classpaths

### DIFF
--- a/openai-java-client-okhttp/build.gradle.kts
+++ b/openai-java-client-okhttp/build.gradle.kts
@@ -9,17 +9,14 @@ listOf(configurations.testCompileClasspath, configurations.testRuntimeClasspath)
             org.gradle.api.attributes.java.TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE,
             17,
         )
-    }
-}
-
-configurations.testRuntimeClasspath.configure {
-    resolutionStrategy.eachDependency {
-        if (
-            requested.group == "com.fasterxml.jackson" ||
-                requested.group.startsWith("com.fasterxml.jackson.")
-        ) {
-            useVersion("2.18.9")
-            because("tests must exercise the SDK's secure published Jackson release")
+        resolutionStrategy.eachDependency {
+            if (
+                requested.group == "com.fasterxml.jackson" ||
+                    requested.group.startsWith("com.fasterxml.jackson.")
+            ) {
+                useVersion("2.18.9")
+                because("test classpaths must use the SDK's secure published Jackson release")
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

- apply the existing secure Jackson `2.18.9` resolution rule to both `testCompileClasspath` and `testRuntimeClasspath`
- keep WireMock `3.13.2` usable while preventing its Jackson `2.20.1` BOM from selecting versions covered by Dependabot alerts 59, 95, 97, 99, and 101
- preserve published dependency metadata and the SDK's older-Jackson compatibility lane

## Root cause

The OkHttp module already constrained Jackson on the test runtime classpath, but its test compile classpath still accepted WireMock's Jackson `2.20.1` BOM. GitHub therefore recorded vulnerable `jackson-core` and `jackson-databind` versions even though the runtime test graph was secure.

## Impact

This changes only test dependency resolution. Generated Maven POM and Gradle module metadata remain free of WireMock and test-only Jackson dependencies.

## Validation

- `:openai-java-client-okhttp:dependencyInsight` for `jackson` on both test classpaths: all Jackson modules resolve to `2.18.9`
- `:openai-java-client-okhttp:test --rerun-tasks`
- `:openai-java-core:testJacksonCompatibility --rerun-tasks`
- generated Maven POM and Gradle module metadata inspection
- `./scripts/lint`
- `./scripts/build --rerun-tasks`
- `./scripts/test --rerun-tasks` with the repository OpenAPI mock server, including ProGuard and R8 checks
