### PR TITLE
fix: parse string-encoded organization costs

### DIFF
--- a/openai-java-core/src/main/kotlin/com/openai/models/admin/organization/usage/UsageCostsResponse.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/models/admin/organization/usage/UsageCostsResponse.kt
@@ -7104,7 +7104,22 @@ private constructor(
                      * @throws OpenAIInvalidDataException if the JSON field has an unexpected type
                      *   (e.g. if the server responded with an unexpected value).
                      */
-                    fun value(): Optional<Double> = value.getOptional("value")
+                    fun value(): Optional<Double> {
+                        val knownValue = value.asKnown()
+                        if (knownValue.isPresent || value.isMissing() || value.isNull()) {
+                            return knownValue
+                        }
+
+                        val stringValue = value.asString()
+                        if (stringValue.isPresent) {
+                            val parsedValue = stringValue.get().toDoubleOrNull()
+                            if (parsedValue != null && parsedValue.isFinite()) {
+                                return Optional.of(parsedValue)
+                            }
+                        }
+
+                        throw OpenAIInvalidDataException("`value` is invalid, received $value")
+                    }
 
                     /**
                      * Returns the raw JSON value of [currency].

--- a/openai-java-core/src/main/kotlin/com/openai/models/admin/organization/usage/UsageCostsResponse.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/models/admin/organization/usage/UsageCostsResponse.kt
@@ -7112,8 +7112,14 @@ private constructor(
 
                         val stringValue = value.asString()
                         if (stringValue.isPresent) {
-                            val parsedValue = stringValue.get().toDoubleOrNull()
-                            if (parsedValue != null && parsedValue.isFinite()) {
+                            val rawValue = stringValue.get()
+                            val parsedValue =
+                                if (DECIMAL_NUMBER_PATTERN.matches(rawValue)) {
+                                    rawValue.toDoubleOrNull()
+                                } else {
+                                    null
+                                }
+                            if (parsedValue?.isFinite() == true) {
                                 return Optional.of(parsedValue)
                             }
                         }
@@ -7152,6 +7158,9 @@ private constructor(
                     fun toBuilder() = Builder().from(this)
 
                     companion object {
+
+                        private val DECIMAL_NUMBER_PATTERN =
+                            Regex("""-?(?:0|[1-9][0-9]*)(?:\.[0-9]+)?(?:[eE][+-]?[0-9]+)?""")
 
                         /** Returns a mutable builder for constructing an instance of [Amount]. */
                         @JvmStatic fun builder() = Builder()

--- a/openai-java-core/src/test/kotlin/com/openai/models/admin/organization/usage/UsageCostsResponseTest.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/models/admin/organization/usage/UsageCostsResponseTest.kt
@@ -8,6 +8,8 @@ import com.openai.errors.OpenAIInvalidDataException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 
 internal class UsageCostsResponseTest {
 
@@ -47,14 +49,15 @@ internal class UsageCostsResponseTest {
 
         val amounts =
             response.data().single().results().map {
-                it.asOrganizationCosts().amount().orElseThrow().value().orElseThrow()
+                it.asOrganizationCosts().amount().get().value().get()
             }
 
         assertThat(amounts).containsExactly(0.0, 0.0036275)
     }
 
-    @Test
-    fun rejectsInvalidStringEncodedCostAmount() {
+    @ParameterizedTest
+    @ValueSource(strings = ["not-a-number", "1f", "0x1.0p0", " 1 ", "01", "+1"])
+    fun rejectsInvalidStringEncodedCostAmount(invalidValue: String) {
         val response =
             jsonMapper()
                 .readValue(
@@ -66,7 +69,7 @@ internal class UsageCostsResponseTest {
                           "results": [
                             {
                               "object": "organization.costs.result",
-                              "amount": {"value": "not-a-number", "currency": "usd"}
+                              "amount": {"value": "$invalidValue", "currency": "usd"}
                             }
                           ],
                           "start_time": 0
@@ -81,7 +84,7 @@ internal class UsageCostsResponseTest {
                 )
 
         val amount =
-            response.data().single().results().single().asOrganizationCosts().amount().orElseThrow()
+            response.data().single().results().single().asOrganizationCosts().amount().get()
 
         assertThatThrownBy { amount.value() }.isInstanceOf(OpenAIInvalidDataException::class.java)
     }

--- a/openai-java-core/src/test/kotlin/com/openai/models/admin/organization/usage/UsageCostsResponseTest.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/models/admin/organization/usage/UsageCostsResponseTest.kt
@@ -4,10 +4,87 @@ package com.openai.models.admin.organization.usage
 
 import com.fasterxml.jackson.module.kotlin.jacksonTypeRef
 import com.openai.core.jsonMapper
+import com.openai.errors.OpenAIInvalidDataException
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 
 internal class UsageCostsResponseTest {
+
+    @Test
+    fun parsesStringEncodedCostAmounts() {
+        val response =
+            jsonMapper()
+                .readValue(
+                    """
+                    {
+                      "data": [
+                        {
+                          "end_time": 1,
+                          "results": [
+                            {
+                              "object": "organization.costs.result",
+                              "amount": {"value": "0E-6176", "currency": "usd"}
+                            },
+                            {
+                              "object": "organization.costs.result",
+                              "amount": {
+                                "value": "0.003627500000000000000000000000000000",
+                                "currency": "usd"
+                              }
+                            }
+                          ],
+                          "start_time": 0
+                        }
+                      ],
+                      "has_more": false,
+                      "object": "page"
+                    }
+                    """
+                        .trimIndent(),
+                    jacksonTypeRef<UsageCostsResponse>(),
+                )
+
+        val amounts =
+            response.data().single().results().map {
+                it.asOrganizationCosts().amount().orElseThrow().value().orElseThrow()
+            }
+
+        assertThat(amounts).containsExactly(0.0, 0.0036275)
+    }
+
+    @Test
+    fun rejectsInvalidStringEncodedCostAmount() {
+        val response =
+            jsonMapper()
+                .readValue(
+                    """
+                    {
+                      "data": [
+                        {
+                          "end_time": 1,
+                          "results": [
+                            {
+                              "object": "organization.costs.result",
+                              "amount": {"value": "not-a-number", "currency": "usd"}
+                            }
+                          ],
+                          "start_time": 0
+                        }
+                      ],
+                      "has_more": false,
+                      "object": "page"
+                    }
+                    """
+                        .trimIndent(),
+                    jacksonTypeRef<UsageCostsResponse>(),
+                )
+
+        val amount =
+            response.data().single().results().single().asOrganizationCosts().amount().orElseThrow()
+
+        assertThatThrownBy { amount.value() }.isInstanceOf(OpenAIInvalidDataException::class.java)
+    }
 
     @Test
     fun create() {


### PR DESCRIPTION
## Summary

- accept numeric strings returned by the organization costs API when reading `amount.value`
- keep the SDK's global JSON coercion rules and raw-field representation unchanged
- continue rejecting malformed and non-finite string values

## Why

The costs endpoint can return monetary values as strings, including scientific notation such as `"0E-6176"` and high-precision decimals. Because the SDK intentionally disables global string-to-float coercion, those values remain raw `JsonString` instances and `Amount.value()` throws `OpenAIInvalidDataException`.

This change handles the wire-format variation only at the affected accessor. Normal JSON numbers, missing/null fields, and invalid values retain their existing behavior.

## Tests

- added focused regression coverage for scientific-notation and long-decimal strings
- added negative coverage for malformed numeric strings
- `./gradlew :openai-java-core:lint`
- `git diff --check`

Fixes #769