### PR TITLE
ci: split core compilation into shards

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
+import com.openai.gradle.CoreCompilationShards
 import com.openai.gradle.GenerateVersionSupportMatrixTask
 import com.openai.gradle.VersionSupportPolicy
 import com.openai.gradle.VerifyVersionSupportPolicyTask
@@ -75,7 +76,9 @@ subprojects {
 }
 
 subprojects {
-    apply(plugin = "org.jetbrains.dokka")
+    if (!CoreCompilationShards.isShardProject(name)) {
+        apply(plugin = "org.jetbrains.dokka")
+    }
 }
 
 val versionSupportFile = layout.projectDirectory.file("gradle/version-support.properties")
@@ -128,7 +131,7 @@ subprojects {
                 sourceCompatibility.set(java.sourceCompatibility.majorVersion.toInt())
                 targetCompatibility.set(java.targetCompatibility.majorVersion.toInt())
                 javaRelease.set(compileJava.flatMap { it.options.release })
-                classFiles.from(mainSourceSet.output.classesDirs)
+                classFiles.from(mainSourceSet.output)
 
                 dependsOn(tasks.named("classes"))
             }
@@ -151,6 +154,10 @@ subprojects {
 // Avoid race conditions between `dokkaJavadocCollector` and `dokkaJavadocJar` tasks
 tasks.named("dokkaJavadocCollector").configure {
     subprojects.flatMap { it.tasks }
-        .filter { it.project.name != "openai-java" && it.name == "dokkaJavadocJar" }
+        .filter {
+            it.project.name != "openai-java" &&
+                !CoreCompilationShards.isShardProject(it.project.name) &&
+                it.name == "dokkaJavadocJar"
+        }
         .forEach { mustRunAfter(it) }
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -21,6 +21,13 @@ tasks.test {
     useJUnitPlatform()
     workingDir(layout.projectDirectory)
     inputs
+        .files(
+            fileTree(layout.projectDirectory.dir("../openai-java-core/src/main/kotlin")) {
+                include("**/*.kt")
+            }
+        )
+        .withPathSensitivity(PathSensitivity.RELATIVE)
+    inputs
         .file(layout.projectDirectory.file("../scripts/detect-breaking-changes"))
         .withPathSensitivity(PathSensitivity.RELATIVE)
     inputs

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -31,6 +31,14 @@ tasks.test {
         .file(layout.projectDirectory.file("../scripts/detect-breaking-changes"))
         .withPathSensitivity(PathSensitivity.RELATIVE)
     inputs
+        .file(
+            layout.projectDirectory.file(
+                "../openai-java-core/src/apiCompatibility/" +
+                    "structured-output-public-api.txt"
+            )
+        )
+        .withPathSensitivity(PathSensitivity.RELATIVE)
+    inputs
         .file(layout.projectDirectory.file("../.github/workflows/ci.yml"))
         .withPathSensitivity(PathSensitivity.RELATIVE)
 }

--- a/buildSrc/src/main/kotlin/com/openai/gradle/CoreCompilationDependencies.kt
+++ b/buildSrc/src/main/kotlin/com/openai/gradle/CoreCompilationDependencies.kt
@@ -1,0 +1,42 @@
+package com.openai.gradle
+
+/** The canonical external compiler classpath for the core artifact and its internal shards. */
+object CoreCompilationDependencies {
+    const val JACKSON_COMPATIBILITY_VERSION = "2.14.0"
+    const val JACKSON_PUBLISHED_VERSION = "2.18.9"
+
+    private val jacksonModules =
+        listOf(
+            "com.fasterxml.jackson.core:jackson-core",
+            "com.fasterxml.jackson.core:jackson-databind",
+            "com.fasterxml.jackson.core:jackson-annotations",
+            "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+            "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+            "com.fasterxml.jackson.module:jackson-module-kotlin",
+        )
+
+    val jacksonCompatibilityDependencies =
+        jacksonModules.map { "$it:$JACKSON_COMPATIBILITY_VERSION" }
+
+    val publishedApiDependencies =
+        listOf(
+            "com.fasterxml.jackson.core:jackson-core:$JACKSON_PUBLISHED_VERSION",
+            "com.fasterxml.jackson.core:jackson-databind:$JACKSON_PUBLISHED_VERSION",
+            "com.google.errorprone:error_prone_annotations:2.33.0",
+            "io.swagger.core.v3:swagger-annotations:2.2.31",
+        )
+
+    val publishedImplementationDependencies =
+        listOf(
+            "com.fasterxml.jackson.core:jackson-annotations:$JACKSON_PUBLISHED_VERSION",
+            "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:$JACKSON_PUBLISHED_VERSION",
+            "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$JACKSON_PUBLISHED_VERSION",
+            "com.fasterxml.jackson.module:jackson-module-kotlin:$JACKSON_PUBLISHED_VERSION",
+            "com.github.victools:jsonschema-generator:4.38.0",
+            "com.github.victools:jsonschema-module-jackson:4.38.0",
+            "com.github.victools:jsonschema-module-swagger-2:4.38.0",
+        )
+
+    val compilerClasspathDependencies =
+        publishedApiDependencies + publishedImplementationDependencies
+}

--- a/buildSrc/src/main/kotlin/com/openai/gradle/CoreCompilationShards.kt
+++ b/buildSrc/src/main/kotlin/com/openai/gradle/CoreCompilationShards.kt
@@ -1,0 +1,252 @@
+package com.openai.gradle
+
+import java.io.Serializable
+import org.gradle.api.file.FileTreeElement
+import org.gradle.api.specs.Spec
+
+enum class CoreCompilationShard(val id: String) {
+    RUNTIME("runtime"),
+    MODELS_COMMON("models-common"),
+    MODELS_ADMIN("models-admin"),
+    MODELS_BETA_RESPONSES("models-beta-responses"),
+    MODELS_BETA("models-beta"),
+    MODELS_GENERAL("models-general"),
+    MODELS_REALTIME("models-realtime"),
+    MODELS_EVALS("models-evals"),
+    CLIENT_BASE("client-base"),
+    SERVICES_ADMIN("services-admin"),
+    SERVICES_BETA("services-beta"),
+    SERVICES_RESPONSES("services-responses"),
+    SERVICES_GENERAL("services-general");
+
+    val projectName: String
+        get() = "${CoreCompilationShards.PROJECT_PREFIX}$id"
+
+    val dependencies: List<CoreCompilationShard>
+        get() =
+            when (this) {
+                RUNTIME -> emptyList()
+                MODELS_COMMON -> listOf(RUNTIME)
+                MODELS_ADMIN,
+                MODELS_BETA_RESPONSES,
+                MODELS_BETA,
+                MODELS_GENERAL,
+                MODELS_EVALS -> listOf(MODELS_COMMON)
+                MODELS_REALTIME -> listOf(MODELS_COMMON, MODELS_GENERAL)
+                CLIENT_BASE -> listOf(MODELS_COMMON)
+                SERVICES_ADMIN -> listOf(CLIENT_BASE, MODELS_ADMIN)
+                SERVICES_BETA -> listOf(CLIENT_BASE, MODELS_BETA, MODELS_BETA_RESPONSES)
+                SERVICES_RESPONSES -> listOf(CLIENT_BASE, MODELS_REALTIME)
+                SERVICES_GENERAL -> listOf(CLIENT_BASE, MODELS_GENERAL, MODELS_EVALS)
+            }
+
+    fun transitiveDependencies(): List<CoreCompilationShard> {
+        val transitiveDependencies = linkedSetOf<CoreCompilationShard>()
+
+        fun collect(shard: CoreCompilationShard) {
+            shard.dependencies.forEach(::collect)
+            transitiveDependencies.add(shard)
+        }
+
+        dependencies.forEach(::collect)
+        return transitiveDependencies.toList()
+    }
+}
+
+/**
+ * Stable source partitions for the generated core library.
+ *
+ * Generated sources stay in `openai-java-core` so code generation remains unchanged. The internal
+ * shard projects compile subsets of that tree and `openai-java-core` embeds their outputs in its
+ * published jar.
+ */
+object CoreCompilationShards {
+    const val PROJECT_PREFIX = "openai-java-core-"
+
+    private val runtimeSources =
+        setOf(
+            "com/openai/auth/TokenExchangeResponse.kt",
+            "com/openai/azure/AzureOpenAIServiceVersion.kt",
+            "com/openai/azure/AzureUrlCategory.kt",
+            "com/openai/azure/AzureUrlPathMode.kt",
+            "com/openai/azure/credential/AzureApiKeyCredential.kt",
+            "com/openai/core/AutoPager.kt",
+            "com/openai/core/AutoPagerAsync.kt",
+            "com/openai/core/BaseDeserializer.kt",
+            "com/openai/core/BaseSerializer.kt",
+            "com/openai/core/Check.kt",
+            "com/openai/core/DefaultSleeper.kt",
+            "com/openai/core/JsonSchemaLocalValidation.kt",
+            "com/openai/core/JsonSchemaValidator.kt",
+            "com/openai/core/LogLevel.kt",
+            "com/openai/core/ObjectMappers.kt",
+            "com/openai/core/Page.kt",
+            "com/openai/core/PageAsync.kt",
+            "com/openai/core/PhantomReachable.kt",
+            "com/openai/core/PhantomReachableExecutorService.kt",
+            "com/openai/core/PhantomReachableSleeper.kt",
+            "com/openai/core/SecurityOptions.kt",
+            "com/openai/core/Sleeper.kt",
+            "com/openai/core/Timeout.kt",
+            "com/openai/core/Utils.kt",
+            "com/openai/core/Values.kt",
+            "com/openai/core/http/AsyncStreamResponse.kt",
+            "com/openai/core/http/HttpMethod.kt",
+            "com/openai/core/http/HttpRequestBody.kt",
+            "com/openai/core/http/PhantomReachableClosingAsyncStreamResponse.kt",
+            "com/openai/core/http/PhantomReachableClosingStreamResponse.kt",
+            "com/openai/core/http/SseMessage.kt",
+            "com/openai/core/http/StreamResponse.kt",
+            "com/openai/credential/BearerTokenCredential.kt",
+            "com/openai/credential/Credential.kt",
+            "com/openai/errors/InvalidWebhookSignatureException.kt",
+            "com/openai/errors/OpenAIException.kt",
+            "com/openai/errors/OpenAIInvalidDataException.kt",
+            "com/openai/errors/OpenAIIoException.kt",
+            "com/openai/errors/OpenAIRetryableException.kt",
+            "com/openai/errors/SubjectTokenProviderException.kt",
+        )
+
+    private val clientBaseSources =
+        setOf(
+            "com/openai/core/ClientOptions.kt",
+            "com/openai/core/PrepareRequest.kt",
+            "com/openai/core/Properties.kt",
+            "com/openai/core/RequestOptions.kt",
+            "com/openai/core/http/AuthenticatingHttpClient.kt",
+            "com/openai/core/http/HttpClient.kt",
+            "com/openai/core/http/LoggingHttpClient.kt",
+            "com/openai/core/http/PhantomReachableClosingHttpClient.kt",
+            "com/openai/core/http/RetryingHttpClient.kt",
+            "com/openai/core/http/WorkloadIdentityHttpClient.kt",
+        )
+
+    val projectNames: List<String> = CoreCompilationShard.values().map { it.projectName }
+
+    fun isShardProject(projectName: String): Boolean = projectName in projectNames
+
+    fun shardForProject(projectName: String): CoreCompilationShard =
+        checkNotNull(CoreCompilationShard.values().find { it.projectName == projectName }) {
+            "$projectName is not a core compilation shard"
+        }
+
+    fun versionPolicyProjectName(projectName: String): String =
+        if (isShardProject(projectName)) "openai-java-core" else projectName
+
+    /** Returns null for sources compiled by the final `openai-java-core` client layer. */
+    fun shardFor(relativePath: String): CoreCompilationShard? {
+        val candidate = relativePath.replace('\\', '/')
+        val packagePathIndex = candidate.indexOf("com/openai/")
+        if (packagePathIndex < 0 || !candidate.endsWith(".kt")) return null
+        val path = candidate.substring(packagePathIndex)
+
+        if (path in runtimeSources) return CoreCompilationShard.RUNTIME
+
+        if (path.startsWith("com/openai/models/")) {
+            if (path.endsWith("Page.kt") || path.endsWith("PageAsync.kt")) {
+                return serviceShardFor(path)
+            }
+
+            return when {
+                path.substringAfter("com/openai/models/").contains('/').not() ->
+                    CoreCompilationShard.MODELS_COMMON
+                path.startsWith("com/openai/models/responses/") ->
+                    CoreCompilationShard.MODELS_COMMON
+                path.startsWith("com/openai/models/chat/") -> CoreCompilationShard.MODELS_COMMON
+                path.startsWith("com/openai/models/completions/") ->
+                    CoreCompilationShard.MODELS_COMMON
+                path.startsWith("com/openai/models/admin/") -> CoreCompilationShard.MODELS_ADMIN
+                path.startsWith("com/openai/models/beta/responses/") ->
+                    CoreCompilationShard.MODELS_BETA_RESPONSES
+                path.startsWith("com/openai/models/beta/") -> CoreCompilationShard.MODELS_BETA
+                path.startsWith("com/openai/models/realtime/") ->
+                    CoreCompilationShard.MODELS_REALTIME
+                path.startsWith("com/openai/models/evals/") -> CoreCompilationShard.MODELS_EVALS
+                path.startsWith("com/openai/models/graders/") -> CoreCompilationShard.MODELS_EVALS
+                path.startsWith("com/openai/models/finetuning/") ->
+                    CoreCompilationShard.MODELS_EVALS
+                else -> CoreCompilationShard.MODELS_GENERAL
+            }
+        }
+
+        if (path.startsWith("com/openai/services/")) return serviceShardFor(path)
+        if (path in clientBaseSources) return CoreCompilationShard.CLIENT_BASE
+        if (path.startsWith("com/openai/auth/")) return CoreCompilationShard.CLIENT_BASE
+        if (path == "com/openai/azure/HttpRequestBuilderExtensions.kt") {
+            return CoreCompilationShard.CLIENT_BASE
+        }
+        if (path == "com/openai/credential/WorkloadIdentityCredential.kt") {
+            return CoreCompilationShard.CLIENT_BASE
+        }
+
+        if (
+            path.startsWith("com/openai/core/") ||
+                path.startsWith("com/openai/errors/") ||
+                path.startsWith("com/openai/azure/") ||
+                path.startsWith("com/openai/credential/")
+        ) {
+            return CoreCompilationShard.MODELS_COMMON
+        }
+
+        return null
+    }
+
+    private fun serviceShardFor(path: String): CoreCompilationShard {
+        val domain =
+            when {
+                path.startsWith("com/openai/models/") ->
+                    path.substringAfter("com/openai/models/").substringBefore('/')
+                path.startsWith("com/openai/services/async/") ->
+                    serviceDomain(path.substringAfter("com/openai/services/async/"))
+                path.startsWith("com/openai/services/blocking/") ->
+                    serviceDomain(path.substringAfter("com/openai/services/blocking/"))
+                path.startsWith("com/openai/services/") ->
+                    serviceDomain(path.substringAfter("com/openai/services/"))
+                else -> "general"
+            }
+
+        return when (domain) {
+            "admin" -> CoreCompilationShard.SERVICES_ADMIN
+            "beta" -> CoreCompilationShard.SERVICES_BETA
+            "chat",
+            "completions",
+            "realtime",
+            "responses" -> CoreCompilationShard.SERVICES_RESPONSES
+            else -> CoreCompilationShard.SERVICES_GENERAL
+        }
+    }
+
+    private fun serviceDomain(relativeServicePath: String): String {
+        if (relativeServicePath.contains('/')) return relativeServicePath.substringBefore('/')
+
+        return when {
+            relativeServicePath.startsWith("AdminService") -> "admin"
+            relativeServicePath.startsWith("BetaService") -> "beta"
+            relativeServicePath.startsWith("ChatService") -> "chat"
+            relativeServicePath.startsWith("CompletionService") -> "completions"
+            relativeServicePath.startsWith("RealtimeService") -> "realtime"
+            relativeServicePath.startsWith("ResponseService") -> "responses"
+            relativeServicePath.startsWith("ResponseStream") -> "responses"
+            else -> "general"
+        }
+    }
+}
+
+class CoreCompilationShardSpec(private val shard: CoreCompilationShard) :
+    Spec<FileTreeElement>, Serializable {
+    override fun isSatisfiedBy(element: FileTreeElement): Boolean =
+        element.isDirectory ||
+            CoreCompilationShards.shardFor(element.relativePath.pathString) == shard
+}
+
+class CoreCompilationClaimedSourceSpec : Spec<FileTreeElement>, Serializable {
+    override fun isSatisfiedBy(element: FileTreeElement): Boolean =
+        !element.isDirectory &&
+            CoreCompilationShards.shardFor(element.relativePath.pathString) != null
+}
+
+class CoreCompilationClaimedSourceIncludeSpec : Spec<FileTreeElement>, Serializable {
+    override fun isSatisfiedBy(element: FileTreeElement): Boolean =
+        element.isDirectory ||
+            CoreCompilationShards.shardFor(element.relativePath.pathString) != null
+}

--- a/buildSrc/src/main/kotlin/com/openai/gradle/VerifyCoreCompilationArtifactTask.kt
+++ b/buildSrc/src/main/kotlin/com/openai/gradle/VerifyCoreCompilationArtifactTask.kt
@@ -1,0 +1,139 @@
+package com.openai.gradle
+
+import java.io.File
+import java.io.Serializable
+import java.util.SortedSet
+import java.util.zip.ZipFile
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.FileTreeElement
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.specs.Spec
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
+
+@DisableCachingByDefault(because = "Artifact verification produces no outputs")
+abstract class VerifyCoreCompilationArtifactTask : DefaultTask() {
+    @get:InputDirectory
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val classesDirectory: DirectoryProperty
+
+    @get:InputDirectory
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val sourceDirectory: DirectoryProperty
+
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.NAME_ONLY)
+    abstract val binaryJar: RegularFileProperty
+
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.NAME_ONLY)
+    abstract val sourcesJar: RegularFileProperty
+
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val publicApiManifest: RegularFileProperty
+
+    @TaskAction
+    fun verify() {
+        val expectedClasses = relativeFiles(classesDirectory.get().asFile, ".class")
+        check(expectedClasses.isNotEmpty()) { "The combined core classes directory is empty." }
+
+        val binaryEntries = zipEntryCounts(binaryJar.get().asFile)
+        assertNoDuplicateEntries("core jar", binaryEntries)
+        assertSameEntries(
+            label = "core class",
+            expected = expectedClasses,
+            actual = binaryEntries.keys.filterTo(sortedSetOf()) { it.endsWith(".class") },
+        )
+
+        val expectedSources =
+            relativeFiles(sourceDirectory.get().asFile, ".kt").mapTo(sortedSetOf()) { "main/$it" }
+        check(expectedSources.isNotEmpty()) { "The core source directory is empty." }
+
+        val sourceEntries = zipEntryCounts(sourcesJar.get().asFile)
+        assertNoDuplicateEntries("core sources jar", sourceEntries)
+        assertSameEntries(
+            label = "core Kotlin source",
+            expected = expectedSources,
+            actual = sourceEntries.keys.filterTo(sortedSetOf()) { it.endsWith(".kt") },
+        )
+
+        structuredOutputPublicApiClasses(publicApiManifest.get().asFile).forEach { className ->
+            val classEntry = "${className.replace('.', '/')}.class"
+            check(classEntry in expectedClasses) {
+                "Public API class is missing from the combined core classes: $className"
+            }
+            check(binaryEntries[classEntry] == 1) {
+                "Public API class must appear exactly once in the core jar: $className"
+            }
+
+            val sourceEntry = "main/${className.substringBefore('$').replace('.', '/')}.kt"
+            check(sourceEntries[sourceEntry] == 1) {
+                "Public API source must appear exactly once in the core sources jar: $className"
+            }
+        }
+    }
+
+    private fun relativeFiles(root: File, extension: String): SortedSet<String> =
+        root
+            .walkTopDown()
+            .filter { it.isFile && it.name.endsWith(extension) }
+            .map { it.relativeTo(root).invariantSeparatorsPath }
+            .toCollection(sortedSetOf())
+
+    private fun zipEntryCounts(archive: File): Map<String, Int> =
+        ZipFile(archive).use { zip ->
+            buildMap {
+                val entries = zip.entries()
+                while (entries.hasMoreElements()) {
+                    val name = entries.nextElement().name
+                    put(name, getOrDefault(name, 0) + 1)
+                }
+            }
+        }
+
+    private fun assertNoDuplicateEntries(label: String, entries: Map<String, Int>) {
+        val duplicates = entries.filterValues { it > 1 }.keys.sorted()
+        check(duplicates.isEmpty()) {
+            "$label contains duplicate entries:\n${duplicates.joinToString("\n") { "  $it" }}"
+        }
+    }
+
+    private fun assertSameEntries(label: String, expected: Set<String>, actual: Set<String>) {
+        val missing = expected - actual
+        val unexpected = actual - expected
+        check(missing.isEmpty() && unexpected.isEmpty()) {
+            buildString {
+                append("Published $label inventory differs from the canonical directory.")
+                if (missing.isNotEmpty()) {
+                    append("\nMissing:\n")
+                    append(missing.joinToString("\n") { "  $it" })
+                }
+                if (unexpected.isNotEmpty()) {
+                    append("\nUnexpected:\n")
+                    append(unexpected.joinToString("\n") { "  $it" })
+                }
+            }
+        }
+    }
+}
+
+class CoreCompilationStagingOutputSpec(private val stagingDirectory: File) :
+    Spec<FileTreeElement>, Serializable {
+    override fun isSatisfiedBy(element: FileTreeElement): Boolean =
+        element.file.toPath().startsWith(stagingDirectory.toPath())
+}
+
+internal fun structuredOutputPublicApiClasses(manifest: File): Set<String> =
+    manifest.useLines { lines ->
+        lines
+            .map(String::trim)
+            .filter { it.isNotEmpty() && !it.startsWith('#') }
+            .map { it.substringBefore(' ').substringBefore('#') }
+            .toCollection(sortedSetOf())
+    }

--- a/buildSrc/src/main/kotlin/openai.core-shard.gradle.kts
+++ b/buildSrc/src/main/kotlin/openai.core-shard.gradle.kts
@@ -1,0 +1,43 @@
+import com.openai.gradle.CoreCompilationDependencies
+import com.openai.gradle.CoreCompilationShard
+import com.openai.gradle.CoreCompilationShardSpec
+import com.openai.gradle.CoreCompilationShards
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+plugins { id("openai.kotlin") }
+
+val shard = CoreCompilationShards.shardForProject(project.name)
+val coreSourceDirectory = rootProject.layout.projectDirectory.dir("openai-java-core/src/main/kotlin")
+
+kotlin.sourceSets.named("main") {
+    kotlin.srcDir(coreSourceDirectory)
+    kotlin.include(CoreCompilationShardSpec(shard))
+}
+
+val friendOutputs =
+    shard.transitiveDependencies().map { dependencyShard ->
+        rootProject.layout.projectDirectory.dir(
+            "${dependencyShard.projectName}/build/classes/kotlin/main"
+        )
+    }
+
+tasks.named<KotlinCompile>("compileKotlin") { friendPaths.from(friendOutputs) }
+
+configurations.configureEach {
+    resolutionStrategy {
+        CoreCompilationDependencies.jacksonCompatibilityDependencies.forEach(::force)
+    }
+}
+
+dependencies {
+    shard.dependencies.forEach { dependencyShard ->
+        api(project(":${dependencyShard.projectName}"))
+    }
+
+    if (shard == CoreCompilationShard.RUNTIME) {
+        // These are internal compilation projects, so exposing every external dependency here only
+        // supplies downstream shards with the same compiler classpath as openai-java-core. The
+        // projects are not published and never appear in openai-java-core's metadata.
+        CoreCompilationDependencies.compilerClasspathDependencies.forEach { api(it) }
+    }
+}

--- a/buildSrc/src/main/kotlin/openai.java.gradle.kts
+++ b/buildSrc/src/main/kotlin/openai.java.gradle.kts
@@ -1,3 +1,4 @@
+import com.openai.gradle.CoreCompilationShards
 import com.openai.gradle.VersionSupportPolicy
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 
@@ -11,7 +12,8 @@ repositories {
 
 val versionSupportPolicy =
     VersionSupportPolicy.load(rootProject.file("gradle/version-support.properties"))
-val runtimeFloor = versionSupportPolicy.runtimeFloor(project.name)
+val versionPolicyProject = CoreCompilationShards.versionPolicyProjectName(project.name)
+val runtimeFloor = versionSupportPolicy.runtimeFloor(versionPolicyProject)
 
 java {
     toolchain {

--- a/buildSrc/src/main/kotlin/openai.kotlin.gradle.kts
+++ b/buildSrc/src/main/kotlin/openai.kotlin.gradle.kts
@@ -1,3 +1,4 @@
+import com.openai.gradle.CoreCompilationShards
 import com.openai.gradle.VersionSupportPolicy
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
@@ -13,7 +14,8 @@ repositories {
 
 val versionSupportPolicy =
     VersionSupportPolicy.load(rootProject.file("gradle/version-support.properties"))
-val runtimeFloor = versionSupportPolicy.runtimeFloor(project.name)
+val versionPolicyProject = CoreCompilationShards.versionPolicyProjectName(project.name)
+val runtimeFloor = versionSupportPolicy.runtimeFloor(versionPolicyProject)
 val kotlinJvmTarget = if (runtimeFloor == 8) "1.8" else runtimeFloor.toString()
 
 kotlin {

--- a/buildSrc/src/test/kotlin/com/openai/gradle/CoreCompilationShardsTest.kt
+++ b/buildSrc/src/test/kotlin/com/openai/gradle/CoreCompilationShardsTest.kt
@@ -2,7 +2,9 @@ package com.openai.gradle
 
 import java.io.File
 import kotlin.test.Test
+import kotlin.test.assertContains
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 class CoreCompilationShardsTest {
@@ -32,6 +34,24 @@ class CoreCompilationShardsTest {
                     ) == shard
                 },
                 "${shard.id} must own at least one source file",
+            )
+        }
+    }
+
+    @Test
+    fun `all structured-output public API classes have exactly one source owner`() {
+        val sourceRoot = File("../openai-java-core/src/main/kotlin")
+        val manifest =
+            File("../openai-java-core/src/apiCompatibility/" + "structured-output-public-api.txt")
+        val publicClasses = structuredOutputPublicApiClasses(manifest)
+
+        assertContains(publicClasses, "com.openai.models.chat.completions.StructuredChatCompletion")
+        publicClasses.forEach { className ->
+            val sourcePath = className.substringBefore('$').replace('.', '/') + ".kt"
+            assertTrue(File(sourceRoot, sourcePath).isFile, "$className has no source file")
+            assertNotNull(
+                CoreCompilationShards.shardFor(sourcePath),
+                "$className must belong to exactly one compilation shard",
             )
         }
     }

--- a/buildSrc/src/test/kotlin/com/openai/gradle/CoreCompilationShardsTest.kt
+++ b/buildSrc/src/test/kotlin/com/openai/gradle/CoreCompilationShardsTest.kt
@@ -1,0 +1,103 @@
+package com.openai.gradle
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class CoreCompilationShardsTest {
+    @Test
+    fun `all generated model and service sources are assigned`() {
+        val sourceRoot = File("../openai-java-core/src/main/kotlin")
+        val sources = sourceRoot.walkTopDown().filter { it.isFile && it.extension == "kt" }.toList()
+
+        val unexpectedClientLayerSources =
+            sources.filter { source ->
+                val path = source.relativeTo(sourceRoot).invariantSeparatorsPath
+                CoreCompilationShards.shardFor(path) == null &&
+                    !path.startsWith("com/openai/client/") &&
+                    !path.startsWith("com/openai/helpers/")
+            }
+
+        assertTrue(
+            unexpectedClientLayerSources.isEmpty(),
+            "Only client implementations and helpers should remain in the final compilation: " +
+                unexpectedClientLayerSources.joinToString(),
+        )
+        CoreCompilationShard.values().forEach { shard ->
+            assertTrue(
+                sources.any { source ->
+                    CoreCompilationShards.shardFor(
+                        source.relativeTo(sourceRoot).invariantSeparatorsPath
+                    ) == shard
+                },
+                "${shard.id} must own at least one source file",
+            )
+        }
+    }
+
+    @Test
+    fun `root service aggregators follow their domain`() {
+        assertEquals(
+            CoreCompilationShard.SERVICES_ADMIN,
+            CoreCompilationShards.shardFor("com/openai/services/async/AdminServiceAsync.kt"),
+        )
+        assertEquals(
+            CoreCompilationShard.SERVICES_BETA,
+            CoreCompilationShards.shardFor("com/openai/services/blocking/BetaServiceImpl.kt"),
+        )
+        assertEquals(
+            CoreCompilationShard.SERVICES_RESPONSES,
+            CoreCompilationShards.shardFor("com/openai/services/ResponseStreamEventValidation.kt"),
+        )
+    }
+
+    @Test
+    fun `service shards depend only on their model domains`() {
+        assertEquals(
+            listOf(CoreCompilationShard.MODELS_COMMON),
+            CoreCompilationShard.CLIENT_BASE.dependencies,
+        )
+        assertEquals(
+            listOf(CoreCompilationShard.CLIENT_BASE, CoreCompilationShard.MODELS_ADMIN),
+            CoreCompilationShard.SERVICES_ADMIN.dependencies,
+        )
+        assertEquals(
+            listOf(
+                CoreCompilationShard.CLIENT_BASE,
+                CoreCompilationShard.MODELS_BETA,
+                CoreCompilationShard.MODELS_BETA_RESPONSES,
+            ),
+            CoreCompilationShard.SERVICES_BETA.dependencies,
+        )
+        assertEquals(
+            listOf(CoreCompilationShard.CLIENT_BASE, CoreCompilationShard.MODELS_REALTIME),
+            CoreCompilationShard.SERVICES_RESPONSES.dependencies,
+        )
+        assertEquals(
+            listOf(
+                CoreCompilationShard.CLIENT_BASE,
+                CoreCompilationShard.MODELS_GENERAL,
+                CoreCompilationShard.MODELS_EVALS,
+            ),
+            CoreCompilationShard.SERVICES_GENERAL.dependencies,
+        )
+    }
+
+    @Test
+    fun `shard dependencies are acyclic`() {
+        val visited = mutableSetOf<CoreCompilationShard>()
+        val visiting = mutableSetOf<CoreCompilationShard>()
+
+        fun visit(shard: CoreCompilationShard) {
+            assertTrue(visiting.add(shard), "Cycle found at ${shard.id}")
+            shard.dependencies.forEach { dependency ->
+                if (dependency !in visited) visit(dependency)
+            }
+            visiting.remove(shard)
+            visited.add(shard)
+        }
+
+        CoreCompilationShard.values().forEach(::visit)
+    }
+}

--- a/openai-java-core-client-base/build.gradle.kts
+++ b/openai-java-core-client-base/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("openai.core-shard") }

--- a/openai-java-core-models-admin/build.gradle.kts
+++ b/openai-java-core-models-admin/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("openai.core-shard") }

--- a/openai-java-core-models-beta-responses/build.gradle.kts
+++ b/openai-java-core-models-beta-responses/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("openai.core-shard") }

--- a/openai-java-core-models-beta/build.gradle.kts
+++ b/openai-java-core-models-beta/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("openai.core-shard") }

--- a/openai-java-core-models-common/build.gradle.kts
+++ b/openai-java-core-models-common/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("openai.core-shard") }

--- a/openai-java-core-models-evals/build.gradle.kts
+++ b/openai-java-core-models-evals/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("openai.core-shard") }

--- a/openai-java-core-models-general/build.gradle.kts
+++ b/openai-java-core-models-general/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("openai.core-shard") }

--- a/openai-java-core-models-realtime/build.gradle.kts
+++ b/openai-java-core-models-realtime/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("openai.core-shard") }

--- a/openai-java-core-runtime/build.gradle.kts
+++ b/openai-java-core-runtime/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("openai.core-shard") }

--- a/openai-java-core-services-admin/build.gradle.kts
+++ b/openai-java-core-services-admin/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("openai.core-shard") }

--- a/openai-java-core-services-beta/build.gradle.kts
+++ b/openai-java-core-services-beta/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("openai.core-shard") }

--- a/openai-java-core-services-general/build.gradle.kts
+++ b/openai-java-core-services-general/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("openai.core-shard") }

--- a/openai-java-core-services-responses/build.gradle.kts
+++ b/openai-java-core-services-responses/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("openai.core-shard") }

--- a/openai-java-core/build.gradle.kts
+++ b/openai-java-core/build.gradle.kts
@@ -2,8 +2,12 @@ import com.openai.gradle.CoreCompilationClaimedSourceIncludeSpec
 import com.openai.gradle.CoreCompilationClaimedSourceSpec
 import com.openai.gradle.CoreCompilationDependencies
 import com.openai.gradle.CoreCompilationShards
+import com.openai.gradle.CoreCompilationStagingOutputSpec
+import com.openai.gradle.VerifyCoreCompilationArtifactTask
+import org.gradle.api.file.DuplicatesStrategy
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.tasks.Classpath
+import org.gradle.api.tasks.Sync
 import org.gradle.jvm.tasks.Jar
 import org.gradle.process.CommandLineArgumentProvider
 import org.jetbrains.dokka.gradle.AbstractDokkaLeafTask
@@ -34,12 +38,15 @@ val mockitoAgent by configurations.creating {
 
 val coreCompilationShardProjects =
     CoreCompilationShards.projectNames.map { project(":$it") }
+val clientLayerClassesDirectory = layout.buildDirectory.dir("classes/kotlin/client-layer")
+val combinedClassesDirectory = layout.buildDirectory.dir("classes/kotlin/main")
 
 kotlin.sourceSets.named("main") {
     kotlin.exclude(CoreCompilationClaimedSourceSpec())
 }
 
-tasks.named<KotlinCompile>("compileKotlin") {
+val compileCoreClientLayer = tasks.named<KotlinCompile>("compileKotlin") {
+    destinationDirectory.set(clientLayerClassesDirectory)
     friendPaths.from(
         coreCompilationShardProjects.map {
             it.layout.buildDirectory.dir("classes/kotlin/main")
@@ -52,13 +59,35 @@ val coreCompilationShardOutputs =
         it.layout.buildDirectory.dir("classes/kotlin/main")
     }
 
-// Add the embedded shard outputs to the main classes variant. Downstream project dependencies use
-// this variant, while the published jar still contains one cohesive openai-java-core artifact.
-(sourceSets.main.get().output.classesDirs as ConfigurableFileCollection).from(
-    coreCompilationShardOutputs
-)
+val assembleCoreClasses = tasks.register<Sync>("assembleCoreClasses") {
+    group = "build"
+    description = "Assembles the client layer and internal shards into the core class directory."
+    dependsOn(compileCoreClientLayer)
+    dependsOn(coreCompilationShardProjects.map { "${it.path}:classes" })
+    from(compileCoreClientLayer.flatMap { it.destinationDirectory })
+    from(coreCompilationShardOutputs)
+    into(combinedClassesDirectory)
+    duplicatesStrategy = DuplicatesStrategy.FAIL
+}
 
-tasks.named<Jar>("kotlinSourcesJar") {
+// Keep one canonical classes directory for tests, detectors, downstream projects, and publishing.
+// The client layer and shards remain independently cacheable; this task only assembles their
+// outputs after compilation.
+val mainClassesDirectories =
+    sourceSets.main.get().output.classesDirs as ConfigurableFileCollection
+mainClassesDirectories.setFrom(combinedClassesDirectory)
+mainClassesDirectories.builtBy(assembleCoreClasses)
+tasks.named("classes") { dependsOn(assembleCoreClasses) }
+
+val coreJar = tasks.named<Jar>("jar") {
+    // The Kotlin plugin captures compileKotlin's destination before it is relocated above. Publish
+    // those client-layer classes through the canonical aggregate instead of the staging directory.
+    exclude(CoreCompilationStagingOutputSpec(clientLayerClassesDirectory.get().asFile))
+    duplicatesStrategy = DuplicatesStrategy.FAIL
+}
+
+val coreSourcesJar = tasks.named<Jar>("kotlinSourcesJar") {
+    duplicatesStrategy = DuplicatesStrategy.FAIL
     from(
         fileTree("src/main/kotlin").matching {
             include(CoreCompilationClaimedSourceIncludeSpec())
@@ -67,6 +96,24 @@ tasks.named<Jar>("kotlinSourcesJar") {
         into("main")
     }
 }
+
+val verifyCoreCompilationArtifact =
+    tasks.register<VerifyCoreCompilationArtifactTask>("verifyCoreCompilationArtifact") {
+        group = "verification"
+        description = "Verifies that the assembled core classes and sources are published once."
+        classesDirectory.set(combinedClassesDirectory)
+        sourceDirectory.set(layout.projectDirectory.dir("src/main/kotlin"))
+        binaryJar.set(coreJar.flatMap { it.archiveFile })
+        sourcesJar.set(coreSourcesJar.flatMap { it.archiveFile })
+        publicApiManifest.set(
+            layout.projectDirectory.file(
+                "src/apiCompatibility/structured-output-public-api.txt"
+            )
+        )
+        dependsOn(coreJar, coreSourcesJar)
+    }
+
+tasks.named("check") { dependsOn(verifyCoreCompilationArtifact) }
 
 tasks.withType<AbstractDokkaLeafTask>().configureEach {
     dokkaSourceSets.configureEach {

--- a/openai-java-core/build.gradle.kts
+++ b/openai-java-core/build.gradle.kts
@@ -1,6 +1,13 @@
+import com.openai.gradle.CoreCompilationClaimedSourceIncludeSpec
+import com.openai.gradle.CoreCompilationClaimedSourceSpec
+import com.openai.gradle.CoreCompilationDependencies
+import com.openai.gradle.CoreCompilationShards
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.tasks.Classpath
+import org.gradle.jvm.tasks.Jar
 import org.gradle.process.CommandLineArgumentProvider
+import org.jetbrains.dokka.gradle.AbstractDokkaLeafTask
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 abstract class JavaAgentArgumentProvider : CommandLineArgumentProvider {
     @get:Classpath abstract val classpath: ConfigurableFileCollection
@@ -16,13 +23,55 @@ plugins {
     id("openai.publish")
 }
 
-val jacksonCompatibilityVersion = "2.14.0"
-val jacksonPublishedVersion = "2.18.9"
+val jacksonCompatibilityVersion = CoreCompilationDependencies.JACKSON_COMPATIBILITY_VERSION
+val jacksonPublishedVersion = CoreCompilationDependencies.JACKSON_PUBLISHED_VERSION
 val mockitoVersion = "5.14.2"
 val mockitoAgent by configurations.creating {
     isCanBeConsumed = false
     isCanBeResolved = true
     isVisible = false
+}
+
+val coreCompilationShardProjects =
+    CoreCompilationShards.projectNames.map { project(":$it") }
+
+kotlin.sourceSets.named("main") {
+    kotlin.exclude(CoreCompilationClaimedSourceSpec())
+}
+
+tasks.named<KotlinCompile>("compileKotlin") {
+    friendPaths.from(
+        coreCompilationShardProjects.map {
+            it.layout.buildDirectory.dir("classes/kotlin/main")
+        }
+    )
+}
+
+val coreCompilationShardOutputs =
+    coreCompilationShardProjects.map {
+        it.layout.buildDirectory.dir("classes/kotlin/main")
+    }
+
+// Add the embedded shard outputs to the main classes variant. Downstream project dependencies use
+// this variant, while the published jar still contains one cohesive openai-java-core artifact.
+(sourceSets.main.get().output.classesDirs as ConfigurableFileCollection).from(
+    coreCompilationShardOutputs
+)
+
+tasks.named<Jar>("kotlinSourcesJar") {
+    from(
+        fileTree("src/main/kotlin").matching {
+            include(CoreCompilationClaimedSourceIncludeSpec())
+        }
+    ) {
+        into("main")
+    }
+}
+
+tasks.withType<AbstractDokkaLeafTask>().configureEach {
+    dokkaSourceSets.configureEach {
+        sourceRoots.from(layout.projectDirectory.dir("src/main/kotlin"))
+    }
 }
 
 // Runtime classpath for `testJacksonCompatibility`: the same dependencies as
@@ -72,18 +121,12 @@ configurations.matching {
 }
 
 dependencies {
-    api("com.fasterxml.jackson.core:jackson-core:$jacksonPublishedVersion")
-    api("com.fasterxml.jackson.core:jackson-databind:$jacksonPublishedVersion")
-    api("com.google.errorprone:error_prone_annotations:2.33.0")
-    api("io.swagger.core.v3:swagger-annotations:2.2.31")
+    coreCompilationShardProjects.forEach { compileOnly(it) }
 
-    implementation("com.fasterxml.jackson.core:jackson-annotations:$jacksonPublishedVersion")
-    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jdk8:$jacksonPublishedVersion")
-    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonPublishedVersion")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonPublishedVersion")
-    implementation("com.github.victools:jsonschema-generator:4.38.0")
-    implementation("com.github.victools:jsonschema-module-jackson:4.38.0")
-    implementation("com.github.victools:jsonschema-module-swagger-2:4.38.0")
+    CoreCompilationDependencies.publishedApiDependencies.forEach { api(it) }
+    CoreCompilationDependencies.publishedImplementationDependencies.forEach {
+        implementation(it)
+    }
 
     testImplementation(kotlin("test"))
     testImplementation(project(":openai-java-client-okhttp"))

--- a/openai-java-core/src/main/kotlin/com/openai/core/Properties.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/core/Properties.kt
@@ -2,8 +2,6 @@
 
 package com.openai.core
 
-import com.openai.client.OpenAIClient
-
 fun getOsArch(): String {
     val osArch = System.getProperty("os.arch")
 
@@ -37,6 +35,6 @@ fun getOsName(): String {
 fun getOsVersion(): String = System.getProperty("os.version", "unknown") ?: "unknown"
 
 fun getPackageVersion(): String =
-    OpenAIClient::class.java.`package`?.implementationVersion ?: "unknown"
+    ClientOptions::class.java.`package`?.implementationVersion ?: "unknown"
 
 fun getJavaVersion(): String = System.getProperty("java.version", "unknown") ?: "unknown"

--- a/openai-java-core/src/main/kotlin/com/openai/core/http/LoggingHttpClient.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/core/http/LoggingHttpClient.kt
@@ -109,16 +109,14 @@ private constructor(
 
         logHeaders(request.headers)
 
-        if (request.body == null) {
+        val requestBody = request.body
+        if (requestBody == null) {
             System.err.println("--> END ${request.method}")
             System.err.println()
             return request
         }
 
-        return request
-            .toBuilder()
-            .body(LoggingHttpRequestBody(request.method, request.body))
-            .build()
+        return request.toBuilder().body(LoggingHttpRequestBody(request.method, requestBody)).build()
     }
 
     private fun logResponse(response: HttpResponse, took: Duration): HttpResponse {

--- a/scripts/detect-breaking-changes
+++ b/scripts/detect-breaking-changes
@@ -337,6 +337,11 @@ validate_public_api_signatures() {
     local extra
 
     classes_root="$(pwd)/openai-java-core/build/classes/kotlin/main"
+    for shard_classes in "$(pwd)"/openai-java-core-*/build/classes/kotlin/main; do
+        if [ -d "${shard_classes}" ]; then
+            classes_root="${classes_root}:${shard_classes}"
+        fi
+    done
     actual_signatures="$(mktemp)"
     classes="$(mktemp)"
     expected_signatures="$(mktemp)"

--- a/scripts/detect-breaking-changes
+++ b/scripts/detect-breaking-changes
@@ -337,11 +337,6 @@ validate_public_api_signatures() {
     local extra
 
     classes_root="$(pwd)/openai-java-core/build/classes/kotlin/main"
-    for shard_classes in "$(pwd)"/openai-java-core-*/build/classes/kotlin/main; do
-        if [ -d "${shard_classes}" ]; then
-            classes_root="${classes_root}:${shard_classes}"
-        fi
-    done
     actual_signatures="$(mktemp)"
     classes="$(mktemp)"
     expected_signatures="$(mktemp)"


### PR DESCRIPTION
## Summary

- split the generated core into 13 internal Gradle compilation shards while continuing to publish one `openai-java-core` artifact
- keep generated sources in their existing tree so code generation and source layout remain unchanged
- model the shard DAG explicitly so independent domains compile in parallel and edits do not invalidate unrelated domains
- preserve the complete binary, sources, documentation, and public API surfaces in the published core artifact

## Why

`openai-java-core` currently compiles 1,789 Kotlin files (about 1.2 million physical lines) as one unit. A change to one generated model invalidates that entire compilation. These internal projects partition the compiler work without adding any published modules or consumer-visible dependencies.

## Local results

| Scenario | Before | After |
| --- | ---: | ---: |
| Fresh core Kotlin compilation | 11m 21s | 6m 09s |
| Warm core Kotlin compilation | — | 20s |

The fresh compilation is about 46% faster. A representative edit to an admin model reran only the admin-model shard, admin-service shard, and six-file final client layer; the other 10 compilation shards stayed up to date.

## Publication compatibility

- the core JAR still contains 26,888 class entries with no duplicates
- the sources JAR contains all 1,789 Kotlin sources exactly once
- generated Maven POM and Gradle module metadata contain no internal shard dependencies
- Dokka still builds documentation from the complete source tree

## Validation

- `buildSrc` tests, including source ownership and dependency-DAG checks
- complete `openai-java-core` tests with the repository-supported mock-server tests skipped locally
- focused `LoggingHttpClientTest`
- `openai-java-core:dokkaJavadoc`
- downstream compilation for the OkHttp client, aggregate SDK, and Bedrock module
- runtime version-policy verification
- structured-output API compatibility detector against `origin/main`
- strict thermo-nuclear maintainability review
