### PR TITLE
fix(http): use locale-independent header name comparator

### DIFF
--- a/openai-java-core/src/main/kotlin/com/openai/core/http/Headers.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/core/http/Headers.kt
@@ -11,6 +11,7 @@ import com.openai.core.JsonObject
 import com.openai.core.JsonString
 import com.openai.core.JsonValue
 import com.openai.core.toImmutable
+import java.util.Locale
 import java.util.TreeMap
 
 class Headers
@@ -29,13 +30,19 @@ private constructor(
 
     companion object {
 
+        // HTTP header names are case-insensitive using ASCII/ROOT rules (not the default locale).
+        // String.CASE_INSENSITIVE_ORDER is insufficient for locales like Turkish (I/ı).
+        private val HEADER_NAME_COMPARATOR: Comparator<String> = Comparator { a, b ->
+            a.lowercase(Locale.ROOT).compareTo(b.lowercase(Locale.ROOT))
+        }
+
         @JvmStatic fun builder() = Builder()
     }
 
     class Builder internal constructor() {
 
         private val map: MutableMap<String, MutableList<String>> =
-            TreeMap(String.CASE_INSENSITIVE_ORDER)
+            TreeMap(HEADER_NAME_COMPARATOR)
         private var size: Int = 0
 
         fun put(name: String, value: JsonValue): Builder = apply {
@@ -93,7 +100,7 @@ private constructor(
 
         fun build() =
             Headers(
-                map.mapValuesTo(TreeMap(String.CASE_INSENSITIVE_ORDER)) { (_, values) ->
+                map.mapValuesTo(TreeMap(HEADER_NAME_COMPARATOR)) { (_, values) ->
                         values.toImmutable()
                     }
                     .toImmutable(),

--- a/openai-java-core/src/test/kotlin/com/openai/core/http/HeadersTest.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/core/http/HeadersTest.kt
@@ -1,6 +1,10 @@
 package com.openai.core.http
 
+import java.util.Locale
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.ResourceLock
+import org.junit.jupiter.api.parallel.Resources
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 
@@ -238,5 +242,28 @@ internal class HeadersTest {
         val size = testCase.headers.size
 
         assertThat(size).isEqualTo(testCase.expectedSize)
+    }
+
+    @Test
+    @ResourceLock(Resources.LOCALE)
+    fun caseInsensitiveUnderTurkishLocale() {
+        val previous = Locale.getDefault()
+        try {
+            Locale.setDefault(Locale("tr", "TR"))
+
+            val headers =
+                Headers.builder()
+                    .put("OpenAI-Organization", "org-value")
+                    .put("OpenAI-Project", "project-value")
+                    .build()
+
+            assertThat(headers.values("openai-organization")).containsExactly("org-value")
+            assertThat(headers.values("OPENAI-ORGANIZATION")).containsExactly("org-value")
+            assertThat(headers.values("OpenAI-Organization")).containsExactly("org-value")
+            assertThat(headers.values("openai-project")).containsExactly("project-value")
+            assertThat(headers.values("OPENAI-PROJECT")).containsExactly("project-value")
+        } finally {
+            Locale.setDefault(previous)
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fixes #755.

Under locales such as Turkish (`tr_TR`), case conversion of `I`/`i` is not ASCII (`I` → `ı`, `i` → `İ`). `Headers` used `TreeMap(String.CASE_INSENSITIVE_ORDER)` for case-insensitive header names; this change pins comparison to `Locale.ROOT` so HTTP header names (e.g. `OpenAI-Organization`, `OpenAI-Project`) resolve consistently regardless of the JVM default locale.

This is the Java equivalent of the Node SDK Turkish-locale header normalization fix (openai/openai-node#1928 / #1941).

### Change

In `Headers.kt`, both the builder map and the built immutable map now use:

```kotlin
Comparator { a, b ->
    a.lowercase(Locale.ROOT).compareTo(b.lowercase(Locale.ROOT))
}
```

instead of `String.CASE_INSENSITIVE_ORDER`.

## Test plan

- [x] Added `caseInsensitiveUnderTurkishLocale` that sets `Locale("tr", "TR")`, puts `OpenAI-Organization` / `OpenAI-Project`, asserts case-insensitive get for mixed/upper/lower ASCII keys, restores locale in `finally`, and uses `@ResourceLock(Resources.LOCALE)` for parallel tests.
- [x] Ran: `./gradlew :openai-java-core:test --tests "com.openai.core.http.HeadersTest"` → **BUILD SUCCESSFUL**

## Notes

Hand-written core path only (`Headers.kt` + test). No generated API model changes.

AI-assisted implementation; human-reviewed before open.