### PR TITLE
ci: use GitHub App for Release Please

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,8 +122,7 @@ jobs:
     needs: build
     if: >-
       needs.build.result == 'success' &&
-      (github.event_name == 'pull_request' ||
-        github.event_name == 'workflow_dispatch')
+      github.event_name == 'pull_request'
     permissions:
       contents: read
       pull-requests: read
@@ -135,58 +134,6 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-
-      - name: Validate dispatched release PR
-        if: github.event_name == 'workflow_dispatch'
-        id: release-pr
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-
-          expected_ref="refs/heads/release-please--branches--main"
-          if [[ "$GITHUB_REF" != "$expected_ref" ]]; then
-            echo "::error::Release PR CI must run on $expected_ref, not $GITHUB_REF"
-            exit 1
-          fi
-
-          release_pr="$(
-            gh api \
-              --method GET \
-              "repos/$GITHUB_REPOSITORY/pulls" \
-              -f state=open \
-              -f head="$GITHUB_REPOSITORY_OWNER:$GITHUB_REF_NAME" \
-              -f base=main \
-              -F per_page=2
-          )"
-          if [[ "$(jq length <<< "$release_pr")" != "1" ]]; then
-            echo "::error::Expected exactly one open release PR from $GITHUB_REF_NAME into main"
-            exit 1
-          fi
-
-          if ! jq -e \
-            --arg repository "$GITHUB_REPOSITORY" \
-            --arg head_ref "$GITHUB_REF_NAME" \
-            --arg head_sha "$GITHUB_SHA" \
-            '.[0] |
-              .user.id == 41898282 and
-              .user.type == "Bot" and
-              .head.repo.full_name == $repository and
-              .head.ref == $head_ref and
-              .head.sha == $head_sha and
-              .base.repo.full_name == $repository and
-              .base.ref == "main"' \
-            <<< "$release_pr" > /dev/null; then
-            echo "::error::Release PR is not the expected github-actions[bot] PR for $GITHUB_SHA"
-            exit 1
-          fi
-
-          base_sha="$(jq -r '.[0].base.sha' <<< "$release_pr")"
-          if ! git cat-file -e "${base_sha}^{commit}"; then
-            echo "::error::PR base commit is not available: $base_sha"
-            exit 1
-          fi
-          echo "base_sha=$base_sha" >> "$GITHUB_OUTPUT"
 
       - name: Set up Java
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
@@ -209,9 +156,7 @@ jobs:
 
       - name: Compile previous tests against the proposed SDK
         env:
-          BASE_COMMIT: >-
-            ${{ github.event.pull_request.base.sha ||
-            steps.release-pr.outputs.base_sha }}
+          BASE_COMMIT: ${{ github.event.pull_request.base.sha }}
           GRADLE_OPTS: -Dkotlin.compiler.execution.strategy=in-process
         run: |
           set -euo pipefail
@@ -350,8 +295,7 @@ jobs:
             [[ "$BUILD_RESULT" == "success" ]] || failed_jobs+=("build: $BUILD_RESULT")
           fi
 
-          if [[ ( "$EVENT_NAME" == "pull_request" ||
-                  "$EVENT_NAME" == "workflow_dispatch" ) &&
+          if [[ "$EVENT_NAME" == "pull_request" &&
                 "$API_COMPATIBILITY_RESULT" != "success" ]]; then
             failed_jobs+=("API compatibility: $API_COMPATIBILITY_RESULT")
           fi

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -36,7 +36,7 @@ jobs:
       github.event_name != 'workflow_dispatch' &&
       github.ref == 'refs/heads/main' &&
       github.repository == 'openai/openai-java'
-    environment: castiron-promotion
+    environment: release
     permissions: {}
     runs-on: ${{ vars.SDK_GHA_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 15

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -36,23 +36,29 @@ jobs:
       github.event_name != 'workflow_dispatch' &&
       github.ref == 'refs/heads/main' &&
       github.repository == 'openai/openai-java'
-    permissions:
-      contents: write
-      issues: write
-      pull-requests: write
+    environment: castiron-promotion
+    permissions: {}
     runs-on: ${{ vars.SDK_GHA_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 15
     outputs:
-      prs_created: ${{ steps.release.outputs.prs_created }}
-      release_pr: ${{ steps.release.outputs.pr }}
       releases_created: ${{ steps.release.outputs.releases_created }}
       source_sha: ${{ steps.release.outputs.sha }}
       release_tag: ${{ steps.release.outputs.tag_name }}
 
     steps:
+      - name: Create release app token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.OPENAI_SDKS_APP_CLIENT_ID }}
+          private-key: ${{ secrets.OPENAI_SDKS_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
+
       - name: Check for a legacy release PR
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           LEGACY_RELEASE_BRANCH: release-please--branches--main--changes--next
         run: |
           set -euo pipefail
@@ -76,39 +82,10 @@ jobs:
         id: release
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           target-branch: main
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-
-  release_pr_ci:
-    name: Release / run release PR CI
-    needs: automatic_release
-    if: needs.automatic_release.outputs.prs_created == 'true'
-    permissions:
-      actions: write
-    runs-on: ${{ vars.SDK_GHA_RUNNER || 'ubuntu-24.04' }}
-    timeout-minutes: 5
-
-    steps:
-      # Events created by GITHUB_TOKEN do not recursively trigger pull_request workflows.
-      # workflow_dispatch is an explicit exception, so dispatch CI for the generated PR head.
-      - name: Run CI for the release PR
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_PR: ${{ needs.automatic_release.outputs.release_pr }}
-        run: |
-          set -euo pipefail
-
-          release_branch="$(jq -r '.headBranchName // empty' <<< "$RELEASE_PR")"
-          if [[ "$release_branch" != "release-please--branches--main" ]]; then
-            echo "::error::Unexpected release PR branch: $release_branch"
-            exit 1
-          fi
-
-          gh workflow run ci.yml \
-            --repo "$GITHUB_REPOSITORY" \
-            --ref "$release_branch"
 
   retry_release:
     name: Release / select retry source
@@ -396,7 +373,6 @@ jobs:
     name: Release / verify outcome
     needs:
       - automatic_release
-      - release_pr_ci
       - retry_release
       - release
       - runtime_compatibility
@@ -413,8 +389,6 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           AUTOMATIC_RESULT: ${{ needs.automatic_release.result }}
-          AUTOMATIC_PRS_CREATED: ${{ needs.automatic_release.outputs.prs_created }}
-          RELEASE_PR_CI_RESULT: ${{ needs.release_pr_ci.result }}
           RETRY_RESULT: ${{ needs.retry_release.result }}
           RELEASE_RESULT: ${{ needs.release.result }}
           SHOULD_PUBLISH: ${{ needs.release.outputs.should_publish }}
@@ -441,9 +415,6 @@ jobs:
               if [[ "$RETRY_RESULT" != "success" ]]; then
                 fail "Manual retry source selection concluded $RETRY_RESULT"
               fi
-              if [[ "$RELEASE_PR_CI_RESULT" != "skipped" ]]; then
-                fail "Manual retry expected release PR CI to be skipped, got $RELEASE_PR_CI_RESULT"
-              fi
               if [[ "$SHOULD_PUBLISH" != "true" ]]; then
                 fail "Manual retry did not select a release to publish"
               fi
@@ -455,21 +426,6 @@ jobs:
               if [[ "$RETRY_RESULT" != "skipped" ]]; then
                 fail "Automatic release expected retry selection to be skipped, got $RETRY_RESULT"
               fi
-              case "$AUTOMATIC_PRS_CREATED" in
-                true)
-                  if [[ "$RELEASE_PR_CI_RESULT" != "success" ]]; then
-                    fail "Release PR CI concluded $RELEASE_PR_CI_RESULT"
-                  fi
-                  ;;
-                false)
-                  if [[ "$RELEASE_PR_CI_RESULT" != "skipped" ]]; then
-                    fail "No-PR run expected release PR CI to be skipped, got $RELEASE_PR_CI_RESULT"
-                  fi
-                  ;;
-                *)
-                  fail "Invalid prs_created output: $AUTOMATIC_PRS_CREATED"
-                  ;;
-              esac
               ;;
             *)
               fail "Unexpected release event: $EVENT_NAME"


### PR DESCRIPTION
## Summary

- mint a repository-scoped installation token for the `openai-sdks` GitHub App from the `release` environment
- pass that token to Release Please and disable the release job's built-in `GITHUB_TOKEN` permissions
- remove the manual release-PR CI dispatch workaround now that app-authored branch pushes and pull-request events trigger Actions normally
- simplify API compatibility CI back to normal pull-request events

Java equivalent of openai/openai-python#3577.

## Validation

- `git diff --check`
- `actionlint` v1.7.7 on `.github/workflows/ci.yml` and `.github/workflows/create-releases.yml`
- YAML parse of both changed workflows
- `./scripts/lint` attempted, but local execution is blocked because this machine only has JDK 25 installed (Gradle fails during configuration with `25.0.2`); CI runs with JDK 21
