### PR TITLE
fix: prevent concurrent JSON deserialization failures

### DIFF
--- a/openai-java-core/build.gradle.kts
+++ b/openai-java-core/build.gradle.kts
@@ -77,6 +77,7 @@ dependencies {
     api("com.google.errorprone:error_prone_annotations:2.33.0")
     api("io.swagger.core.v3:swagger-annotations:2.2.31")
 
+    implementation("org.jetbrains.kotlin:kotlin-reflect:1.8.20")
     implementation("com.fasterxml.jackson.core:jackson-annotations:$jacksonPublishedVersion")
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jdk8:$jacksonPublishedVersion")
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonPublishedVersion")


### PR DESCRIPTION
Concurrent first use of SDK models can hit a race in Kotlin reflection, causing Jackson to fail to access a private constructor. For union types, that failure can be swallowed and produce the wrong variant or `_unknown` instead of the expected value.

Require `kotlin-reflect` 1.8.20, which contains the upstream [KT-27585 fix](https://github.com/JetBrains/kotlin/commit/99b38ccb741deb41a083043db4971958c0209f99). This is a dependency-only fix; it leaves the SDK’s Java 8 floor, Kotlin language/API level, and deserializer behavior unchanged.