### PR TITLE
tests: serialize conversation item service tests

### DIFF
--- a/openai-java-core/src/test/kotlin/com/openai/ConversationItemTestLockExtension.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/ConversationItemTestLockExtension.kt
@@ -1,0 +1,55 @@
+package com.openai
+
+import java.nio.channels.FileChannel
+import java.nio.channels.FileLock
+import java.nio.file.Paths
+import java.nio.file.StandardOpenOption.CREATE
+import java.nio.file.StandardOpenOption.WRITE
+import org.junit.jupiter.api.extension.BeforeAllCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+
+/**
+ * Serializes conversation item tests across Gradle worker JVMs that share the Steady mock server.
+ *
+ * The JUnit resource lock on the test classes covers concurrency within each worker JVM; this file
+ * lock covers concurrency between workers.
+ */
+internal class ConversationItemTestLockExtension : BeforeAllCallback {
+
+    override fun beforeAll(context: ExtensionContext) {
+        val channel = FileChannel.open(LOCK_FILE, CREATE, WRITE)
+        val lock =
+            try {
+                channel.lock()
+            } catch (throwable: Throwable) {
+                channel.close()
+                throw throwable
+            }
+
+        context.getStore(NAMESPACE).put(LOCK_KEY, LockResource(channel, lock))
+    }
+
+    private class LockResource(private val channel: FileChannel, private val lock: FileLock) :
+        ExtensionContext.Store.CloseableResource {
+
+        override fun close() {
+            try {
+                lock.release()
+            } finally {
+                channel.close()
+            }
+        }
+    }
+
+    companion object {
+
+        private val LOCK_FILE =
+            Paths.get(
+                System.getProperty("java.io.tmpdir"),
+                "openai-java-conversation-item-tests.lock",
+            )
+        private val NAMESPACE =
+            ExtensionContext.Namespace.create(ConversationItemTestLockExtension::class.java)
+        private const val LOCK_KEY = "conversation-item-tests"
+    }
+}

--- a/openai-java-core/src/test/kotlin/com/openai/services/async/conversations/ItemServiceAsyncTest.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/services/async/conversations/ItemServiceAsyncTest.kt
@@ -2,6 +2,7 @@
 
 package com.openai.services.async.conversations
 
+import com.openai.ConversationItemTestLockExtension
 import com.openai.TestServerExtension
 import com.openai.client.okhttp.OpenAIOkHttpClientAsync
 import com.openai.models.conversations.items.ItemCreateParams
@@ -13,7 +14,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.parallel.ResourceLock
 
-@ExtendWith(TestServerExtension::class)
+@ExtendWith(TestServerExtension::class, ConversationItemTestLockExtension::class)
 @ResourceLock("conversation-item-response-deserialization")
 internal class ItemServiceAsyncTest {
 

--- a/openai-java-core/src/test/kotlin/com/openai/services/async/conversations/ItemServiceAsyncTest.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/services/async/conversations/ItemServiceAsyncTest.kt
@@ -11,8 +11,10 @@ import com.openai.models.responses.EasyInputMessage
 import com.openai.models.responses.ResponseIncludable
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.parallel.ResourceLock
 
 @ExtendWith(TestServerExtension::class)
+@ResourceLock("conversation-item-response-deserialization")
 internal class ItemServiceAsyncTest {
 
     @Test

--- a/openai-java-core/src/test/kotlin/com/openai/services/blocking/conversations/ItemServiceTest.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/services/blocking/conversations/ItemServiceTest.kt
@@ -2,6 +2,7 @@
 
 package com.openai.services.blocking.conversations
 
+import com.openai.ConversationItemTestLockExtension
 import com.openai.TestServerExtension
 import com.openai.client.okhttp.OpenAIOkHttpClient
 import com.openai.models.conversations.items.ItemCreateParams
@@ -13,7 +14,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.parallel.ResourceLock
 
-@ExtendWith(TestServerExtension::class)
+@ExtendWith(TestServerExtension::class, ConversationItemTestLockExtension::class)
 @ResourceLock("conversation-item-response-deserialization")
 internal class ItemServiceTest {
 

--- a/openai-java-core/src/test/kotlin/com/openai/services/blocking/conversations/ItemServiceTest.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/services/blocking/conversations/ItemServiceTest.kt
@@ -11,8 +11,10 @@ import com.openai.models.responses.EasyInputMessage
 import com.openai.models.responses.ResponseIncludable
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.parallel.ResourceLock
 
 @ExtendWith(TestServerExtension::class)
+@ResourceLock("conversation-item-response-deserialization")
 internal class ItemServiceTest {
 
     @Test


### PR DESCRIPTION
## Summary

- serialize the blocking and async conversation-item service tests within each JUnit worker
- coordinate those tests across Gradle worker JVMs with an OS-backed file lock
- keep the mock implementation and CI workflows unchanged

## Root cause

Steady-generated conversation-item responses can be invalid for the SDK union discriminator/model validation when the blocking and async fixture tests access the shared mock server concurrently. JUnit resource locks cover concurrency inside one worker JVM; the file lock covers separate Gradle worker JVMs.

## Validation

- 20/20 cache-disabled focused repetitions with four Gradle workers
- `./scripts/lint`
- `./scripts/test --no-build-cache --max-workers=4`