### PR TITLE
docs(api): describe response stream event unions

### DIFF
--- a/.castiron.stats.yml
+++ b/.castiron.stats.yml
@@ -1,6 +1,6 @@
 schema_version: 1
-generation_id: 44af854c-977e-4576-b575-1e97d7b130db
-openapi_spec_hash: 15849b9fe3deb3c72da0825905cc0ad9
-openapi_transformed_spec_hash: 9a60ddf3a1c752e15eb43fce666d6da8
+generation_id: a68d69bb-f8a7-4e0c-8eea-a2c0215d752b
+openapi_spec_hash: 143aa2ed6323d61a1834c74044e29d30
+openapi_transformed_spec_hash: 5af6fa4fd590fcc79ba2fdd69b9f7b82
 config_hash: fcda4ecfe265daddba6fad25a8504a3f
-codegen_sha: b320692e9103694cfc5d48b1de7c0cdf96f7b0e6
+codegen_sha: fb74fa30832d64dc32800aa4f537b047086fffd9

--- a/api_reference/openapi.transformed.yml
+++ b/api_reference/openapi.transformed.yml
@@ -54296,6 +54296,7 @@ components:
             "sequence_number": 1
           }
     ResponseStreamEvent:
+      description: Event emitted while a response is streamed.
       anyOf:
       - $ref: '#/components/schemas/ResponseAudioDeltaEvent'
       - $ref: '#/components/schemas/ResponseAudioDoneEvent'
@@ -77148,6 +77149,7 @@ components:
               when the originating `response.create` event supplied a
               `stream_id`.
     BetaResponseStreamEvent:
+      description: Event emitted while a response is streamed.
       anyOf:
       - $ref: '#/components/schemas/BetaResponseAudioDeltaEvent'
       - $ref: '#/components/schemas/BetaResponseAudioDoneEvent'

--- a/openai-java-core/src/main/kotlin/com/openai/models/beta/responses/BetaResponseStreamEvent.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/models/beta/responses/BetaResponseStreamEvent.kt
@@ -18,7 +18,7 @@ import java.util.Objects
 import java.util.Optional
 import kotlin.jvm.optionals.getOrNull
 
-/** Emitted when there is a partial audio response. */
+/** Event emitted while a response is streamed. */
 @JsonDeserialize(using = BetaResponseStreamEvent.Deserializer::class)
 @JsonSerialize(using = BetaResponseStreamEvent.Serializer::class)
 class BetaResponseStreamEvent

--- a/openai-java-core/src/main/kotlin/com/openai/models/responses/ResponseStreamEvent.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/models/responses/ResponseStreamEvent.kt
@@ -18,7 +18,7 @@ import java.util.Objects
 import java.util.Optional
 import kotlin.jvm.optionals.getOrNull
 
-/** Emitted when there is a partial audio response. */
+/** Event emitted while a response is streamed. */
 @JsonDeserialize(using = ResponseStreamEvent.Deserializer::class)
 @JsonSerialize(using = ResponseStreamEvent.Serializer::class)
 class ResponseStreamEvent


### PR DESCRIPTION
## Summary
- Accurately describe stable and beta Responses streaming event unions.
- Refresh generated OpenAPI reference and Castiron provenance from the exact upstream source.
- Source: https://github.com/openai/openai/pull/1277036
- OpenAPI commit: bc61c5299f7f6fdd6061ccad0ac7e4ec0f659098

## Validation
- Castiron local dry run and exact generated-candidate patch comparison.
- git diff --check and transformed OpenAPI reference hash verified.