### PR TITLE
fix: add diarized JSON transcription response handling

### DIFF
--- a/openai-java-core/src/main/kotlin/com/openai/models/audio/AudioResponseFormat.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/models/audio/AudioResponseFormat.kt
@@ -166,6 +166,7 @@ class AudioResponseFormat @JsonCreator private constructor(private val value: Js
             SRT -> false
             VERBOSE_JSON -> true
             VTT -> false
+            DIARIZED_JSON -> true
             else -> false
         }
 


### PR DESCRIPTION
## Summary

Treat `diarized_json` as a JSON response format when creating audio transcriptions.

`AudioResponseFormat.DIARIZED_JSON` was missing from `isJson()`, causing both blocking and async transcription clients to select the string response handler. Consequently, a diarized JSON response was wrapped as `Transcription.text` instead of being deserialized as `TranscriptionCreateResponse.diarized`.

This change makes `diarized_json` use the existing JSON handler, consistently with `json` and `verbose_json`.

## Testing

- `./scripts/test`

Fixes #800