### PR TITLE
fix(api): clarify audio upload metadata requirements

### DIFF
--- a/.castiron.stats.yml
+++ b/.castiron.stats.yml
@@ -1,6 +1,6 @@
 schema_version: 1
-generation_id: 35daab74-8d4e-4d6f-9c38-c54f7b82e45d
-openapi_spec_hash: 8d5c14d02f8cc28de343933fae3a9c28
-openapi_transformed_spec_hash: cc042503b90491f4f162ce95fae87c36
+generation_id: 8e78be37-d321-40c4-8a75-6a8d344f7616
+openapi_spec_hash: 1faf0319c407c6534ef7c381614afbb6
+openapi_transformed_spec_hash: 53eff50caa9d18046e4ff0615bc7512d
 config_hash: 4617b0962f16d328804312ac81aac630
-codegen_sha: 4e53657fc2ec8e3d75183902427cdf95db8462a0
+codegen_sha: dd2f9827bb2d421d8a4599a221810f35651e1bc9

--- a/api_reference/openapi.transformed.yml
+++ b/api_reference/openapi.transformed.yml
@@ -34062,6 +34062,7 @@ components:
         file:
           description: |
             The audio file object (not file name) to transcribe, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.
+            The request must include enough format metadata for the file to be identified. We recommend an extension-bearing filename and an appropriate content type.
           type: string
           x-oaiTypeLabel: file
           format: binary
@@ -34369,7 +34370,7 @@ components:
       properties:
         file:
           description: |
-            The audio file object (not file name) translate, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.
+            The audio file object (not file name) translate, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm. The request must include enough format metadata for the file to be identified. We recommend an extension-bearing filename and an appropriate content type.
           type: string
           x-oaiTypeLabel: file
           format: binary

--- a/openai-java-core/src/main/kotlin/com/openai/models/audio/transcriptions/TranscriptionCreateParams.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/models/audio/transcriptions/TranscriptionCreateParams.kt
@@ -49,7 +49,9 @@ private constructor(
 
     /**
      * The audio file object (not file name) to transcribe, in one of these formats: flac, mp3, mp4,
-     * mpeg, mpga, m4a, ogg, wav, or webm.
+     * mpeg, mpga, m4a, ogg, wav, or webm. The request must include enough format metadata for the
+     * file to be identified. We recommend an extension-bearing filename and an appropriate content
+     * type.
      *
      * @throws OpenAIInvalidDataException if the JSON field has an unexpected type or is
      *   unexpectedly missing or null (e.g. if the server responded with an unexpected value).
@@ -339,7 +341,9 @@ private constructor(
 
         /**
          * The audio file object (not file name) to transcribe, in one of these formats: flac, mp3,
-         * mp4, mpeg, mpga, m4a, ogg, wav, or webm.
+         * mp4, mpeg, mpga, m4a, ogg, wav, or webm. The request must include enough format metadata
+         * for the file to be identified. We recommend an extension-bearing filename and an
+         * appropriate content type.
          */
         fun file(file: InputStream) = apply { body.file(file) }
 
@@ -354,13 +358,17 @@ private constructor(
 
         /**
          * The audio file object (not file name) to transcribe, in one of these formats: flac, mp3,
-         * mp4, mpeg, mpga, m4a, ogg, wav, or webm.
+         * mp4, mpeg, mpga, m4a, ogg, wav, or webm. The request must include enough format metadata
+         * for the file to be identified. We recommend an extension-bearing filename and an
+         * appropriate content type.
          */
         fun file(file: ByteArray) = apply { body.file(file) }
 
         /**
          * The audio file object (not file name) to transcribe, in one of these formats: flac, mp3,
-         * mp4, mpeg, mpga, m4a, ogg, wav, or webm.
+         * mp4, mpeg, mpga, m4a, ogg, wav, or webm. The request must include enough format metadata
+         * for the file to be identified. We recommend an extension-bearing filename and an
+         * appropriate content type.
          */
         fun file(path: Path) = apply { body.file(path) }
 
@@ -838,7 +846,9 @@ private constructor(
 
         /**
          * The audio file object (not file name) to transcribe, in one of these formats: flac, mp3,
-         * mp4, mpeg, mpga, m4a, ogg, wav, or webm.
+         * mp4, mpeg, mpga, m4a, ogg, wav, or webm. The request must include enough format metadata
+         * for the file to be identified. We recommend an extension-bearing filename and an
+         * appropriate content type.
          *
          * @throws OpenAIInvalidDataException if the JSON field has an unexpected type or is
          *   unexpectedly missing or null (e.g. if the server responded with an unexpected value).
@@ -1168,7 +1178,9 @@ private constructor(
 
             /**
              * The audio file object (not file name) to transcribe, in one of these formats: flac,
-             * mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.
+             * mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm. The request must include enough format
+             * metadata for the file to be identified. We recommend an extension-bearing filename
+             * and an appropriate content type.
              */
             fun file(file: InputStream) = file(MultipartField.of(file))
 
@@ -1183,13 +1195,17 @@ private constructor(
 
             /**
              * The audio file object (not file name) to transcribe, in one of these formats: flac,
-             * mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.
+             * mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm. The request must include enough format
+             * metadata for the file to be identified. We recommend an extension-bearing filename
+             * and an appropriate content type.
              */
             fun file(file: ByteArray) = file(file.inputStream())
 
             /**
              * The audio file object (not file name) to transcribe, in one of these formats: flac,
-             * mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.
+             * mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm. The request must include enough format
+             * metadata for the file to be identified. We recommend an extension-bearing filename
+             * and an appropriate content type.
              */
             fun file(path: Path) =
                 file(

--- a/openai-java-core/src/main/kotlin/com/openai/models/audio/translations/TranslationCreateParams.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/models/audio/translations/TranslationCreateParams.kt
@@ -36,7 +36,9 @@ private constructor(
 
     /**
      * The audio file object (not file name) translate, in one of these formats: flac, mp3, mp4,
-     * mpeg, mpga, m4a, ogg, wav, or webm.
+     * mpeg, mpga, m4a, ogg, wav, or webm. The request must include enough format metadata for the
+     * file to be identified. We recommend an extension-bearing filename and an appropriate content
+     * type.
      *
      * @throws OpenAIInvalidDataException if the JSON field has an unexpected type or is
      *   unexpectedly missing or null (e.g. if the server responded with an unexpected value).
@@ -173,7 +175,9 @@ private constructor(
 
         /**
          * The audio file object (not file name) translate, in one of these formats: flac, mp3, mp4,
-         * mpeg, mpga, m4a, ogg, wav, or webm.
+         * mpeg, mpga, m4a, ogg, wav, or webm. The request must include enough format metadata for
+         * the file to be identified. We recommend an extension-bearing filename and an appropriate
+         * content type.
          */
         fun file(file: InputStream) = apply { body.file(file) }
 
@@ -188,13 +192,17 @@ private constructor(
 
         /**
          * The audio file object (not file name) translate, in one of these formats: flac, mp3, mp4,
-         * mpeg, mpga, m4a, ogg, wav, or webm.
+         * mpeg, mpga, m4a, ogg, wav, or webm. The request must include enough format metadata for
+         * the file to be identified. We recommend an extension-bearing filename and an appropriate
+         * content type.
          */
         fun file(file: ByteArray) = apply { body.file(file) }
 
         /**
          * The audio file object (not file name) translate, in one of these formats: flac, mp3, mp4,
-         * mpeg, mpga, m4a, ogg, wav, or webm.
+         * mpeg, mpga, m4a, ogg, wav, or webm. The request must include enough format metadata for
+         * the file to be identified. We recommend an extension-bearing filename and an appropriate
+         * content type.
          */
         fun file(path: Path) = apply { body.file(path) }
 
@@ -439,7 +447,9 @@ private constructor(
 
         /**
          * The audio file object (not file name) translate, in one of these formats: flac, mp3, mp4,
-         * mpeg, mpga, m4a, ogg, wav, or webm.
+         * mpeg, mpga, m4a, ogg, wav, or webm. The request must include enough format metadata for
+         * the file to be identified. We recommend an extension-bearing filename and an appropriate
+         * content type.
          *
          * @throws OpenAIInvalidDataException if the JSON field has an unexpected type or is
          *   unexpectedly missing or null (e.g. if the server responded with an unexpected value).
@@ -576,7 +586,9 @@ private constructor(
 
             /**
              * The audio file object (not file name) translate, in one of these formats: flac, mp3,
-             * mp4, mpeg, mpga, m4a, ogg, wav, or webm.
+             * mp4, mpeg, mpga, m4a, ogg, wav, or webm. The request must include enough format
+             * metadata for the file to be identified. We recommend an extension-bearing filename
+             * and an appropriate content type.
              */
             fun file(file: InputStream) = file(MultipartField.of(file))
 
@@ -591,13 +603,17 @@ private constructor(
 
             /**
              * The audio file object (not file name) translate, in one of these formats: flac, mp3,
-             * mp4, mpeg, mpga, m4a, ogg, wav, or webm.
+             * mp4, mpeg, mpga, m4a, ogg, wav, or webm. The request must include enough format
+             * metadata for the file to be identified. We recommend an extension-bearing filename
+             * and an appropriate content type.
              */
             fun file(file: ByteArray) = file(file.inputStream())
 
             /**
              * The audio file object (not file name) translate, in one of these formats: flac, mp3,
-             * mp4, mpeg, mpga, m4a, ogg, wav, or webm.
+             * mp4, mpeg, mpga, m4a, ogg, wav, or webm. The request must include enough format
+             * metadata for the file to be identified. We recommend an extension-bearing filename
+             * and an appropriate content type.
              */
             fun file(path: Path) =
                 file(


### PR DESCRIPTION
## Summary

Regenerates the Java SDK from the latest OpenAPI input for the audio upload documentation change.

- Clarifies that transcription and translation uploads must include enough metadata for the file format to be identified.
- Recommends an extension-bearing filename and an appropriate content type.
- Updates generated Kotlin parameter documentation, the transformed OpenAPI document, and Castiron provenance.

This is documentation-only; runtime behavior and exported type shapes are unchanged.

## Source

- Originating API change: [openai/openai#1270941](https://github.com/openai/openai/pull/1270941)
- OpenAPI input: [openai/openai-openapi@577fa922](https://github.com/openai/openai-openapi/commit/577fa92299e000af1616f3be1fec740e3383a86a)

## Validation

- Rebased directly onto the current public `main`
- Every changed file matches the Castiron-generated candidate
- `git diff --check`
- Thermo-nuclear code-quality review