### PR TITLE
ci: reduce duplicate compilation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,8 @@ jobs:
 
   test:
     name: CI / tests
+    needs: build
+    if: needs.build.result == 'success'
     runs-on: ${{ vars.SDK_GHA_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 30
 
@@ -107,6 +109,14 @@ jobs:
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
+        with:
+          cache-read-only: true
+
+      - name: Restore exact-run Gradle build cache
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ci-gradle-build-cache-${{ github.run_id }}
+          path: ~/.gradle/caches/build-cache-1
 
       - name: Run tests
         run: ./scripts/test
@@ -155,15 +165,22 @@ jobs:
         run: |
           set -euo pipefail
 
-          # The proposed detector verifies the current compatibility policy. Running the baseline
-          # detector as well prevents a PR from weakening that policy to hide an SDK break.
-          ./scripts/detect-breaking-changes "$BASE_COMMIT"
-
           BASE_DETECTOR="$(mktemp ./scripts/detect-breaking-changes.baseline.XXXXXX)"
           trap 'rm -f "$BASE_DETECTOR"' EXIT
           git show "${BASE_COMMIT}:scripts/detect-breaking-changes" > "$BASE_DETECTOR"
           chmod +x "$BASE_DETECTOR"
+
+          # Always enforce the trusted baseline policy so a PR cannot weaken the detector to hide
+          # an SDK break. The proposed detector is identical on most PRs, so only run its duplicate
+          # compilation when the PR actually changes the detector.
           "$BASE_DETECTOR" "$BASE_COMMIT"
+
+          if git diff --quiet "$BASE_COMMIT" -- scripts/detect-breaking-changes; then
+            echo "API compatibility detector is unchanged; skipping duplicate validation."
+          else
+            echo "API compatibility detector changed; validating the proposed detector."
+            ./scripts/detect-breaking-changes "$BASE_COMMIT"
+          fi
 
   version_support_matrix:
     name: CI / version support matrix

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -23,4 +23,7 @@ tasks.test {
     inputs
         .file(layout.projectDirectory.file("../scripts/detect-breaking-changes"))
         .withPathSensitivity(PathSensitivity.RELATIVE)
+    inputs
+        .file(layout.projectDirectory.file("../.github/workflows/ci.yml"))
+        .withPathSensitivity(PathSensitivity.RELATIVE)
 }

--- a/buildSrc/src/test/kotlin/com/openai/gradle/ApiCompatibilityCachePolicyTest.kt
+++ b/buildSrc/src/test/kotlin/com/openai/gradle/ApiCompatibilityCachePolicyTest.kt
@@ -5,6 +5,7 @@ import kotlin.io.path.readText
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class ApiCompatibilityCachePolicyTest {
     @Test
@@ -20,5 +21,45 @@ class ApiCompatibilityCachePolicyTest {
         assertContains(detector, "project.tasks.named(taskName).configure")
         assertContains(detector, "task.outputs.upToDateWhen { false }")
         assertContains(detector, "task.outputs.doNotCacheIf")
+    }
+
+    @Test
+    fun `tests consume the exact build cache after build succeeds`() {
+        val workflow = Path.of("../.github/workflows/ci.yml").readText()
+        val testJob =
+            workflow.substringAfter("\n  test:\n").substringBefore("\n  api_compatibility:\n")
+
+        assertContains(testJob, "needs: build")
+        assertContains(testJob, "if: needs.build.result == 'success'")
+        assertContains(testJob, "cache-read-only: true")
+        assertContains(testJob, "name: Restore exact-run Gradle build cache")
+        assertContains(testJob, "name: ci-gradle-build-cache-\${{ github.run_id }}")
+    }
+
+    @Test
+    fun `trusted detector always runs and proposed detector only runs when changed`() {
+        val workflow = Path.of("../.github/workflows/ci.yml").readText()
+        val apiCompatibilityJob =
+            workflow
+                .substringAfter("\n  api_compatibility:\n")
+                .substringBefore("\n  version_support_matrix:\n")
+
+        val trustedDetector = apiCompatibilityJob.indexOf("\"\$BASE_DETECTOR\" \"\$BASE_COMMIT\"")
+        val changeCheck =
+            apiCompatibilityJob.indexOf(
+                "git diff --quiet \"\$BASE_COMMIT\" -- scripts/detect-breaking-changes"
+            )
+        val proposedDetector =
+            apiCompatibilityJob.indexOf("./scripts/detect-breaking-changes \"\$BASE_COMMIT\"")
+
+        assertTrue(trustedDetector >= 0, "The trusted detector must always run.")
+        assertTrue(
+            changeCheck > trustedDetector,
+            "Check for detector changes after trusted validation.",
+        )
+        assertTrue(
+            proposedDetector > changeCheck,
+            "Only run the proposed detector inside the changed-detector branch.",
+        )
     }
 }


### PR DESCRIPTION
## Summary

- make `CI / tests` wait for `CI / build`, then restore the build job's exact-run Gradle build cache
- keep the test job's shared Gradle cache read-only so the build remains the only producer
- always run the trusted baseline API-compatibility detector, but only run the proposed detector when that script changes
- add `buildSrc` policy tests that lock in both workflow invariants

## Why

An analysis of 300 completed CI runs from 2026-07-21 through 2026-08-17 found:

- successful PR CI had a 10.5-minute median and 19.3-minute P90
- cold-cache PRs had an 18.5-minute median, versus 9.3 minutes warm
- tests, API compatibility, and build consumed about 84% of runner time
- cold build and test jobs independently spent roughly 10-13 minutes compiling much of the same Kotlin tree
- the API compatibility job ran two full detector builds even when the detector was byte-for-byte unchanged

This change addresses those two largest avoidable sources of work. The modeled reduction is roughly 9 runner-minutes on a cold PR (about 4 averaged across the observed cache mix), plus roughly 3-4 minutes of elapsed and runner time in the normal unchanged-detector API check. Actual impact should be measured from CI after this PR has accumulated representative runs.

## Safety

- A build failure still fails the required check; the dependent test job simply avoids doing redundant work after that failure.
- The transferred cache is scoped to the same workflow run and commit. The test job consumes it read-only.
- The trusted detector from the merge-base always runs first, so a PR cannot weaken the policy to hide an SDK break.
- When the detector changes, both the trusted and proposed policies still run.

## Prior art

- [Gradle's contributor workflow](https://github.com/gradle/gradle/blob/master/.github/workflows/contributor-pr.yml) compiles first and makes downstream sanity/unit-test jobs depend on that build.
- [Apache Kafka's build workflow](https://github.com/apache/kafka/blob/trunk/.github/workflows/build.yml) separates validation/testing with explicit dependencies and restricts cache writes to trusted branches.
- [OkHttp's build workflow](https://github.com/square/okhttp/blob/master/.github/workflows/build.yml) gates expensive compatibility variants to main or explicit PR labels.

## Validation

- `./scripts/lint`
- `./gradlew :buildSrc:test`
- `actionlint v1.7.12 .github/workflows/ci.yml`
- `yq eval '.' .github/workflows/ci.yml`
- `git diff --check`
