### PR TITLE
ci: normalize multipart compatibility fixtures

### DIFF
--- a/scripts/detect-breaking-changes
+++ b/scripts/detect-breaking-changes
@@ -37,6 +37,7 @@ PROPOSED_EXCLUSIONS_PATH="${POLICY_PATH}/excluded-generated-tests.txt"
 PROPOSED_DEPENDENCIES_PATH="${POLICY_PATH}/dependencies.txt"
 PROPOSED_PUBLIC_API_PATH="${POLICY_PATH}/structured-output-public-api.txt"
 PROPOSED_FIXTURE_PATH="${POLICY_PATH}/kotlin"
+MULTIPART_INTERNAL_EXPRESSION='field.map { (it as? ByteArray)?.inputStream() ?: it }'
 
 rm -rf "${COMPATIBILITY_ROOT}"
 mkdir -p "${COMPATIBILITY_ROOT}"
@@ -171,6 +172,32 @@ validate_policy_files() {
     fi
 }
 
+# Generated multipart assertions call the Kotlin-internal MultipartField.map helper. Rewrite only
+# the isolated compatibility copies so their public builders and factories remain covered.
+normalize_multipart_assertions() {
+    local source_root="$1"
+    local policy_name="$2"
+    local rewritten_files=0
+    local file_path
+    local grep_status
+
+    while IFS= read -r -d '' file_path; do
+        if grep -Fq "${MULTIPART_INTERNAL_EXPRESSION}" "${file_path}"; then
+            INTERNAL_SOURCE="${MULTIPART_INTERNAL_EXPRESSION}" PUBLIC_SOURCE='field' \
+                perl -0pi -e 's/\Q$ENV{INTERNAL_SOURCE}\E/$ENV{PUBLIC_SOURCE}/g' "${file_path}"
+            rewritten_files=$((rewritten_files + 1))
+        else
+            grep_status=$?
+            if [ "${grep_status}" -ne 1 ]; then
+                echo "Failed to inspect ${policy_name} compatibility fixture: ${file_path}" >&2
+                return "${grep_status}"
+            fi
+        fi
+    done < <(find "${source_root}" -type f -name '*.kt' -print0)
+
+    echo "Normalized ${rewritten_files} ${policy_name} multipart compatibility fixture(s)."
+}
+
 validate_exclusions \
     "${BASELINE_EXCLUSIONS_PATH}" \
     "${COMPATIBILITY_ROOT}" \
@@ -190,6 +217,12 @@ validate_policy_files \
     "${PROPOSED_DEPENDENCIES_PATH}" \
     "${PROPOSED_FIXTURE_PATH}" \
     "${PROPOSED_PUBLIC_API_PATH}" \
+    proposed
+normalize_multipart_assertions \
+    "${COMPATIBILITY_ROOT}/openai-java-core/src/test/kotlin" \
+    baseline
+normalize_multipart_assertions \
+    "${PROPOSED_COMPATIBILITY_ROOT}/openai-java-core/src/test/kotlin" \
     proposed
 
 # Keep the compatibility compilation policy in this detector rather than in the proposed build


### PR DESCRIPTION
## Summary

- normalize generated multipart assertions in the isolated API-compatibility source copies
- keep new multipart fixtures compiled against the public API without adding per-test exclusions
- leave `excluded-generated-tests.txt` completely unchanged

This is a generic CI fix based on `main`; it contains no release changes. After it lands, #825 can regenerate or rebase and pass without adding the content-provenance test to the exclusion manifest.

## Root cause

Generated multipart tests call Kotlin-internal `MultipartField.map` inside recursive-comparison assertions. That helper is available to the normal test friend module but intentionally unavailable to the isolated consumer-style compatibility source sets. The detector now rewrites only that assertion expression in its temporary source copies, preserving public builders and factories in compatibility coverage while leaving generated and production sources untouched.

The existing legacy multipart exclusions remain unchanged in this migration PR because CI deliberately also runs the detector frozen at the base commit. Once this fix is on `main`, both detector runs know how to normalize future generated multipart tests automatically.

## Validation

- fetched `origin/main` and rebased the branch onto it
- `./scripts/lint`
- `bash -n scripts/detect-breaking-changes`
- `git diff --check origin/main...HEAD`
- reproduced the exact CI sequence: proposed detector followed by the detector from `origin/main`; both passed
- applied the final one-file patch to #825 at `784cbca1`; it normalized exactly the new content-provenance fixture and both compatibility checks passed with no manifest edit
- thermo-nuclear code-quality review; removed a redundant exclusion-validator special case

## CI follow-up

The first rewritten run showed why the legacy manifest entries cannot be removed in this same PR: the proposed detector passed, but the detector frozen at `main` still depended on those existing entries. Commit `29b571ee` leaves the manifest unchanged and preserves the generic fix.