### PR TITLE
ci: cache API compatibility production compilation

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -19,4 +19,8 @@ dependencies {
 
 tasks.test {
     useJUnitPlatform()
+    workingDir(layout.projectDirectory)
+    inputs
+        .file(layout.projectDirectory.file("../scripts/detect-breaking-changes"))
+        .withPathSensitivity(PathSensitivity.RELATIVE)
 }

--- a/buildSrc/src/test/kotlin/com/openai/gradle/ApiCompatibilityCachePolicyTest.kt
+++ b/buildSrc/src/test/kotlin/com/openai/gradle/ApiCompatibilityCachePolicyTest.kt
@@ -1,0 +1,24 @@
+package com.openai.gradle
+
+import java.nio.file.Path
+import kotlin.io.path.readText
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertFalse
+
+class ApiCompatibilityCachePolicyTest {
+    @Test
+    fun `compatibility compilation always executes while production caching stays enabled`() {
+        val detector = Path.of("../scripts/detect-breaking-changes").readText()
+
+        assertFalse(
+            detector.contains("--no-build-cache"),
+            "The API compatibility detector must leave the build cache enabled for production compilation.",
+        )
+        assertContains(detector, "compileExternalApiCompatibilityKotlin")
+        assertContains(detector, "compileProposedApiCompatibilityKotlin")
+        assertContains(detector, "project.tasks.named(taskName).configure")
+        assertContains(detector, "task.outputs.upToDateWhen { false }")
+        assertContains(detector, "task.outputs.doNotCacheIf")
+    }
+}

--- a/scripts/detect-breaking-changes
+++ b/scripts/detect-breaking-changes
@@ -291,6 +291,18 @@ gradle.beforeProject { project ->
                 System.getenv("PROPOSED_FIXTURE_SOURCE_ROOT"),
                 System.getenv("PROPOSED_DEPENDENCIES_FILE")
             )
+
+            [
+                "compileExternalApiCompatibilityKotlin",
+                "compileProposedApiCompatibilityKotlin"
+            ].each { taskName ->
+                project.tasks.named(taskName).configure { task ->
+                    task.outputs.upToDateWhen { false }
+                    task.outputs.doNotCacheIf(
+                        "API compatibility compilation must always execute"
+                    ) { true }
+                }
+            }
         }
     }
 }
@@ -305,8 +317,7 @@ GENERATED_TEST_SOURCE_ROOT="${GENERATED_TEST_SOURCE_ROOT}" \
     ./scripts/gradle \
     --init-script "${COMPATIBILITY_INIT_SCRIPT}" \
     :openai-java-core:compileExternalApiCompatibilityKotlin \
-    :openai-java-core:compileProposedApiCompatibilityKotlin \
-    --no-build-cache
+    :openai-java-core:compileProposedApiCompatibilityKotlin
 
 validate_public_api_signatures() {
     local manifest_path="$1"


### PR DESCRIPTION
## Summary

- keep the Gradle build cache enabled for ordinary production compilation in the API compatibility job
- explicitly make the external and proposed compatibility compilation tasks non-cacheable and never up-to-date, so both still execute on every detector pass
- add a regression test that guards the cache-safety boundary

## Why

The API compatibility job is frequently on the required-CI critical path. Its global `--no-build-cache` flag forced the large production Kotlin compilation to rerun even when an identical content-addressed result was available. Compatibility fixtures still need fresh compilation, but that does not require disabling caching for the entire build.

## Local measurement

With relevant module outputs removed before each run on the same commit:

- cache population run: **3m30s**
- cache restoration run: **1m05s**
- local improvement: **2m25s**

The restoration run reported both production Kotlin compilations `FROM-CACHE`, while `compileExternalApiCompatibilityKotlin` and `compileProposedApiCompatibilityKotlin` both executed normally.

## CI experiment result

The first PR run completed the API compatibility job in **10m54s**, effectively unchanged from the 10–11 minute baseline. Although setup-gradle restored a default-branch cache, all 16 Gradle tasks executed and `openai-java-core:compileKotlin` took about **6m24s**. The restored entry came from the default-branch `analyze` job, where CodeQL intentionally runs with `--no-build-cache`, so it did not contain a matching production compilation result.

This draft therefore does **not** yet meet the performance acceptance bar. It remains open to discuss whether explicit trusted cache seeding is worth its additional CI cost and cache-poisoning boundary; no review is requested yet.

## Safety validation

- both compatibility compilation tasks are explicitly non-cacheable
- both tasks are forced out of Gradle's up-to-date shortcut
- both baseline and proposed public API signature checks pass on a compatible change
- a temporary nonexistent public API signature was correctly rejected, confirming the detector still fails closed

## Validation

- `bash -n scripts/detect-breaking-changes`
- `./scripts/gradle :buildSrc:test`
- `./scripts/lint`
- `./scripts/test`
- full API compatibility detector, cold-output and warm-cache passes
- all GitHub checks green, including both CodeQL workflows