### PR TITLE
ci(workflows): allow configurable GitHub Actions runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   lint:
     name: CI / lint
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.SDK_GHA_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 15
 
     steps:
@@ -51,7 +51,7 @@ jobs:
       !(github.repository == 'stainless-sdks/openai-java' &&
         github.event_name == 'push' &&
         !startsWith(github.ref, 'refs/heads/stl/'))
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.SDK_GHA_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 30
 
     steps:
@@ -95,7 +95,7 @@ jobs:
 
   test:
     name: CI / tests
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.SDK_GHA_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 30
 
     steps:
@@ -127,7 +127,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.SDK_GHA_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 20
 
     steps:
@@ -228,7 +228,7 @@ jobs:
 
   version_support_matrix:
     name: CI / version support matrix
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.SDK_GHA_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 5
 
     outputs:
@@ -266,7 +266,7 @@ jobs:
         (github.repository == 'stainless-sdks/openai-java' &&
           github.event_name == 'push' &&
           !startsWith(github.ref, 'refs/heads/stl/')))
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.SDK_GHA_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 20
 
     strategy:
@@ -320,7 +320,7 @@ jobs:
       - test
       - api_compatibility
       - runtime_compatibility
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.SDK_GHA_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 5
 
     steps:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,6 +13,7 @@ concurrency:
 jobs:
   analyze:
     name: Analyze Java and Kotlin
+    if: github.repository != 'openai/openai-java-internal'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     permissions:

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -40,7 +40,7 @@ jobs:
       contents: write
       issues: write
       pull-requests: write
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.SDK_GHA_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 15
     outputs:
       prs_created: ${{ steps.release.outputs.prs_created }}
@@ -87,7 +87,7 @@ jobs:
     if: needs.automatic_release.outputs.prs_created == 'true'
     permissions:
       actions: write
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.SDK_GHA_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 5
 
     steps:
@@ -118,7 +118,7 @@ jobs:
       github.repository == 'openai/openai-java'
     permissions:
       contents: read
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.SDK_GHA_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 15
     outputs:
       source_sha: ${{ steps.retry.outputs.source_sha }}
@@ -196,7 +196,7 @@ jobs:
       (needs.automatic_release.result == 'success' ||
       needs.retry_release.result == 'success')
     permissions: {}
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.SDK_GHA_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 1
     outputs:
       should_publish: >-
@@ -233,7 +233,7 @@ jobs:
       needs.runtime_compatibility.result == 'success'
     permissions:
       contents: read
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.SDK_GHA_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 90
     environment: publish
 

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -19,7 +19,7 @@ jobs:
       github.repository == 'openai/openai-java' &&
       github.event.head_commit.message != 'codegen metadata'
     environment: CI
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.SDK_GHA_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 20
 
     steps:

--- a/.github/workflows/runtime-compatibility.yml
+++ b/.github/workflows/runtime-compatibility.yml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   version_support_matrix:
     name: Runtime compatibility / version support matrix
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.SDK_GHA_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 5
 
     outputs:
@@ -54,7 +54,7 @@ jobs:
   runtime_compatibility:
     name: Runtime compatibility / Java ${{ matrix.java }}
     needs: version_support_matrix
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.SDK_GHA_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 20
 
     strategy:


### PR DESCRIPTION
## Summary

- Allow each repository to select an appropriate GitHub Actions runner through the optional `SDK_GHA_RUNNER` repository variable.
- Preserve the existing `ubuntu-24.04` defaults across CI, runtime compatibility, examples, and release workflows when no override is configured.
- Keep CodeQL disabled where code scanning is not enabled without changing its existing runner or permissions elsewhere.

## Validation

- Parsed all six GitHub Actions workflow files successfully.
- Verified all 15 configurable jobs retain their original `ubuntu-24.04` fallback.
- Verified CodeQL retains its existing `ubuntu-latest` runner and permissions.
- Confirmed the source pull request's complete CI suite passes.

Reviewer validation: https://github.com/openai/openai-java-internal/pull/14