### PR TITLE
build(deps): patch test Jackson dependencies

### DIFF
--- a/openai-java-client-okhttp/build.gradle.kts
+++ b/openai-java-client-okhttp/build.gradle.kts
@@ -49,6 +49,7 @@ dependencies {
 
     testImplementation(kotlin("test"))
     testImplementation("org.assertj:assertj-core:3.27.7")
+    testImplementation(platform("com.fasterxml.jackson:jackson-bom:2.21.5"))
     testImplementation(platform("org.eclipse.jetty:jetty-bom:12.0.33"))
     testImplementation(platform("org.eclipse.jetty.ee10:jetty-ee10-bom:12.0.33"))
     testImplementation("org.wiremock:wiremock-jetty12:3.13.2")

--- a/openai-java-core/build.gradle.kts
+++ b/openai-java-core/build.gradle.kts
@@ -99,6 +99,7 @@ dependencies {
 
     testImplementation(kotlin("test"))
     testImplementation(project(":openai-java-client-okhttp"))
+    testImplementation(platform("com.fasterxml.jackson:jackson-bom:2.21.5"))
     testImplementation(platform("org.eclipse.jetty:jetty-bom:12.0.33"))
     testImplementation(platform("org.eclipse.jetty.ee10:jetty-ee10-bom:12.0.33"))
     testImplementation("org.wiremock:wiremock-jetty12:3.13.2")


### PR DESCRIPTION
## Summary

- align the WireMock test dependency graph on Jackson BOM 2.21.5 in the core and OkHttp client modules
- remove Jackson 2.20.1 from every resolvable Gradle configuration
- preserve the SDK's published Jackson 2.18.9 runtime and intentional Jackson 2.14.0 compatibility test floor

This targets Dependabot alerts [#59](https://github.com/openai/openai-java/security/dependabot/59), [#95](https://github.com/openai/openai-java/security/dependabot/95), [#97](https://github.com/openai/openai-java/security/dependabot/97), [#99](https://github.com/openai/openai-java/security/dependabot/99), and [#101](https://github.com/openai/openai-java/security/dependabot/101).

## Why

WireMock 3.13.2 imports Jackson BOM 2.20.1. That version is present only in test dependency metadata and the isolated compatibility harness, but it is affected by the recent Jackson Core and Databind advisories on the 2.19+ line. Importing the fixed 2.21.5 BOM at `testImplementation` is the narrowest update that removes that vulnerable line without raising any consumer-facing or compatibility baseline.

## Compatibility

- test dependency metadata resolves Jackson Core and Databind 2.21.5
- normal SDK tests still resolve the published Jackson 2.18.9 release
- the older-Jackson compatibility suite still resolves Jackson 2.14.0
- generated Maven POMs and Gradle module metadata contain neither Jackson 2.21.5 nor the test BOM
- no source, binary API, runtime dependency, or published dependency scope changes

## Validation

- exhaustive scan of every resolvable Gradle configuration: no Jackson 2.20.1 remains
- dependency insight for test metadata, normal test runtime, and compatibility runtime
- Maven POM and Gradle module metadata inspection
- `./scripts/test --rerun-tasks`
- `./scripts/lint`
- `./scripts/build --rerun-tasks`
- ProGuard and R8 tests