### PR TITLE
ci: migrate release-please to upstream action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,12 @@ on:
     branches:
       - main
       - next
+  workflow_dispatch:
+    inputs:
+      base_sha:
+        description: Base commit used for API compatibility checks
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -100,7 +106,9 @@ jobs:
 
   api_compatibility:
     name: CI / API compatibility
-    if: github.event_name == 'pull_request'
+    if: >-
+      github.event_name == 'pull_request' ||
+      github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-24.04
     timeout-minutes: 20
 
@@ -123,7 +131,7 @@ jobs:
 
       - name: Compile previous tests against the proposed SDK
         env:
-          BASE_COMMIT: ${{ github.event.pull_request.base.sha }}
+          BASE_COMMIT: ${{ github.event.pull_request.base.sha || inputs.base_sha }}
           GRADLE_OPTS: -Dkotlin.compiler.execution.strategy=in-process
         run: |
           set -euo pipefail
@@ -198,10 +206,12 @@ jobs:
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
 
       - name: Run consumer compatibility smoke test
+        env:
+          RUNTIME_JAVA_VERSION: ${{ matrix.java }}
         run: >-
           ./scripts/gradle
           :openai-java-runtime-compatibility:runRuntimeCompatibility
-          -PruntimeJavaVersion=${{ matrix.java }}
+          -PruntimeJavaVersion="$RUNTIME_JAVA_VERSION"
 
   required:
     name: CI / required
@@ -242,7 +252,9 @@ jobs:
             [[ "$BUILD_RESULT" == "success" ]] || failed_jobs+=("build: $BUILD_RESULT")
           fi
 
-          if [[ "$EVENT_NAME" == "pull_request" && "$API_COMPATIBILITY_RESULT" != "success" ]]; then
+          if [[ ( "$EVENT_NAME" == "pull_request" ||
+                  "$EVENT_NAME" == "workflow_dispatch" ) &&
+                "$API_COMPATIBILITY_RESULT" != "success" ]]; then
             failed_jobs+=("API compatibility: $API_COMPATIBILITY_RESULT")
           fi
           [[ "$RUNTIME_COMPATIBILITY_RESULT" == "success" ]] ||

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,6 @@ on:
       - main
       - next
   workflow_dispatch:
-    inputs:
-      base_sha:
-        description: Base commit used for API compatibility checks
-        required: true
-        type: string
 
 permissions:
   contents: read
@@ -109,6 +104,9 @@ jobs:
     if: >-
       github.event_name == 'pull_request' ||
       github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: read
+      pull-requests: read
     runs-on: ubuntu-24.04
     timeout-minutes: 20
 
@@ -117,6 +115,58 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+
+      - name: Validate dispatched release PR
+        if: github.event_name == 'workflow_dispatch'
+        id: release-pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          expected_ref="refs/heads/release-please--branches--main"
+          if [[ "$GITHUB_REF" != "$expected_ref" ]]; then
+            echo "::error::Release PR CI must run on $expected_ref, not $GITHUB_REF"
+            exit 1
+          fi
+
+          release_pr="$(
+            gh api \
+              --method GET \
+              "repos/$GITHUB_REPOSITORY/pulls" \
+              -f state=open \
+              -f head="$GITHUB_REPOSITORY_OWNER:$GITHUB_REF_NAME" \
+              -f base=main \
+              -F per_page=2
+          )"
+          if [[ "$(jq length <<< "$release_pr")" != "1" ]]; then
+            echo "::error::Expected exactly one open release PR from $GITHUB_REF_NAME into main"
+            exit 1
+          fi
+
+          if ! jq -e \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg head_ref "$GITHUB_REF_NAME" \
+            --arg head_sha "$GITHUB_SHA" \
+            '.[0] |
+              .user.id == 41898282 and
+              .user.type == "Bot" and
+              .head.repo.full_name == $repository and
+              .head.ref == $head_ref and
+              .head.sha == $head_sha and
+              .base.repo.full_name == $repository and
+              .base.ref == "main"' \
+            <<< "$release_pr" > /dev/null; then
+            echo "::error::Release PR is not the expected github-actions[bot] PR for $GITHUB_SHA"
+            exit 1
+          fi
+
+          base_sha="$(jq -r '.[0].base.sha' <<< "$release_pr")"
+          if ! git cat-file -e "${base_sha}^{commit}"; then
+            echo "::error::PR base commit is not available: $base_sha"
+            exit 1
+          fi
+          echo "base_sha=$base_sha" >> "$GITHUB_OUTPUT"
 
       - name: Set up Java
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
@@ -131,7 +181,9 @@ jobs:
 
       - name: Compile previous tests against the proposed SDK
         env:
-          BASE_COMMIT: ${{ github.event.pull_request.base.sha || inputs.base_sha }}
+          BASE_COMMIT: >-
+            ${{ github.event.pull_request.base.sha ||
+            steps.release-pr.outputs.base_sha }}
           GRADLE_OPTS: -Dkotlin.compiler.execution.strategy=in-process
         run: |
           set -euo pipefail

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -18,8 +18,7 @@ on:
         type: boolean
         default: false
 
-permissions:
-  contents: read
+permissions: {}
 
 concurrency:
   group: create-releases
@@ -31,9 +30,12 @@ env:
   MAVEN_ARTIFACTS: openai-java openai-java-core openai-java-client-okhttp openai-java-bedrock
 
 jobs:
-  release:
-    name: Release / select source
-    if: github.ref == 'refs/heads/main' && github.repository == 'openai/openai-java'
+  automatic_release:
+    name: Release / create
+    if: >-
+      github.event_name != 'workflow_dispatch' &&
+      github.ref == 'refs/heads/main' &&
+      github.repository == 'openai/openai-java'
     permissions:
       contents: write
       issues: write
@@ -41,24 +43,35 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     outputs:
-      should_publish: >-
-        ${{ github.event_name == 'workflow_dispatch' ||
-        steps.automatic.outputs.releases_created == 'true' }}
-      source_sha: ${{ steps.retry.outputs.source_sha || steps.automatic.outputs.sha }}
-      release_tag: ${{ steps.retry.outputs.release_tag || steps.automatic.outputs.tag_name }}
+      releases_created: ${{ steps.release.outputs.releases_created }}
+      source_sha: ${{ steps.release.outputs.sha }}
+      release_tag: ${{ steps.release.outputs.tag_name }}
 
     steps:
       - name: Create release
-        if: github.event_name != 'workflow_dispatch'
-        id: automatic
+        id: release
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           target-branch: main
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
+  retry_release:
+    name: Release / select retry source
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      github.ref == 'refs/heads/main' &&
+      github.repository == 'openai/openai-java'
+    permissions:
+      contents: read
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    outputs:
+      source_sha: ${{ steps.retry.outputs.source_sha }}
+      release_tag: ${{ steps.retry.outputs.release_tag }}
+
+    steps:
       - name: Validate retry request
-        if: github.event_name == 'workflow_dispatch'
         env:
           RELEASE_TAG: ${{ inputs.release_tag }}
           CONFIRMED: ${{ inputs.confirm_no_pending_deployment }}
@@ -73,7 +86,6 @@ jobs:
           fi
 
       - name: Check out retry source
-        if: github.event_name == 'workflow_dispatch'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
@@ -81,7 +93,6 @@ jobs:
           ref: refs/tags/${{ inputs.release_tag }}
 
       - name: Verify retry source
-        if: github.event_name == 'workflow_dispatch'
         id: retry
         env:
           GH_TOKEN: ${{ github.token }}
@@ -121,10 +132,39 @@ jobs:
             echo "release_tag=$RELEASE_TAG"
           } >> "$GITHUB_OUTPUT"
 
+  release:
+    name: Release / select source
+    needs:
+      - automatic_release
+      - retry_release
+    if: >-
+      always() &&
+      (needs.automatic_release.result == 'success' ||
+      needs.retry_release.result == 'success')
+    permissions: {}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 1
+    outputs:
+      should_publish: >-
+        ${{ needs.retry_release.result == 'success' ||
+        needs.automatic_release.outputs.releases_created == 'true' }}
+      source_sha: >-
+        ${{ needs.retry_release.outputs.source_sha ||
+        needs.automatic_release.outputs.source_sha }}
+      release_tag: >-
+        ${{ needs.retry_release.outputs.release_tag ||
+        needs.automatic_release.outputs.release_tag }}
+
+    steps:
+      - name: Select release source
+        run: echo "Release source selected"
+
   runtime_compatibility:
     name: Release / runtime compatibility
     needs: release
     if: needs.release.outputs.should_publish == 'true'
+    permissions:
+      contents: read
     uses: ./.github/workflows/runtime-compatibility.yml
     with:
       ref: ${{ needs.release.outputs.source_sha }}
@@ -137,6 +177,8 @@ jobs:
     if: >-
       needs.release.outputs.should_publish == 'true' &&
       needs.runtime_compatibility.result == 'success'
+    permissions:
+      contents: read
     runs-on: ubuntu-24.04
     timeout-minutes: 90
     environment: publish

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -34,9 +34,12 @@ jobs:
   release:
     name: Release / select source
     if: github.ref == 'refs/heads/main' && github.repository == 'openai/openai-java'
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
     runs-on: ubuntu-24.04
     timeout-minutes: 15
-    environment: publish
     outputs:
       should_publish: >-
         ${{ github.event_name == 'workflow_dispatch' ||
@@ -45,19 +48,14 @@ jobs:
       release_tag: ${{ steps.retry.outputs.release_tag || steps.automatic.outputs.tag_name }}
 
     steps:
-      - name: Check out main
-        if: github.event_name != 'workflow_dispatch'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
-
       - name: Create release
         if: github.event_name != 'workflow_dispatch'
         id: automatic
-        uses: stainless-api/trigger-release-please@bb6677c5a04578eec1ccfd9e1913b5b78ed64c61 # v1.4.0
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
-          repo: ${{ github.event.repository.full_name }}
-          stainless-api-key: ${{ secrets.STAINLESS_API_KEY }}
+          target-branch: main
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
 
       - name: Validate retry request
         if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -108,8 +108,7 @@ jobs:
 
           gh workflow run ci.yml \
             --repo "$GITHUB_REPOSITORY" \
-            --ref "$release_branch" \
-            -f base_sha="$GITHUB_SHA"
+            --ref "$release_branch"
 
   retry_release:
     name: Release / select retry source

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -52,6 +52,7 @@ jobs:
         id: release
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           target-branch: main
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
@@ -95,7 +96,7 @@ jobs:
       - name: Verify retry source
         id: retry
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ inputs.release_tag }}
         run: |
           set -euo pipefail

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -43,11 +43,35 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     outputs:
+      prs_created: ${{ steps.release.outputs.prs_created }}
+      release_pr: ${{ steps.release.outputs.pr }}
       releases_created: ${{ steps.release.outputs.releases_created }}
       source_sha: ${{ steps.release.outputs.sha }}
       release_tag: ${{ steps.release.outputs.tag_name }}
 
     steps:
+      - name: Check for a legacy release PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LEGACY_RELEASE_BRANCH: release-please--branches--main--changes--next
+        run: |
+          set -euo pipefail
+
+          legacy_pr="$(
+            gh pr list \
+              --repo "$GITHUB_REPOSITORY" \
+              --state open \
+              --head "$LEGACY_RELEASE_BRANCH" \
+              --json number,url \
+              --jq '.[0] // empty'
+          )"
+          if [[ -n "$legacy_pr" ]]; then
+            legacy_number="$(jq -r '.number' <<< "$legacy_pr")"
+            legacy_url="$(jq -r '.url' <<< "$legacy_pr")"
+            echo "::error::Merge or close legacy release PR #$legacy_number before running upstream release-please: $legacy_url"
+            exit 1
+          fi
+
       - name: Create release
         id: release
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
@@ -56,6 +80,36 @@ jobs:
           target-branch: main
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  release_pr_ci:
+    name: Release / run release PR CI
+    needs: automatic_release
+    if: needs.automatic_release.outputs.prs_created == 'true'
+    permissions:
+      actions: write
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+
+    steps:
+      # Events created by GITHUB_TOKEN do not recursively trigger pull_request workflows.
+      # workflow_dispatch is an explicit exception, so dispatch CI for the generated PR head.
+      - name: Run CI for the release PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_PR: ${{ needs.automatic_release.outputs.release_pr }}
+        run: |
+          set -euo pipefail
+
+          release_branch="$(jq -r '.headBranchName // empty' <<< "$RELEASE_PR")"
+          if [[ "$release_branch" != "release-please--branches--main" ]]; then
+            echo "::error::Unexpected release PR branch: $release_branch"
+            exit 1
+          fi
+
+          gh workflow run ci.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref "$release_branch" \
+            -f base_sha="$GITHUB_SHA"
 
   retry_release:
     name: Release / select retry source

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,7 @@
   "packages": {
     ".": {}
   },
-  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/v17.6.0/schemas/config.json",
   "include-v-in-tag": true,
   "include-component-in-tag": false,
   "pull-request-header": "Automated Release PR",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,13 +2,9 @@
   "packages": {
     ".": {}
   },
-  "$schema": "https://raw.githubusercontent.com/stainless-api/release-please/main/schemas/config.json",
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "include-v-in-tag": true,
   "include-component-in-tag": false,
-  "versioning": "prerelease",
-  "prerelease": true,
-  "bump-minor-pre-major": true,
-  "bump-patch-for-minor-pre-major": false,
   "pull-request-header": "Automated Release PR",
   "pull-request-title-pattern": "release: ${version}",
   "changelog-sections": [
@@ -61,6 +57,7 @@
   ],
   "release-type": "simple",
   "extra-files": [
+    "CONTRIBUTING.md",
     "README.md",
     "bedrock.md",
     "build.gradle.kts"


### PR DESCRIPTION
## Summary

- replace the Stainless release trigger with the pinned upstream `googleapis/release-please-action` v5.0.0
- run release-please explicitly against `main` using the repository manifest and `${{ secrets.GITHUB_TOKEN }}`
- switch to the upstream configuration schema and remove prerelease/beta versioning
- include `CONTRIBUTING.md`, whose release-please version markers were previously omitted from `extra-files`
- remove the `STAINLESS_API_KEY` workflow input and keep publish-environment secrets isolated to the publish job
- deny token permissions by default and split automatic release creation, release-PR CI dispatch, manual retry handling, and publishing so each job receives only the scopes it needs
- explicitly dispatch full CI for `GITHUB_TOKEN`-generated release PRs, including API compatibility and the required aggregate check
- reject untrusted manual CI dispatches by requiring the exact bot-authored release PR head and deriving the compatibility baseline from that PR's GitHub-reported base
- refuse to run upstream release-please while legacy release PR #835 remains open, preventing competing release PRs

The automatic release job alone receives `contents`, `issues`, and `pull-requests` write access. A separate release-PR CI job receives only `actions: write`; retry selection, runtime compatibility, and publishing receive only `contents: read`; the source selector receives no token permissions. The dispatched compatibility check adds only job-scoped `pull-requests: read` to validate the generated PR. Both the upstream action and retry verification explicitly use the built-in `GITHUB_TOKEN`—there is no private GitHub App credential or Stainless key in either path.

The live `stainless release-please branches` ruleset now excludes only `refs/heads/release-please--branches--main` from its create/update/delete restriction. GitHub does not permit its built-in Actions integration to be a ruleset bypass actor, so this exact-branch exclusion is required for `GITHUB_TOKEN`; every other `release-please--*` branch and all `main` protections remain unchanged.

**Cutover requirement:** merge or close legacy release PR #835 before the first upstream release run. The workflow enforces this and fails before creating a competing PR.

After this PR lands and the upstream workflow is in use, `STAINLESS_API_KEY` can be deleted from the `publish` environment.

## Validation

- `actionlint` v1.7.12
- `zizmor` v1.28.0 workflow audit: no findings
- config validation against the release-please v17.6.0 JSON schema bundled by action v5.0.0
- release-please v17.6.0 resolved-config validation against `main`
- synthetic feature dry run produced stable `release: 4.50.0` on `release-please--branches--main` and loaded all annotated version files
- legacy-PR guard confirmed against open PR #835
- pinned upstream source confirms created and updated release PRs populate both [`prs_created` and `pr`](https://github.com/googleapis/release-please-action/blob/45996ed1f6d02564a971a2fa1b5860e934307cf7/src/index.ts#L219-L225); unchanged PRs are omitted by [release-please's update path](https://github.com/googleapis/release-please/blob/v17.6.0/src/manifest.ts#L1090-L1103)
- required CI and CodeQL passed on `676311eb`
- OkTest: 237/237 SDK tests passed on `676311eb`
- thermo-nuclear code-quality review after the permission/job split and dispatch hardening: no findings
