### PR TITLE
fix(deps): make swagger-annotations compileOnly to avoid jakarta conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -787,6 +787,11 @@ annotations. These allow type-specific constraints to be added to your schema pr
 learn more about the supported constraints in the OpenAI documentation on
 [Supported properties](https://platform.openai.com/docs/guides/structured-outputs#supported-properties).
 
+Add either `io.swagger.core.v3:swagger-annotations` or `io.swagger.core.v3:swagger-annotations-jakarta`
+to your project yourself (the SDK no longer ships either as a transitive dependency, so javax and
+Jakarta consumers do not conflict). Without one of those artifacts on the classpath, Swagger
+annotations are ignored and Jackson annotations still work for schema generation.
+
 ```java
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.media.ArraySchema;

--- a/openai-java-core/build.gradle.kts
+++ b/openai-java-core/build.gradle.kts
@@ -75,7 +75,10 @@ dependencies {
     api("com.fasterxml.jackson.core:jackson-core:$jacksonPublishedVersion")
     api("com.fasterxml.jackson.core:jackson-databind:$jacksonPublishedVersion")
     api("com.google.errorprone:error_prone_annotations:2.33.0")
-    api("io.swagger.core.v3:swagger-annotations:2.2.31")
+    // compileOnly: do not force javax swagger-annotations onto consumers. It conflicts with
+    // swagger-annotations-jakarta (same package). Consumers who use @Schema / @ArraySchema must
+    // declare either artifact themselves. See extractSchema() for optional Swagger2Module wiring.
+    compileOnly("io.swagger.core.v3:swagger-annotations:2.2.31")
 
     implementation("com.fasterxml.jackson.core:jackson-annotations:$jacksonPublishedVersion")
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jdk8:$jacksonPublishedVersion")
@@ -88,6 +91,7 @@ dependencies {
     testImplementation(kotlin("test"))
     testImplementation(project(":openai-java-client-okhttp"))
     testImplementation(platform("com.fasterxml.jackson:jackson-bom:2.21.5"))
+    testImplementation("io.swagger.core.v3:swagger-annotations:2.2.31")
     testImplementation("org.assertj:assertj-core:3.27.7")
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.3")
     testImplementation("org.junit.jupiter:junit-jupiter-params:5.9.3")

--- a/openai-java-core/src/main/kotlin/com/openai/core/StructuredOutputs.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/core/StructuredOutputs.kt
@@ -203,9 +203,15 @@ internal fun extractSchema(type: Class<*>): ObjectNode {
             // Use `JacksonModule` to support the use of Jackson annotations to set property and
             // class names and descriptions and to mark fields with `@JsonIgnore`.
             .with(JacksonModule())
-            // Use `Swagger2Module` to support OpenAPI Swagger 2 `@Schema` annotations to set
-            // property constraints (e.g., a `"pattern"` constraint for a string property).
-            .with(Swagger2Module())
+
+    // Swagger annotations are compileOnly (not a transitive dependency) so consumers can use
+    // either swagger-annotations or swagger-annotations-jakarta. Swagger2Module hard-references
+    // those classes; only register it when they are loadable on the consumer classpath.
+    if (isSwaggerAnnotationsPresent()) {
+        // Use `Swagger2Module` to support OpenAPI Swagger 2 `@Schema` annotations to set
+        // property constraints (e.g., a `"pattern"` constraint for a string property).
+        configBuilder.with(Swagger2Module())
+    }
 
     configBuilder
         .forFields()
@@ -217,6 +223,10 @@ internal fun extractSchema(type: Class<*>): ObjectNode {
 
     return SchemaGenerator(configBuilder.build()).generateSchema(type)
 }
+
+/** True when javax or jakarta swagger-annotations are on the classpath (shared package). */
+private fun isSwaggerAnnotationsPresent(): Boolean =
+    runCatching { Class.forName("io.swagger.v3.oas.annotations.media.Schema") }.isSuccess
 
 /**
  * Creates an instance of a Java class using data from a JSON string. The JSON data should conform

--- a/openai-java-example/build.gradle.kts
+++ b/openai-java-example/build.gradle.kts
@@ -10,6 +10,8 @@ repositories {
 dependencies {
     implementation(project(":openai-java"))
     implementation(project(":openai-java-bedrock"))
+    // Structured-output examples use @Schema / @ArraySchema; not transitive from openai-java-core.
+    implementation("io.swagger.core.v3:swagger-annotations:2.2.31")
     // Keep Azure Identity's Netty runtime aligned on a secure release.
     implementation(platform("io.netty:netty-bom:4.1.136.Final"))
     implementation("com.azure:azure-identity:1.18.4")


### PR DESCRIPTION
## Summary

Fixes #796.

`openai-java-core` declared `api("io.swagger.core.v3:swagger-annotations:…")`, which forced the **javax** Swagger annotations artifact onto every consumer classpath. That conflicts with `swagger-annotations-jakarta` (same package `io.swagger.v3.oas.annotations`), common in Spring Boot 3 / springdoc apps.

### Change

- Mark `swagger-annotations` as **`compileOnly`** (plus `testImplementation` for SDK tests) so it is **not** a published transitive dependency.
- Register `Swagger2Module` only when `io.swagger.v3.oas.annotations.media.Schema` is loadable, so structured outputs still work when neither annotation artifact is present (Jackson annotations continue to drive schema generation).
- Add an explicit `swagger-annotations` dependency to `openai-java-example` (examples use `@Schema` / `@ArraySchema`).
- Document in the README that consumers who want Swagger annotations must declare either `swagger-annotations` or `swagger-annotations-jakarta` themselves.

### Tradeoff

**Consumers who need Swagger annotations at compile time for their own schema classes must declare the dependency themselves** (javax *or* jakarta coordinate). That is intentional: the SDK should not pick a side and break the other ecosystem. Jackson-based schema generation needs no extra dependency.

`jsonschema-module-swagger-2` already treats `swagger-annotations` as `provided`; this aligns the SDK with that model.

### Competing PRs

Searched open/closed PRs for `swagger` / `#796` on `openai/openai-java` before opening — none found covering this change.

## Test plan

- [x] `./gradlew :openai-java-core:compileKotlin :openai-java-example:compileJava`
- [x] `./gradlew :openai-java-core:test --tests 'com.openai.core.StructuredOutputsTest'` — **95 tests, 0 failures** (JDK 21)
- [x] Confirmed published `pom-default.xml` no longer lists `swagger-annotations` (only `jsonschema-module-swagger-2`, which does not transitively pull annotations)
- [ ] CI green on this PR