### PR TITLE
fix: clear async workload refresh state after sync failures

### DIFF
--- a/openai-java-core/src/main/kotlin/com/openai/auth/WorkloadIdentityAuth.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/auth/WorkloadIdentityAuth.kt
@@ -155,7 +155,7 @@ internal class WorkloadIdentityAuth(
         return when (action) {
             is TokenAction.ReturnCached -> CompletableFuture.completedFuture(action.token)
             is TokenAction.BackgroundRefresh -> {
-                performRefreshAndComplete(action.future)
+                startAsyncRefresh(action.future)
                 CompletableFuture.completedFuture(action.token)
             }
             is TokenAction.WaitForRefresh ->
@@ -165,20 +165,25 @@ internal class WorkloadIdentityAuth(
                         is TokenRefreshResult.Failure -> throw result.error
                     }
                 }
-            is TokenAction.ForegroundRefresh -> {
-                val refresh = refreshTokenAsync()
-                refresh.whenComplete { token, error ->
-                    finishRefresh(action.future, token, unwrapCompletionException(error))
-                }
-                refresh
-            }
+            is TokenAction.ForegroundRefresh -> startAsyncRefresh(action.future)
         }
     }
 
-    private fun performRefreshAndComplete(future: CompletableFuture<TokenRefreshResult>) {
-        refreshTokenAsync().whenComplete { token, error ->
+    private fun startAsyncRefresh(
+        future: CompletableFuture<TokenRefreshResult>
+    ): CompletableFuture<String> {
+        val refresh =
+            try {
+                refreshTokenAsync()
+            } catch (error: Throwable) {
+                finishRefresh(future, null, error)
+                return CompletableFuture<String>().also { it.completeExceptionally(error) }
+            }
+
+        refresh.whenComplete { token, error ->
             finishRefresh(future, token, unwrapCompletionException(error))
         }
+        return refresh
     }
 
     private fun finishRefresh(

--- a/openai-java-core/src/test/kotlin/com/openai/auth/WorkloadIdentityAuthSynchronousProviderFailureTest.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/auth/WorkloadIdentityAuthSynchronousProviderFailureTest.kt
@@ -1,0 +1,121 @@
+package com.openai.auth
+
+import com.fasterxml.jackson.databind.json.JsonMapper
+import com.openai.core.http.HttpClient
+import com.openai.core.http.HttpRequest
+import com.openai.core.http.HttpResponse
+import java.io.ByteArrayInputStream
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionException
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+
+internal class WorkloadIdentityAuthSynchronousProviderFailureTest {
+
+    @Test
+    fun getTokenAsync_clearsForegroundRefreshAfterSynchronousProviderFailure() {
+        val failure = IllegalStateException("provider failed")
+        var providerCalls = 0
+        val provider =
+            object : SubjectTokenProvider {
+                override fun tokenType() = SubjectTokenType.JWT
+
+                override fun getToken(httpClient: HttpClient, jsonMapper: JsonMapper): String =
+                    error("not used")
+
+                override fun getTokenAsync(
+                    httpClient: HttpClient,
+                    jsonMapper: JsonMapper,
+                ): CompletableFuture<String> {
+                    providerCalls++
+                    throw failure
+                }
+            }
+        val httpClient = mock<HttpClient>()
+        val auth = createAuth(provider, httpClient)
+
+        val firstFailure = assertThrows<CompletionException> { auth.getTokenAsync().join() }
+        val secondFailure = assertThrows<CompletionException> { auth.getTokenAsync().join() }
+
+        assertThat(firstFailure.cause).isSameAs(failure)
+        assertThat(secondFailure.cause).isSameAs(failure)
+        assertThat(providerCalls).isEqualTo(2)
+        verifyNoInteractions(httpClient)
+    }
+
+    @Test
+    fun getTokenAsync_keepsCachedTokenAndAllowsAnotherBackgroundRefreshAfterSynchronousFailure() {
+        val subjectToken = "subject-token"
+        val accessToken = "access-token"
+        val failure = IllegalStateException("provider failed")
+        var asyncProviderCalls = 0
+        val provider =
+            object : SubjectTokenProvider {
+                override fun tokenType() = SubjectTokenType.JWT
+
+                override fun getToken(httpClient: HttpClient, jsonMapper: JsonMapper): String =
+                    subjectToken
+
+                override fun getTokenAsync(
+                    httpClient: HttpClient,
+                    jsonMapper: JsonMapper,
+                ): CompletableFuture<String> {
+                    asyncProviderCalls++
+                    throw failure
+                }
+            }
+        val httpClient = mock<HttpClient>()
+        val response =
+            mockResponse(
+                200,
+                """
+                {
+                    "access_token": "$accessToken",
+                    "issued_token_type": "urn:ietf:params:oauth:token-type:access_token",
+                    "token_type": "Bearer",
+                    "expires_in": 60
+                }
+                """
+                    .trimIndent(),
+            )
+        whenever(httpClient.execute(any<HttpRequest>())).thenReturn(response)
+        val auth = createAuth(provider, httpClient)
+
+        assertThat(auth.getToken()).isEqualTo(accessToken)
+        assertThat(auth.getTokenAsync().join()).isEqualTo(accessToken)
+        assertThat(auth.getTokenAsync().join()).isEqualTo(accessToken)
+
+        assertThat(asyncProviderCalls).isEqualTo(2)
+        verify(httpClient, times(1)).execute(any<HttpRequest>())
+    }
+
+    private fun createAuth(
+        provider: SubjectTokenProvider,
+        httpClient: HttpClient,
+    ): WorkloadIdentityAuth =
+        WorkloadIdentityAuth(
+            config =
+                WorkloadIdentity.builder()
+                    .clientId("client-id")
+                    .identityProviderId("provider-id")
+                    .serviceAccountId("service-account-id")
+                    .provider(provider)
+                    .build(),
+            httpClient = httpClient,
+            jsonMapper = JsonMapper(),
+        )
+
+    private fun mockResponse(statusCode: Int, body: String): HttpResponse {
+        val response = mock<HttpResponse>()
+        whenever(response.statusCode()).thenReturn(statusCode)
+        whenever(response.body()).thenAnswer { ByteArrayInputStream(body.toByteArray()) }
+        return response
+    }
+}


### PR DESCRIPTION
## Summary

Ensure `WorkloadIdentityAuth.getTokenAsync()` clears its shared refresh state when a custom `SubjectTokenProvider.getTokenAsync()` throws synchronously instead of returning a future.

Fixes #852.

## Problem

`getTokenAsync()` stores a new `refreshInFlight` future before it calls the provider. If `getTokenAsync()` on the provider throws synchronously, the exception escapes before any `whenComplete` callback is registered.

That leaves `refreshInFlight` pointing at a future that will never complete.

For a foreground refresh, the first caller sees the synchronous exception and every later caller waits on the abandoned shared future indefinitely. The same state leak can occur when an expiring cached token triggers a background refresh.

## Fix

Centralize async refresh startup in `startAsyncRefresh()`.

The helper:

- calls `refreshTokenAsync()` inside a `try` block;
- on a synchronous exception, routes the error through the existing `finishRefresh()` path so `refreshInFlight` is cleared and waiters are completed;
- returns an exceptionally completed `CompletableFuture` to the foreground caller instead of throwing before a future is returned;
- preserves the background-refresh contract by allowing the caller to continue using the still-valid cached token.

Asynchronous provider and token-exchange failures continue through the existing completion callback unchanged.

## Regression coverage

Added focused tests for both affected paths:

1. **Foreground refresh:** a provider that throws synchronously causes each `getTokenAsync()` call to return a failed future, and a second call starts a new refresh instead of hanging on stale state.
2. **Background refresh:** after seeding a still-valid but expiring token, synchronous provider failures do not prevent the cached token from being returned and do not block a later background-refresh attempt.

## Validation

- branch is based directly on current upstream `main` at `6a46d024ed67e2be889a4c729837a664d5e7902c`;
- branch is 0 commits behind upstream;
- production diff is 15 additions / 10 deletions in `WorkloadIdentityAuth.kt`;
- changes are limited to the workload-identity refresh lifecycle and focused tests.

Full repository validation is left to GitHub Actions because this environment does not have a complete local checkout/toolchain for the repository.

## Risk

Low. Normal successful refreshes and asynchronously completed failures keep their existing flow. The behavior changes only when refresh startup itself throws before returning a `CompletableFuture`.