### PR TITLE
build(deps): patch test-only Logback dependencies

### DIFF
--- a/openai-java-spring-boot-starter/build.gradle.kts
+++ b/openai-java-spring-boot-starter/build.gradle.kts
@@ -9,9 +9,6 @@ repositories {
 
 dependencies {
     constraints {
-        implementation("org.springframework:spring-expression:5.3.39") {
-            because("5.3.39 fixes CVE-2024-38808 in Spring Boot's transitive runtime")
-        }
         testImplementation("org.xmlunit:xmlunit-core:2.11.0") {
             because("2.10.0 fixes CVE-2024-31573 in this test-only dependency")
         }

--- a/openai-java-spring-boot-starter/build.gradle.kts
+++ b/openai-java-spring-boot-starter/build.gradle.kts
@@ -9,6 +9,9 @@ repositories {
 
 dependencies {
     constraints {
+        implementation("org.springframework:spring-expression:5.3.39") {
+            because("5.3.39 fixes CVE-2024-38808 in Spring Boot's transitive runtime")
+        }
         testImplementation("org.xmlunit:xmlunit-core:2.11.0") {
             because("2.10.0 fixes CVE-2024-31573 in this test-only dependency")
         }
@@ -18,6 +21,12 @@ dependencies {
         testImplementation("org.slf4j:slf4j-api") {
             version { strictly("1.7.36") }
             because("Spring Boot 2.7 and Logback 1.2 require SLF4J 1.7 at test runtime")
+        }
+        testImplementation("ch.qos.logback:logback-classic:1.2.13") {
+            because("1.2.13 fixes vulnerabilities in Spring Boot's test logging stack")
+        }
+        testImplementation("ch.qos.logback:logback-core:1.2.13") {
+            because("1.2.13 fixes vulnerabilities in Spring Boot's test logging stack")
         }
     }
 


### PR DESCRIPTION
## Summary

- constrain the Spring Boot starter's test-only Logback classic/core dependencies to 1.2.13
- keep the starter on Spring Boot 2.7, SLF4J 1.7, and the existing Java 8 runtime target

This addresses Dependabot alerts [#21](https://github.com/openai/openai-java/security/dependabot/21), [#22](https://github.com/openai/openai-java/security/dependabot/22), and [#23](https://github.com/openai/openai-java/security/dependabot/23).

## Why

Spring Boot 2.7.18 resolves Logback 1.2.12, which is affected by CVE-2023-6378 and CVE-2023-6481.

The newer Logback 1.3/1.5 fixes are intentionally out of scope because they require the SLF4J 2 and Java 11 ecosystem. Logback 1.2.13 is the narrow patch compatible with Spring Boot 2.7 and SLF4J 1.7.

Spring Expression alert #29 was removed from this PR after review showed that a library-side constraint cannot reliably override an application's own Spring Boot 2.7 dependency-management rules for both Maven and Gradle consumers. It should be handled separately as part of a broader Spring Boot upgrade or an explicit consumer-level override.

## Compatibility

- Logback remains test-only and does not appear in Maven or Gradle publication metadata.
- No source, binary API, runtime dependency, or artifact dependency scope changes.
- Real Spring Boot startup and auto-configuration tests pass with Logback 1.2.13.

## Validation

- dependency insight for Logback classic/core on test compile/runtime classpaths
- generated Maven POM and Gradle module metadata inspection
- focused Spring Boot starter tests
- `./scripts/lint`
- `./scripts/build --rerun-tasks`
- `./scripts/test --rerun-tasks`
- older-Jackson compatibility suite
- ProGuard and R8 tests
