### PR TITLE
docs: keep README badges on latest release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
 # OpenAI Java API Library
 
-<!-- These URLs intentionally omit versions and stay outside Release Please markers so they track the latest release. -->
+<!-- This URL intentionally omits a version and stays outside Release Please markers so it tracks the latest release. -->
 [![Maven Central](https://img.shields.io/maven-central/v/com.openai/openai-java)](https://central.sonatype.com/artifact/com.openai/openai-java)
-[![javadoc](https://javadoc.io/badge2/com.openai/openai-java/javadoc.svg)](https://javadoc.io/doc/com.openai/openai-java)
 
 The OpenAI Java SDK provides convenient access to the [OpenAI REST API](https://platform.openai.com/docs) from applications written in Java.
 
-The REST API documentation can be found on [platform.openai.com](https://platform.openai.com/docs). Javadocs are available on [javadoc.io](https://javadoc.io/doc/com.openai/openai-java).
+The REST API documentation can be found on [platform.openai.com](https://platform.openai.com/docs).
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenAI Java API Library
 
-<!-- These URLs intentionally omit a version so they always resolve to the latest release. -->
+<!-- These URLs intentionally omit versions and stay outside Release Please markers so they track the latest release. -->
 [![Maven Central](https://img.shields.io/maven-central/v/com.openai/openai-java)](https://central.sonatype.com/artifact/com.openai/openai-java)
 [![javadoc](https://javadoc.io/badge2/com.openai/openai-java/javadoc.svg)](https://javadoc.io/doc/com.openai/openai-java)
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # OpenAI Java API Library
 
-<!-- This URL intentionally omits a version and stays outside Release Please markers so it tracks the latest release. -->
+<!-- These URLs intentionally omit versions and stay outside Release Please markers so they track the latest release. -->
 [![Maven Central](https://img.shields.io/maven-central/v/com.openai/openai-java)](https://central.sonatype.com/artifact/com.openai/openai-java)
+[![javadoc](https://javadoc.io/badge2/com.openai/openai-java/javadoc.svg)](https://javadoc.io/doc/com.openai/openai-java)
 
 The OpenAI Java SDK provides convenient access to the [OpenAI REST API](https://platform.openai.com/docs) from applications written in Java.
 
-The REST API documentation can be found on [platform.openai.com](https://platform.openai.com/docs).
+The REST API documentation can be found on [platform.openai.com](https://platform.openai.com/docs). Javadocs are available on [javadoc.io](https://javadoc.io/doc/com.openai/openai-java).
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,12 @@
 # OpenAI Java API Library
 
-<!-- x-release-please-start-version -->
-
-[![Maven Central](https://img.shields.io/maven-central/v/com.openai/openai-java)](https://central.sonatype.com/artifact/com.openai/openai-java/4.50.0)
-[![javadoc](https://javadoc.io/badge2/com.openai/openai-java/4.50.0/javadoc.svg)](https://javadoc.io/doc/com.openai/openai-java/4.49.0)
-
-<!-- x-release-please-end -->
+<!-- These URLs intentionally omit a version so they always resolve to the latest release. -->
+[![Maven Central](https://img.shields.io/maven-central/v/com.openai/openai-java)](https://central.sonatype.com/artifact/com.openai/openai-java)
+[![javadoc](https://javadoc.io/badge2/com.openai/openai-java/javadoc.svg)](https://javadoc.io/doc/com.openai/openai-java)
 
 The OpenAI Java SDK provides convenient access to the [OpenAI REST API](https://platform.openai.com/docs) from applications written in Java.
 
-<!-- x-release-please-start-version -->
-
-The REST API documentation can be found on [platform.openai.com](https://platform.openai.com/docs). Javadocs are available on [javadoc.io](https://javadoc.io/doc/com.openai/openai-java/4.50.0).
-
-<!-- x-release-please-end -->
+The REST API documentation can be found on [platform.openai.com](https://platform.openai.com/docs). Javadocs are available on [javadoc.io](https://javadoc.io/doc/com.openai/openai-java).
 
 ## Installation
 


### PR DESCRIPTION
## Summary

- use the versionless Maven Central artifact URL for the Maven badge target
- use Javadoc.io's versionless latest-version badge and documentation URLs
- keep these dynamic URLs outside Release Please's version-managed sections

## Why

Release Please's generic README updater changed the first version on the Javadoc badge line but left the link target on the previous release, as caught in [the 4.50.0 release review](https://github.com/openai/openai-java/pull/838#discussion_r3707542907). Using the providers' latest-version URLs removes the duplicated version state, so future release PRs cannot leave the badge image and target out of sync.

## Impact

The README badges and Javadoc links now follow the latest published artifact without requiring per-release edits. Installation snippets remain version-pinned and managed by Release Please.

## Validation

- `mise exec java@21 -- ./scripts/lint`
- `git diff --check`
- verified Release Please marker pairs remain balanced
- thermo-nuclear code quality review: no findings