### PR TITLE
ci: reduce CodeQL build time

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,6 +9,10 @@ on:
       - main
   workflow_dispatch:
 
+concurrency:
+  group: codeql-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   analyze:
     name: Analyze Java and Kotlin
@@ -39,10 +43,10 @@ jobs:
           languages: java-kotlin
           build-mode: manual
 
-      - name: Build SDK
+      - name: Build production classes
         env:
           GRADLE_OPTS: -Dkotlin.compiler.execution.strategy=in-process
-        run: ./scripts/build --no-build-cache
+        run: ./scripts/gradle classes --no-build-cache
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: codeql-${{ github.event.pull_request.number || github.ref }}
+  group: codeql-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:


### PR DESCRIPTION
## Summary

- compile only production classes during CodeQL's manual build
- cancel superseded CodeQL runs for the same pull request

## Why

Recent CodeQL runs average 23m52s, with the manual build accounting for 19m45s. The full `scripts/build` path compiles test sources, runs build-logic tests and policy checks, and creates artifacts that CodeQL does not need to analyze production Java and Kotlin.

The workflow also allowed stale runs from earlier commits on the same pull request to continue consuming runner time.

## Impact

`classes` still compiles every production source set across all eight included Gradle projects while preserving `--no-build-cache`, which CodeQL requires to observe compilation. Test and packaging coverage remains in the normal CI workflow.

The PR's first cold CodeQL run reduced the production build step from the 19m45s historical average to 11m25s (8m20s / 42% faster). The full job fell from 23m52s to 14m55s (8m57s / 38% faster).

## Validation

- `./scripts/gradle classes --dry-run --no-build-cache` with JDK 21
- `GRADLE_OPTS=-Dkotlin.compiler.execution.strategy=in-process ./scripts/gradle classes --no-build-cache` with JDK 21
- YAML parse of `.github/workflows/codeql.yml`
- thermo-nuclear code quality review
- all pull-request checks, including both CodeQL analyses
