### PR TITLE
fix: preserve shared resources across derived clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -1343,12 +1343,12 @@ import java.util.concurrent.CompletableFuture;
 
 CompletableFuture<JobListPageAsync> pageFuture = client.async().fineTuning().jobs().list();
 
-pageFuture.thenRun(page -> page.autoPager().subscribe(job -> {
+pageFuture.thenAccept(page -> page.autoPager().subscribe(job -> {
     System.out.println(job);
 }));
 
 // If you need to handle errors or completion of the stream
-pageFuture.thenRun(page -> page.autoPager().subscribe(new AsyncStreamResponse.Handler<>() {
+pageFuture.thenAccept(page -> page.autoPager().subscribe(new AsyncStreamResponse.Handler<>() {
     @Override
     public void onNext(FineTuningJob job) {
         System.out.println(job);
@@ -1366,7 +1366,7 @@ pageFuture.thenRun(page -> page.autoPager().subscribe(new AsyncStreamResponse.Ha
 }));
 
 // Or use futures
-pageFuture.thenRun(page -> page.autoPager()
+pageFuture.thenAccept(page -> page.autoPager()
     .subscribe(job -> {
         System.out.println(job);
     })

--- a/openai-java-core/src/main/kotlin/com/openai/client/OpenAIClientAsyncImpl.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/client/OpenAIClientAsyncImpl.kt
@@ -234,7 +234,10 @@ class OpenAIClientAsyncImpl(private val clientOptions: ClientOptions) : OpenAICl
 
     override fun videos(): VideoServiceAsync = videos
 
-    override fun close() = clientOptions.close()
+    override fun close() {
+        clientOptionsWithUserAgent.close()
+        if (clientOptionsWithUserAgent !== clientOptions) clientOptions.close()
+    }
 
     class WithRawResponseImpl internal constructor(private val clientOptions: ClientOptions) :
         OpenAIClientAsync.WithRawResponse {

--- a/openai-java-core/src/main/kotlin/com/openai/client/OpenAIClientImpl.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/client/OpenAIClientImpl.kt
@@ -213,7 +213,10 @@ class OpenAIClientImpl(private val clientOptions: ClientOptions) : OpenAIClient 
 
     override fun videos(): VideoService = videos
 
-    override fun close() = clientOptions.close()
+    override fun close() {
+        clientOptionsWithUserAgent.close()
+        if (clientOptionsWithUserAgent !== clientOptions) clientOptions.close()
+    }
 
     class WithRawResponseImpl internal constructor(private val clientOptions: ClientOptions) :
         OpenAIClient.WithRawResponse {

--- a/openai-java-core/src/main/kotlin/com/openai/core/ClientOptions.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/core/ClientOptions.kt
@@ -30,8 +30,58 @@ import java.util.concurrent.Executor
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.ThreadFactory
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
 import kotlin.jvm.optionals.getOrNull
+
+private class ClientOptionsResource(private val close: () -> Unit) {
+    private var references = 1
+    private var closed = false
+
+    @Synchronized
+    fun retain() {
+        check(!closed) { "Cannot retain a closed client resource" }
+        references++
+    }
+
+    fun release() {
+        val shouldClose =
+            synchronized(this) {
+                check(references > 0) { "Client resource released too many times" }
+                references--
+                if (references == 0) {
+                    closed = true
+                    true
+                } else false
+            }
+
+        if (shouldClose) close()
+    }
+}
+
+private class ClientOptionsResources(
+    val httpClient: ClientOptionsResource,
+    val httpRequestAuthenticator: ClientOptionsResource?,
+    val workloadIdentityAuth: ClientOptionsResource?,
+    val streamHandlerExecutor: ClientOptionsResource,
+    val sleeper: ClientOptionsResource,
+) {
+    fun release() {
+        httpRequestAuthenticator?.release()
+        workloadIdentityAuth?.release()
+        httpClient.release()
+        streamHandlerExecutor.release()
+        sleeper.release()
+    }
+}
+
+private class ClientOptionsCloseAction(private val resources: ClientOptionsResources) : () -> Unit {
+    private val closed = AtomicBoolean(false)
+
+    override fun invoke() {
+        if (closed.compareAndSet(false, true)) resources.release()
+    }
+}
 
 /** A class representing the SDK client configuration. */
 class ClientOptions
@@ -141,12 +191,16 @@ private constructor(
     private val organization: String?,
     private val project: String?,
     private val webhookSecret: String?,
+    private val resources: ClientOptionsResources,
 ) {
+
+    private val closeAction = ClientOptionsCloseAction(resources)
 
     init {
         if (checkJacksonVersionCompatibility) {
             checkJacksonVersionCompatibility()
         }
+        closeWhenPhantomReachable(this, closeAction)
     }
 
     /**
@@ -217,6 +271,11 @@ private constructor(
         private var project: String? = null
         private var webhookSecret: String? = null
         private var workloadIdentity: WorkloadIdentity? = null
+        private var httpClientResource: ClientOptionsResource? = null
+        private var httpRequestAuthenticatorResource: ClientOptionsResource? = null
+        private var workloadIdentityAuthResource: ClientOptionsResource? = null
+        private var streamHandlerExecutorResource: ClientOptionsResource? = null
+        private var sleeperResource: ClientOptionsResource? = null
 
         @JvmSynthetic
         internal fun from(clientOptions: ClientOptions) = apply {
@@ -226,6 +285,11 @@ private constructor(
             jsonMapper = clientOptions.jsonMapper
             streamHandlerExecutor = clientOptions.streamHandlerExecutor
             sleeper = clientOptions.sleeper
+            httpClientResource = clientOptions.resources.httpClient
+            httpRequestAuthenticatorResource = clientOptions.resources.httpRequestAuthenticator
+            workloadIdentityAuthResource = clientOptions.resources.workloadIdentityAuth
+            streamHandlerExecutorResource = clientOptions.resources.streamHandlerExecutor
+            sleeperResource = clientOptions.resources.sleeper
             clock = clientOptions.clock
             baseUrl = clientOptions.baseUrl
             headers = clientOptions.headers.toBuilder()
@@ -256,6 +320,7 @@ private constructor(
          */
         fun httpClient(httpClient: HttpClient) = apply {
             this.httpClient = PhantomReachableClosingHttpClient(httpClient)
+            this.httpClientResource = null
         }
 
         /**
@@ -269,6 +334,7 @@ private constructor(
             this.httpRequestAuthenticator =
                 if (httpRequestAuthenticator == null) null
                 else PhantomReachableClosingHttpRequestAuthenticator(httpRequestAuthenticator)
+            this.httpRequestAuthenticatorResource = null
         }
 
         /**
@@ -302,6 +368,7 @@ private constructor(
                 if (streamHandlerExecutor is ExecutorService)
                     PhantomReachableExecutorService(streamHandlerExecutor)
                 else streamHandlerExecutor
+            this.streamHandlerExecutorResource = null
         }
 
         /**
@@ -313,7 +380,10 @@ private constructor(
          *
          * This class takes ownership of the sleeper and closes it when closed.
          */
-        fun sleeper(sleeper: Sleeper) = apply { this.sleeper = PhantomReachableSleeper(sleeper) }
+        fun sleeper(sleeper: Sleeper) = apply {
+            this.sleeper = PhantomReachableSleeper(sleeper)
+            this.sleeperResource = null
+        }
 
         /**
          * The clock to use for operations that require timing, like retries.
@@ -393,6 +463,7 @@ private constructor(
         fun apiKey(apiKey: String?) = apply {
             this.apiKey = apiKey
             this.credential = apiKey?.let { BearerTokenCredential.create(it) }
+            this.workloadIdentityAuthResource = null
         }
 
         /** Alias for calling [Builder.apiKey] with `apiKey.orElse(null)`. */
@@ -406,6 +477,7 @@ private constructor(
         fun credential(credential: Credential) = apply {
             this.apiKey = null
             this.credential = credential
+            this.workloadIdentityAuthResource = null
         }
 
         fun azureServiceVersion(azureServiceVersion: AzureOpenAIServiceVersion) = apply {
@@ -434,6 +506,7 @@ private constructor(
 
         fun workloadIdentity(workloadIdentity: WorkloadIdentity?) = apply {
             this.workloadIdentity = workloadIdentity
+            this.workloadIdentityAuthResource = null
         }
 
         /** Alias for calling [Builder.workloadIdentity] with `workloadIdentity.orElse(null)`. */
@@ -701,6 +774,31 @@ private constructor(
             val effectiveWorkloadIdentityAuth =
                 (credential as? WorkloadIdentityCredential)?.getAuth()
 
+            val resources =
+                ClientOptionsResources(
+                    httpClient =
+                        httpClientResource?.also { it.retain() }
+                            ?: ClientOptionsResource { httpClient.close() },
+                    httpRequestAuthenticator =
+                        httpRequestAuthenticatorResource?.also { it.retain() }
+                            ?: httpRequestAuthenticator?.let {
+                                ClientOptionsResource { it.close() }
+                            },
+                    workloadIdentityAuth =
+                        workloadIdentityAuthResource?.also { it.retain() }
+                            ?: effectiveWorkloadIdentityAuth?.let {
+                                ClientOptionsResource { it.close() }
+                            },
+                    streamHandlerExecutor =
+                        streamHandlerExecutorResource?.also { it.retain() }
+                            ?: ClientOptionsResource {
+                                (streamHandlerExecutor as? ExecutorService)?.shutdown()
+                            },
+                    sleeper =
+                        sleeperResource?.also { it.retain() }
+                            ?: ClientOptionsResource { sleeper.close() },
+                )
+
             val loggingDelegate =
                 if (httpRequestAuthenticator != null) httpClient
                 else
@@ -756,6 +854,7 @@ private constructor(
                 organization,
                 project,
                 webhookSecret,
+                resources,
             )
         }
     }
@@ -770,11 +869,7 @@ private constructor(
      * releases threads and connections if they remain idle, but if you are writing an application
      * that needs to aggressively release unused resources, then you may call this method.
      */
-    fun close() {
-        httpClient.close()
-        (streamHandlerExecutor as? ExecutorService)?.shutdown()
-        sleeper.close()
-    }
+    fun close() = closeAction()
 
     @JvmSynthetic
     internal fun securityHeaders(security: SecurityOptions): Headers {

--- a/openai-java-core/src/main/kotlin/com/openai/core/ClientOptions.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/core/ClientOptions.kt
@@ -200,7 +200,9 @@ private constructor(
         if (checkJacksonVersionCompatibility) {
             checkJacksonVersionCompatibility()
         }
-        closeWhenPhantomReachable(this, closeAction)
+        // Async request futures retain the HTTP client chain, not this options object. Observe the
+        // chain so phantom cleanup cannot close resources while an in-flight request still uses it.
+        closeWhenPhantomReachable(httpClient, closeAction)
     }
 
     /**

--- a/openai-java-core/src/test/kotlin/com/openai/core/ClientOptionsTest.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/core/ClientOptionsTest.kt
@@ -7,12 +7,15 @@ import com.openai.auth.SubjectTokenProvider
 import com.openai.auth.SubjectTokenType
 import com.openai.auth.WorkloadIdentity
 import com.openai.azure.credential.AzureApiKeyCredential
+import com.openai.client.OpenAIClientAsyncImpl
+import com.openai.client.OpenAIClientImpl
 import com.openai.core.http.HttpClient
 import com.openai.core.http.HttpRequest
 import com.openai.core.http.HttpRequestAuthenticator
 import com.openai.credential.BearerTokenCredential
 import com.openai.credential.WorkloadIdentityCredential
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ExecutorService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -20,6 +23,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 
 @ExtendWith(MockitoExtension::class)
@@ -208,6 +212,93 @@ internal class ClientOptionsTest {
 
         assertThat(clientOptions.headers.values("OpenAI-Organization"))
             .containsExactly("another My Organization")
+    }
+
+    @Test
+    fun toBuilder_closingDerivedOptionsDoesNotCloseSharedResources() {
+        val executor = mock<ExecutorService>()
+        val sleeper = mock<Sleeper>()
+        val original =
+            ClientOptions.builder()
+                .httpClient(httpClient)
+                .streamHandlerExecutor(executor)
+                .sleeper(sleeper)
+                .apiKey("My API Key")
+                .build()
+        val derived = original.toBuilder().baseUrl("https://example.test").build()
+
+        derived.close()
+
+        verify(httpClient, never()).close()
+        verify(executor, never()).shutdown()
+        verify(sleeper, never()).close()
+
+        original.close()
+
+        verify(httpClient).close()
+        verify(executor).shutdown()
+        verify(sleeper).close()
+    }
+
+    @Test
+    fun toBuilder_closingOriginalOptionsDoesNotCloseResourcesUsedByDerivedOptions() {
+        val executor = mock<ExecutorService>()
+        val sleeper = mock<Sleeper>()
+        val original =
+            ClientOptions.builder()
+                .httpClient(httpClient)
+                .streamHandlerExecutor(executor)
+                .sleeper(sleeper)
+                .apiKey("My API Key")
+                .build()
+        val derived = original.toBuilder().build()
+
+        original.close()
+
+        verify(httpClient, never()).close()
+        verify(executor, never()).shutdown()
+        verify(sleeper, never()).close()
+
+        derived.close()
+        derived.close()
+
+        verify(httpClient, times(1)).close()
+        verify(executor, times(1)).shutdown()
+        verify(sleeper, times(1)).close()
+    }
+
+    @Test
+    fun toBuilder_replacingHttpClientOnlyClosesReplacement() {
+        val replacement = mock<HttpClient>()
+        val original = ClientOptions.builder().httpClient(httpClient).apiKey("My API Key").build()
+        val derived = original.toBuilder().httpClient(replacement).build()
+
+        derived.close()
+
+        verify(replacement).close()
+        verify(httpClient, never()).close()
+
+        original.close()
+
+        verify(httpClient).close()
+    }
+
+    @Test
+    fun syncClientCloseClosesInternalUserAgentOptions() {
+        val options = ClientOptions.builder().httpClient(httpClient).apiKey("My API Key").build()
+
+        OpenAIClientImpl(options).close()
+
+        verify(httpClient).close()
+    }
+
+    @Test
+    fun asyncClientCloseClosesInternalUserAgentOptions() {
+        val options = ClientOptions.builder().httpClient(httpClient).apiKey("My API Key").build()
+
+        OpenAIClientAsyncImpl(options).close()
+
+        verify(httpClient).close()
     }
 
     @Test

--- a/openai-java-core/src/test/kotlin/com/openai/core/ClientOptionsTest.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/core/ClientOptionsTest.kt
@@ -10,21 +10,27 @@ import com.openai.azure.credential.AzureApiKeyCredential
 import com.openai.client.OpenAIClientAsyncImpl
 import com.openai.client.OpenAIClientImpl
 import com.openai.core.http.HttpClient
+import com.openai.core.http.HttpMethod
 import com.openai.core.http.HttpRequest
 import com.openai.core.http.HttpRequestAuthenticator
+import com.openai.core.http.HttpResponse
 import com.openai.credential.BearerTokenCredential
 import com.openai.credential.WorkloadIdentityCredential
+import java.lang.ref.WeakReference
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ExecutorService
+import java.util.concurrent.TimeUnit
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 
 @ExtendWith(MockitoExtension::class)
 internal class ClientOptionsTest {
@@ -338,6 +344,56 @@ internal class ClientOptionsTest {
         verify(authenticator, never()).close()
         // This exists so that `clientOptions` is still reachable.
         assertThat(clientOptions).isEqualTo(clientOptions)
+    }
+
+    @Test
+    fun inFlightAsyncRequest_keepsResourcesOpenWhenClientOptionsIsGarbageCollected() {
+        val pendingResponse = CompletableFuture<HttpResponse>()
+        val sleeper = mock<Sleeper>()
+        val executor = mock<ExecutorService>()
+        whenever(
+                httpClient.executeAsync(
+                    any<HttpRequest>(),
+                    any(),
+                )
+            )
+            .thenReturn(pendingResponse)
+
+        val (requestFuture, optionsReference) =
+            startPendingAsyncRequest(httpClient, sleeper, executor)
+
+        val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+        while (System.nanoTime() < deadline && optionsReference.get() != null) {
+            System.gc()
+            Thread.sleep(10)
+        }
+
+        assertThat(optionsReference.get()).isNull()
+        verify(httpClient, never()).close()
+        verify(sleeper, never()).close()
+        verify(executor, never()).shutdown()
+
+        requestFuture.cancel(false)
+    }
+
+    private fun startPendingAsyncRequest(
+        httpClient: HttpClient,
+        sleeper: Sleeper,
+        executor: ExecutorService,
+    ): Pair<CompletableFuture<HttpResponse>, WeakReference<ClientOptions>> {
+        val clientOptions =
+            ClientOptions.builder()
+                .httpClient(httpClient)
+                .sleeper(sleeper)
+                .streamHandlerExecutor(executor)
+                .build()
+        val request =
+            HttpRequest.builder()
+                .method(HttpMethod.GET)
+                .baseUrl("https://example.com")
+                .build()
+        val future = clientOptions.httpClient.executeAsync(request)
+        return future to WeakReference(clientOptions)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- preserve shared HTTP, executor, sleeper, authenticator, and workload-identity resources across `ClientOptions.toBuilder()` / `withOptions()` views
- close shared resources only after the last owning options/client is closed, with idempotent explicit and phantom-reachability cleanup
- close internal user-agent option views from sync and async clients
- add regression coverage for both close orders, replacement HTTP clients, and sync/async client shutdown

## Testing

- `git diff --check`
- `./gradlew :openai-java-core:test --tests com.openai.core.ClientOptionsTest --no-daemon --console=plain` (timed out without diagnostics in the local environment)
- `./gradlew :openai-java-core:compileKotlin --no-daemon --max-workers=1 --offline --console=plain` (timed out without diagnostics in the local environment)

Fixes #850