### PR TITLE
build(deps): patch consumer-neutral dependencies

### DIFF
--- a/buildSrc/src/main/kotlin/openai.wiremock-test.gradle.kts
+++ b/buildSrc/src/main/kotlin/openai.wiremock-test.gradle.kts
@@ -37,7 +37,7 @@ dependencies {
         }
     }
 
-    testImplementation(platform("org.eclipse.jetty:jetty-bom:12.0.33"))
-    testImplementation(platform("org.eclipse.jetty.ee10:jetty-ee10-bom:12.0.33"))
+    testImplementation(platform("org.eclipse.jetty:jetty-bom:12.0.36"))
+    testImplementation(platform("org.eclipse.jetty.ee10:jetty-ee10-bom:12.0.36"))
     testImplementation("org.wiremock:wiremock-jetty12:3.13.2")
 }

--- a/openai-java-bedrock/build.gradle.kts
+++ b/openai-java-bedrock/build.gradle.kts
@@ -36,6 +36,8 @@ dependencies {
     runtimeOnly("software.amazon.awssdk:url-connection-client")
 
     testImplementation(kotlin("test"))
+    // Keep WireMock's transitive Jackson runtime aligned on a secure release.
+    testImplementation(platform("com.fasterxml.jackson:jackson-bom:2.21.5"))
     testImplementation("org.assertj:assertj-core:3.27.7")
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.3")
     testImplementation("org.junit-pioneer:junit-pioneer:1.9.1")

--- a/openai-java-example/build.gradle.kts
+++ b/openai-java-example/build.gradle.kts
@@ -10,6 +10,8 @@ repositories {
 dependencies {
     implementation(project(":openai-java"))
     implementation(project(":openai-java-bedrock"))
+    // Keep Azure Identity's Netty runtime aligned on a secure release.
+    implementation(platform("io.netty:netty-bom:4.1.136.Final"))
     implementation("com.azure:azure-identity:1.18.4")
 }
 


### PR DESCRIPTION
## Summary

- align the example module's Azure Identity Netty runtime on `4.1.136.Final`
- align WireMock's shared test-only Jetty runtime on `12.0.36`
- align Bedrock's WireMock test runtime on Jackson `2.21.5`

## Why

Azure Identity and WireMock transitively request older patch releases covered by 21 Dependabot alerts. The direct dependencies do not yet select the fixed versions, so this adds narrow BOM alignments at the modules that own those dependency graphs.

Core and OkHttp deliberately continue testing against the SDK's published Jackson `2.18.9` baseline. The Jackson `2.21.5` alignment is scoped to Bedrock, which has no compatibility override and was otherwise resolving WireMock's `2.20.1` BOM.

## Impact

There is no published SDK API or consumer migration impact. The Netty alignment applies only to the unpublished example module, while the Jetty and Jackson alignments apply only to test configurations.

## Validation

- confirmed Netty resolves to `4.1.136.Final`
- confirmed Jetty resolves to `12.0.36`
- confirmed Bedrock resolves Jackson to `2.21.5`
- confirmed core and OkHttp intentionally retain Jackson `2.18.9` compatibility runtimes
- `:openai-java-bedrock:test`
- `:openai-java-example:classes`
- `./scripts/lint`
- `git diff --check`
- thermo-nuclear code-quality review: no blockers