### PR TITLE
Automatic module names

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ implementation("com.openai:openai-java-bedrock:4.51.0")
 <!-- x-release-please-end -->
 
 ```java
+import com.openai.bedrock.BedrockOpenAIOkHttpClient;
 import com.openai.client.OpenAIClient;
-import com.openai.client.okhttp.BedrockOpenAIOkHttpClient;
 
 // Uses the standard AWS credential chain, including environment credentials,
 // ~/.aws/credentials, AWS_PROFILE, workload roles, and instance metadata.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,21 @@ implementation("com.openai:openai-java:4.51.0")
 The framework-neutral SDK artifacts require Java 8 or later. Runtime floors and lifecycle states
 are declared per artifact in the [Java version support policy](docs/version-support-policy.md).
 
+### Java Platform Module System
+
+The published artifacts are not modular JARs, but each one declares a stable `Automatic-Module-Name`
+so it can be placed on the module path:
+
+| Artifact | Module name |
+| --- | --- |
+| `openai-java` | `com.openai` |
+| `openai-java-core` | `com.openai.core` |
+| `openai-java-client-okhttp` | `com.openai.client.okhttp` |
+| `openai-java-bedrock` | `com.openai.bedrock` |
+
+Each package is contained in exactly one artifact, so these modules can be resolved together on the
+module path.
+
 ## Usage
 
 > [!TIP]

--- a/bedrock.md
+++ b/bedrock.md
@@ -29,8 +29,8 @@ implementation("com.openai:openai-java-bedrock:4.51.0")
 Configure AWS credentials as you normally would, then provide the region:
 
 ```java
+import com.openai.bedrock.BedrockOpenAIOkHttpClient;
 import com.openai.client.OpenAIClient;
-import com.openai.client.okhttp.BedrockOpenAIOkHttpClient;
 
 OpenAIClient client = BedrockOpenAIOkHttpClient.builder()
         .awsRegion("us-east-1")

--- a/buildSrc/src/main/kotlin/openai.publish.gradle.kts
+++ b/buildSrc/src/main/kotlin/openai.publish.gradle.kts
@@ -23,6 +23,31 @@ repositories {
     mavenCentral()
 }
 
+// Stable JPMS module names for the published artifacts, derived from the `com.openai` group ID and
+// the packages each artifact ships. Without them, consumers on the module path get a name derived
+// from the JAR file name, which is neither namespaced nor stable across renames. Treat these as
+// public API: once released, changing a name breaks every consumer that `requires` it.
+val automaticModuleNames =
+    mapOf(
+        // Aggregator artifact: ships no packages of its own, so it takes the group's root name.
+        "openai-java" to "com.openai",
+        // Ships `com.openai.core` along with the rest of the `com.openai` namespace.
+        "openai-java-core" to "com.openai.core",
+        "openai-java-client-okhttp" to "com.openai.client.okhttp",
+        "openai-java-bedrock" to "com.openai.bedrock",
+    )
+
+val automaticModuleName =
+    checkNotNull(automaticModuleNames[project.name]) {
+        "${project.name} is published but has no automatic module name"
+    }
+
+pluginManager.withPlugin("java") {
+    tasks.named<Jar>("jar") {
+        manifest { attributes("Automatic-Module-Name" to automaticModuleName) }
+    }
+}
+
 extra["signingInMemoryKey"] = System.getenv("GPG_SIGNING_KEY")
 extra["signingInMemoryKeyId"] = System.getenv("GPG_SIGNING_KEY_ID")
 extra["signingInMemoryKeyPassword"] = System.getenv("GPG_SIGNING_PASSWORD")

--- a/openai-java-bedrock/src/main/kotlin/com/openai/bedrock/BedrockOpenAIOkHttpClient.kt
+++ b/openai-java-bedrock/src/main/kotlin/com/openai/bedrock/BedrockOpenAIOkHttpClient.kt
@@ -1,9 +1,8 @@
-package com.openai.client.okhttp
+package com.openai.bedrock
 
 import com.fasterxml.jackson.databind.json.JsonMapper
-import com.openai.bedrock.BedrockAuthOptions
-import com.openai.bedrock.resolve
 import com.openai.client.OpenAIClient
+import com.openai.client.okhttp.OpenAIOkHttpClient
 import com.openai.core.LogLevel
 import com.openai.core.Sleeper
 import com.openai.core.Timeout

--- a/openai-java-bedrock/src/test/kotlin/com/openai/bedrock/BedrockOpenAIOkHttpClientTest.kt
+++ b/openai-java-bedrock/src/test/kotlin/com/openai/bedrock/BedrockOpenAIOkHttpClientTest.kt
@@ -1,4 +1,4 @@
-package com.openai.client.okhttp
+package com.openai.bedrock
 
 import com.github.tomakehurst.wiremock.client.WireMock.findAll
 import com.github.tomakehurst.wiremock.client.WireMock.get

--- a/openai-java-example/src/main/java/com/openai/example/BedrockResponsesExample.java
+++ b/openai-java-example/src/main/java/com/openai/example/BedrockResponsesExample.java
@@ -1,7 +1,7 @@
 package com.openai.example;
 
+import com.openai.bedrock.BedrockOpenAIOkHttpClient;
 import com.openai.client.OpenAIClient;
-import com.openai.client.okhttp.BedrockOpenAIOkHttpClient;
 import com.openai.models.responses.ResponseCreateParams;
 
 public final class BedrockResponsesExample {

--- a/openai-java-example/src/main/java/com/openai/example/BedrockResponsesStreamingAsyncExample.java
+++ b/openai-java-example/src/main/java/com/openai/example/BedrockResponsesStreamingAsyncExample.java
@@ -1,7 +1,7 @@
 package com.openai.example;
 
+import com.openai.bedrock.BedrockOpenAIOkHttpClient;
 import com.openai.client.OpenAIClientAsync;
-import com.openai.client.okhttp.BedrockOpenAIOkHttpClient;
 import com.openai.models.responses.ResponseCreateParams;
 
 public final class BedrockResponsesStreamingAsyncExample {

--- a/openai-java-runtime-compatibility/src/main/java/com/openai/compatibility/BedrockRuntimeProbe.java
+++ b/openai-java-runtime-compatibility/src/main/java/com/openai/compatibility/BedrockRuntimeProbe.java
@@ -1,7 +1,7 @@
 package com.openai.compatibility;
 
+import com.openai.bedrock.BedrockOpenAIOkHttpClient;
 import com.openai.client.OpenAIClient;
-import com.openai.client.okhttp.BedrockOpenAIOkHttpClient;
 
 public final class BedrockRuntimeProbe {
     private static final String[] RUNTIME_PROVIDER_CLASSES = {


### PR DESCRIPTION
This PR adds automatic module names to all artifacts that are published. This way, users can refer to the libraries by a stable name. Currently, OpenAI module names are inferred by the jar's file name, which makes OpenAI libraries instable when used in context of the module system.

Unfortunately, there is currently a split package bug in OpenAI where both Bedrock and the OKHttp client are offered in the same package. This makes OpenAI for Java inherently incompatible with Java's module system. This requires a rename what will break API usage. I am flagging this for your decision, but this is something to clean up at some point anyways, but should likely follow a major release to flag the API breakage.