### PR TITLE
test: configure Mockito as Java agent

### DIFF
--- a/buildSrc/src/main/kotlin/openai.java.gradle.kts
+++ b/buildSrc/src/main/kotlin/openai.java.gradle.kts
@@ -34,10 +34,6 @@ tasks.named<Jar>("jar") {
 tasks.withType<Test>().configureEach {
     useJUnitPlatform()
 
-    // Mockito/Byte Buddy can attach a test-time Java agent. Keep JVM warnings about that out of
-    // stderr so output-sensitive tests can assert application logs exactly.
-    jvmArgs("-XX:+EnableDynamicAgentLoading")
-
     // Run tests in parallel to some degree.
     maxParallelForks = (Runtime.getRuntime().availableProcessors() / 2).coerceAtLeast(1)
     forkEvery = 100

--- a/openai-java-core/build.gradle.kts
+++ b/openai-java-core/build.gradle.kts
@@ -1,3 +1,14 @@
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.tasks.Classpath
+import org.gradle.process.CommandLineArgumentProvider
+
+abstract class JavaAgentArgumentProvider : CommandLineArgumentProvider {
+    @get:Classpath abstract val classpath: ConfigurableFileCollection
+
+    override fun asArguments(): Iterable<String> =
+        listOf("-javaagent:${classpath.singleFile.absolutePath}")
+}
+
 plugins {
     id("java")
     id("openai.kotlin")
@@ -8,7 +19,10 @@ plugins {
 val jacksonCompatibilityVersion = "2.14.0"
 val jacksonPublishedVersion = "2.18.9"
 val mockitoVersion = "5.14.2"
-val mockitoAgent by configurations.creating
+val mockitoAgent by configurations.creating {
+    isCanBeConsumed = false
+    isCanBeResolved = true
+}
 
 // Runtime classpath for `testJacksonCompatibility`: the same dependencies as
 // `testRuntimeClasspath`, but forced to the older Jackson version that the SDK supports.
@@ -101,7 +115,11 @@ val testJacksonCompatibility by tasks.registering(Test::class) {
 }
 
 tasks.withType<Test>().configureEach {
-    jvmArgs("-javaagent:${mockitoAgent.asPath}")
+    jvmArgumentProviders.add(
+        objects.newInstance<JavaAgentArgumentProvider>().apply {
+            classpath.from(mockitoAgent)
+        }
+    )
 }
 
 tasks.test {

--- a/openai-java-core/build.gradle.kts
+++ b/openai-java-core/build.gradle.kts
@@ -7,6 +7,8 @@ plugins {
 
 val jacksonCompatibilityVersion = "2.14.0"
 val jacksonPublishedVersion = "2.18.9"
+val mockitoVersion = "5.14.2"
+val mockitoAgent by configurations.creating
 
 // Runtime classpath for `testJacksonCompatibility`: the same dependencies as
 // `testRuntimeClasspath`, but forced to the older Jackson version that the SDK supports.
@@ -75,9 +77,10 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.3")
     testImplementation("org.junit.jupiter:junit-jupiter-params:5.9.3")
     testImplementation("org.junit-pioneer:junit-pioneer:1.9.1")
-    testImplementation("org.mockito:mockito-core:5.14.2")
-    testImplementation("org.mockito:mockito-junit-jupiter:5.14.2")
+    testImplementation("org.mockito:mockito-core:$mockitoVersion")
+    testImplementation("org.mockito:mockito-junit-jupiter:$mockitoVersion")
     testImplementation("org.mockito.kotlin:mockito-kotlin:4.1.0")
+    mockitoAgent("org.mockito:mockito-core:$mockitoVersion") { isTransitive = false }
 }
 
 // Re-run the core and model tests against the older supported Jackson version. Service and
@@ -95,6 +98,10 @@ val testJacksonCompatibility by tasks.registering(Test::class) {
     exclude("**/WireMockHandlebarsCompatibilityTest*")
     systemProperty("junit.jupiter.execution.parallel.enabled", false)
     systemProperty("expected.jackson.version", jacksonCompatibilityVersion)
+}
+
+tasks.withType<Test>().configureEach {
+    jvmArgs("-javaagent:${mockitoAgent.asPath}")
 }
 
 tasks.test {


### PR DESCRIPTION
## Summary

- configure Mockito Core as an explicit Java agent for core-module test JVMs
- remove the global dynamic-agent-loading suppression flag
- keep the existing pre-capture SLF4J initialization in `LoggingHttpClientTest`

## Root cause

`LoggingHttpClientTest` redirects process-wide stderr while tests run in parallel. On a cold JDK 21 test JVM, the first Mockito use self-attached Byte Buddy and emitted a diagnostic that could be captured as part of the HTTP log assertion. The old `-XX:+EnableDynamicAgentLoading` flag hid the JVM warning, but not Mockito's self-attachment notice, and does not follow Mockito's documented Java 21 setup.

This uses Mockito's recommended `-javaagent` configuration with the existing pinned Mockito version. The agent configuration is non-transitive and test-only, so it does not affect the SDK's published dependencies or runtime behavior.

## Reproduction

With both existing mitigations temporarily removed and `SKIP_MOCK_TESTS=true`, a cold core-suite run executed 6,268 tests and produced one failure:

`LoggingHttpClientTest.debugLevel_logsRequestBody`

Its captured stderr was prefixed by the one-time SLF4J provider diagnostics and Mockito self-attachment warning before the expected HTTP log.

## Validation

- 10/10 fresh focused `LoggingHttpClientTest` runs passed
- core suite: 6,268 tests, 0 failures/errors, 591 expected skips
- Jackson compatibility suite: 5,629 tests, 0 failures/errors
- repository-wide offline `test`: passed
- post-rebase JDK 21 core + compatibility validation: passed
- verified test workers contain `-javaagent:...mockito-core-5.14.2.jar` and no `-XX:+EnableDynamicAgentLoading`

No CI workflow changes are included.
