### PR TITLE
ci: run Java CodeQL on pull requests and merge groups

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
+  merge_group:
+    types:
+      - checks_requested
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary
- Restore the existing real Java/Kotlin CodeQL manual-build analysis for every eligible pull request targeting `main`, including drafts and maintainer-approved forks.
- Run the same analysis for future merge-queue `checks_requested` events while retaining the current main-push and manual-dispatch behavior.
- Preserve all SHA-pinned actions, `contents: read` / `security-events: write`, `persist-credentials: false`, Java 21, the no-build-cache Gradle build, and the existing job/concurrency settings.

## Verification
- Duplicate-key-safe YAML parsing and simulated main-branch PR, push, merge-group, and unsafe-event cases passed.
- Verified every action remains SHA-pinned, the exact `Analyze Java and Kotlin` check and real CodeQL init/build/analyze steps are unchanged, and all prior workflow settings are semantically identical.
- `git diff --check` passed; the change is limited to six added lines in `.github/workflows/codeql.yml`.
- Confirmed the current main-branch CodeQL run and uploaded analysis succeeded, and historical PR runs demonstrate both successful repository PR analysis and the existing external-contributor approval gate.

## Rollout and tradeoffs
- This intentionally reverses the PR-throughput tradeoff in #832: real CodeQL analysis historically adds roughly 15–18 minutes per eligible PR.
- No merge queue is currently enabled. Its existing required CI check also needs separate queue support before a queue could be adopted.
- Branch rules are intentionally unchanged: requiring CodeQL now would block existing PRs and unverified fork/merge-queue paths. After merge, verify the exact `Analyze Java and Kotlin` Actions check on current repository PRs and approved forks, and on merge groups if a queue is enabled, before making it required.