### PR TITLE
fix(core): ignore metadata-only SSE blocks

### DIFF
--- a/openai-java-core/src/main/kotlin/com/openai/core/handlers/SseHandler.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/core/handlers/SseHandler.kt
@@ -39,7 +39,7 @@ internal fun sseHandler(jsonMapper: JsonMapper): Handler<StreamResponse<SseMessa
 
             val jsonNode =
                 try {
-                    message.json<JsonNode>()
+                    message.json<JsonNode?>() ?: jsonMapper.createObjectNode()
                 } catch (e: Exception) {
                     jsonMapper.createObjectNode()
                 }
@@ -110,18 +110,20 @@ private class SseState(
     }
 
     private fun flush(): SseMessage? {
-        if (isEmpty()) {
-            return null
-        }
-
+        // Per the SSE spec, metadata-only blocks do not dispatch an event. Check the collection
+        // rather than the joined data because an explicitly empty `data:` field is still an event.
         val message =
-            SseMessage.builder()
-                .jsonMapper(jsonMapper)
-                .event(event)
-                .data(data.joinToString("\n"))
-                .id(lastId)
-                .retry(retry)
-                .build()
+            if (data.isEmpty()) {
+                null
+            } else {
+                SseMessage.builder()
+                    .jsonMapper(jsonMapper)
+                    .event(event)
+                    .data(data.joinToString("\n"))
+                    .id(lastId)
+                    .retry(retry)
+                    .build()
+            }
 
         // NOTE: Per the SSE spec, do not reset lastId.
         event = null
@@ -130,9 +132,6 @@ private class SseState(
 
         return message
     }
-
-    private fun isEmpty(): Boolean =
-        event.isNullOrEmpty() && data.isEmpty() && lastId.isNullOrEmpty() && retry == null
 }
 
 @JvmSynthetic

--- a/openai-java-core/src/main/kotlin/com/openai/core/handlers/SseHandler.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/core/handlers/SseHandler.kt
@@ -113,7 +113,8 @@ private class SseState(
         // Per the SSE spec, metadata-only blocks do not dispatch an event. Check the collection
         // rather than the joined data because an explicitly empty `data:` field is still an event.
         if (data.isEmpty()) {
-            // The event type buffer is reset only after a data-bearing event is dispatched.
+            // The dispatch algorithm clears the event type buffer even when no event is emitted.
+            event = null
             retry = null
             return null
         }

--- a/openai-java-core/src/main/kotlin/com/openai/core/handlers/SseHandler.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/core/handlers/SseHandler.kt
@@ -112,18 +112,20 @@ private class SseState(
     private fun flush(): SseMessage? {
         // Per the SSE spec, metadata-only blocks do not dispatch an event. Check the collection
         // rather than the joined data because an explicitly empty `data:` field is still an event.
+        if (data.isEmpty()) {
+            // The event type buffer is reset only after a data-bearing event is dispatched.
+            retry = null
+            return null
+        }
+
         val message =
-            if (data.isEmpty()) {
-                null
-            } else {
-                SseMessage.builder()
-                    .jsonMapper(jsonMapper)
-                    .event(event)
-                    .data(data.joinToString("\n"))
-                    .id(lastId)
-                    .retry(retry)
-                    .build()
-            }
+            SseMessage.builder()
+                .jsonMapper(jsonMapper)
+                .event(event)
+                .data(data.joinToString("\n"))
+                .id(lastId)
+                .retry(retry)
+                .build()
 
         // NOTE: Per the SSE spec, do not reset lastId.
         event = null

--- a/openai-java-core/src/test/kotlin/com/openai/core/handlers/SseHandlerTest.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/core/handlers/SseHandlerTest.kt
@@ -53,7 +53,7 @@ internal class SseHandlerTest {
         ),
         EVENT_MISSING_DATA(
             buildString {
-                append("event: retained\n")
+                append("event: ignored\n")
                 append("\n")
                 append("data: {\"foo\":true}\n")
                 append("\n")
@@ -61,7 +61,7 @@ internal class SseHandlerTest {
                 append("\n")
             },
             listOf(
-                sseMessageBuilder().event("retained").data("{\"foo\":true}").build(),
+                sseMessageBuilder().data("{\"foo\":true}").build(),
                 sseMessageBuilder().data("{\"bar\":false}").build(),
             ),
         ),

--- a/openai-java-core/src/test/kotlin/com/openai/core/handlers/SseHandlerTest.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/core/handlers/SseHandlerTest.kt
@@ -53,12 +53,17 @@ internal class SseHandlerTest {
         ),
         EVENT_MISSING_DATA(
             buildString {
-                append("event: ignored\n")
+                append("event: retained\n")
                 append("\n")
                 append("data: {\"foo\":true}\n")
                 append("\n")
+                append("data: {\"bar\":false}\n")
+                append("\n")
             },
-            listOf(sseMessageBuilder().data("{\"foo\":true}").build()),
+            listOf(
+                sseMessageBuilder().event("retained").data("{\"foo\":true}").build(),
+                sseMessageBuilder().data("{\"bar\":false}").build(),
+            ),
         ),
         ID_MISSING_DATA(
             buildString {

--- a/openai-java-core/src/test/kotlin/com/openai/core/handlers/SseHandlerTest.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/core/handlers/SseHandlerTest.kt
@@ -42,6 +42,40 @@ internal class SseHandlerTest {
                 sseMessageBuilder().data("{\"bar\":false}").build(),
             ),
         ),
+        RETRY_MISSING_DATA(
+            buildString {
+                append("retry: 10000\n")
+                append("\n")
+                append("data: {\"foo\":true}\n")
+                append("\n")
+            },
+            listOf(sseMessageBuilder().data("{\"foo\":true}").build()),
+        ),
+        EVENT_MISSING_DATA(
+            buildString {
+                append("event: ignored\n")
+                append("\n")
+                append("data: {\"foo\":true}\n")
+                append("\n")
+            },
+            listOf(sseMessageBuilder().data("{\"foo\":true}").build()),
+        ),
+        ID_MISSING_DATA(
+            buildString {
+                append("id: 1\n")
+                append("\n")
+                append("data: {\"foo\":true}\n")
+                append("\n")
+            },
+            listOf(sseMessageBuilder().data("{\"foo\":true}").id("1").build()),
+        ),
+        EMPTY_DATA(
+            buildString {
+                append("data:\n")
+                append("\n")
+            },
+            listOf(sseMessageBuilder().data("").build()),
+        ),
         DATA_JSON_ESCAPED_DOUBLE_NEW_LINE(
             buildString {
                 append("data: {\n")


### PR DESCRIPTION
## Summary

- ignore SSE blocks that contain only control metadata and no `data` field
- preserve `id` state for subsequent data events while resetting per-block `event` and `retry` metadata
- keep explicitly empty `data:` events distinct from metadata-only blocks
- make SSE error inspection null-safe for empty payloads

## Root cause

`SseState.flush()` treated `event`, `id`, and `retry` state as sufficient to emit an `SseMessage`. A metadata-only block therefore produced a message with empty data. Jackson returned `null` for that payload, and the handler dereferenced it while checking for an `error` property.

## Impact

OpenAI-compatible servers can send valid SSE control blocks such as `retry: 10000`. The client now ignores those non-events and continues consuming subsequent streamed data.

## Validation

- `./gradlew :openai-java-core:test --tests com.openai.core.handlers.SseHandlerTest`
- `./gradlew :openai-java-core:testJacksonCompatibility --tests com.openai.core.handlers.SseHandlerTest`
- `./gradlew :openai-java-core:lint`

Fixes #804