### PR TITLE
tests: serialize shared mock server access

### DIFF
--- a/openai-java-core/src/test/kotlin/com/openai/TestServerExtension.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/TestServerExtension.kt
@@ -1,13 +1,23 @@
 package com.openai
 
 import java.lang.RuntimeException
+import java.lang.reflect.Method
 import java.net.URL
+import java.nio.channels.FileChannel
+import java.nio.file.Paths
+import java.nio.file.StandardOpenOption.CREATE
+import java.nio.file.StandardOpenOption.WRITE
+import java.util.UUID
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
 import org.junit.jupiter.api.extension.BeforeAllCallback
 import org.junit.jupiter.api.extension.ConditionEvaluationResult
 import org.junit.jupiter.api.extension.ExecutionCondition
 import org.junit.jupiter.api.extension.ExtensionContext
+import org.junit.jupiter.api.extension.InvocationInterceptor
+import org.junit.jupiter.api.extension.ReflectiveInvocationContext
 
-class TestServerExtension : BeforeAllCallback, ExecutionCondition {
+class TestServerExtension : BeforeAllCallback, ExecutionCondition, InvocationInterceptor {
 
     override fun beforeAll(context: ExtensionContext?) {
         try {
@@ -40,10 +50,31 @@ class TestServerExtension : BeforeAllCallback, ExecutionCondition {
         }
     }
 
+    override fun interceptTestMethod(
+        invocation: InvocationInterceptor.Invocation<Void>,
+        invocationContext: ReflectiveInvocationContext<Method>,
+        extensionContext: ExtensionContext,
+    ) {
+        PROCESS_LOCK.withLock {
+            FileChannel.open(LOCK_FILE, CREATE, WRITE).use { channel ->
+                channel.lock().use { invocation.proceed() }
+            }
+        }
+    }
+
     companion object {
 
         val BASE_URL = System.getenv("TEST_API_BASE_URL") ?: "http://localhost:4010"
 
         const val SKIP_TESTS_ENV: String = "SKIP_MOCK_TESTS"
+
+        // JUnit resource locks do not coordinate separate Gradle test-worker JVMs. Use both a
+        // process-local lock and an OS file lock so tests sharing one mock server cannot race.
+        private val PROCESS_LOCK = ReentrantLock(true)
+        private val LOCK_FILE =
+            Paths.get(
+                System.getProperty("java.io.tmpdir"),
+                "openai-java-test-server-${UUID.nameUUIDFromBytes(BASE_URL.toByteArray())}.lock",
+            )
     }
 }


### PR DESCRIPTION
## Summary

- Serialize every test using the shared Steady mock server across JUnit threads and Gradle worker JVMs.
- Add a process-local lock plus a URL-scoped OS file lock in `TestServerExtension`.
- Keep the fix entirely in the test harness; no CI workflow changes.
- Generalize and supersede the conversation-item-only approach in #813.

## Root cause

The generated `output_text` payload is valid Steady data. Seed 1 makes the failure reproducible under concurrent blocking/async service classes, but the isolated async test and high-volume in-process deserialization both pass. The failure occurs when separate Gradle workers access the persistent mock concurrently, so a JUnit-only resource lock cannot fully coordinate it. This is the same underlying race topology as the conversation-item flake covered by #813.

## Validation

- Reproduced the response service pair failure before the fix (immediate at seed 1).
- Response blocking/async pair: 30/30 post-fix passes.
- Conversation-item blocking/async pair: 30/30 post-fix passes.
- `:openai-java-core:lintKotlin` passes.
- Full JDK 21 core suite passes: 6,268 tests, 0 failures, 20 skipped.
- Full Jackson compatibility suite passes: 5,629 tests, 0 failures.