### PR TITLE
fix: clamp negative Retry-After delays

### DIFF
--- a/openai-java-core/src/main/kotlin/com/openai/core/http/RetryingHttpClient.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/core/http/RetryingHttpClient.kt
@@ -212,8 +212,10 @@ private constructor(
                     }
             }
             ?.let { retryAfterNanos ->
-                // If the API asks us to wait a certain amount of time, do what it says.
-                return Duration.ofNanos(retryAfterNanos.toLong())
+                // If the API asks us to wait a certain amount of time, do what it says. A past
+                // HTTP date or malformed negative numeric delay has already elapsed, so retry
+                // immediately instead of passing a negative duration to the sleeper.
+                return Duration.ofNanos(retryAfterNanos.toLong().coerceAtLeast(0L))
             }
 
         // Apply exponential backoff, but not more than the max.

--- a/openai-java-core/src/test/kotlin/com/openai/core/http/RetryingHttpClientNegativeRetryAfterTest.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/core/http/RetryingHttpClientNegativeRetryAfterTest.kt
@@ -1,0 +1,136 @@
+package com.openai.core.http
+
+import com.openai.core.RequestOptions
+import com.openai.core.Sleeper
+import java.io.ByteArrayInputStream
+import java.io.InputStream
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneOffset
+import java.util.concurrent.CompletableFuture
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+internal class RetryingHttpClientNegativeRetryAfterTest {
+
+    @ParameterizedTest
+    @ValueSource(booleans = [false, true])
+    fun negativeRetryAfterSecondsRetriesImmediately(async: Boolean) {
+        val sleeper = RecordingSleeper()
+        val client = retryingClient("Retry-After", "-1", Clock.systemUTC(), sleeper)
+
+        val response = client.execute(request(), async)
+
+        assertThat(response.statusCode()).isEqualTo(200)
+        assertThat(sleeper.durations).containsExactly(Duration.ZERO)
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = [false, true])
+    fun negativeRetryAfterMillisecondsRetriesImmediately(async: Boolean) {
+        val sleeper = RecordingSleeper()
+        val client = retryingClient("Retry-After-Ms", "-1", Clock.systemUTC(), sleeper)
+
+        val response = client.execute(request(), async)
+
+        assertThat(response.statusCode()).isEqualTo(200)
+        assertThat(sleeper.durations).containsExactly(Duration.ZERO)
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = [false, true])
+    fun pastRetryAfterDateRetriesImmediately(async: Boolean) {
+        val sleeper = RecordingSleeper()
+        val clock = Clock.fixed(Instant.parse("2015-10-21T07:28:05Z"), ZoneOffset.UTC)
+        val client =
+            retryingClient(
+                "Retry-After",
+                "Wed, 21 Oct 2015 07:28:00 GMT",
+                clock,
+                sleeper,
+            )
+
+        val response = client.execute(request(), async)
+
+        assertThat(response.statusCode()).isEqualTo(200)
+        assertThat(sleeper.durations).containsExactly(Duration.ZERO)
+    }
+
+    private fun retryingClient(
+        headerName: String,
+        headerValue: String,
+        clock: Clock,
+        sleeper: RecordingSleeper,
+    ): HttpClient {
+        var calls = 0
+        val underlying =
+            object : HttpClient {
+                private fun nextResponse(): HttpResponse {
+                    calls++
+                    return if (calls == 1) {
+                        TestResponse(
+                            503,
+                            Headers.builder().put(headerName, headerValue).build(),
+                        )
+                    } else {
+                        TestResponse(200, Headers.builder().build())
+                    }
+                }
+
+                override fun execute(
+                    request: HttpRequest,
+                    requestOptions: RequestOptions,
+                ): HttpResponse = nextResponse()
+
+                override fun executeAsync(
+                    request: HttpRequest,
+                    requestOptions: RequestOptions,
+                ): CompletableFuture<HttpResponse> = CompletableFuture.completedFuture(nextResponse())
+
+                override fun close() {}
+            }
+
+        return RetryingHttpClient.builder()
+            .httpClient(underlying)
+            .sleeper(sleeper)
+            .clock(clock)
+            .maxRetries(1)
+            .build()
+    }
+
+    private fun request(): HttpRequest =
+        HttpRequest.builder().method(HttpMethod.POST).baseUrl("https://example.test").build()
+
+    private fun HttpClient.execute(request: HttpRequest, async: Boolean): HttpResponse =
+        if (async) executeAsync(request).join() else execute(request)
+
+    private class RecordingSleeper : Sleeper {
+        val durations = mutableListOf<Duration>()
+
+        override fun sleep(duration: Duration) {
+            durations.add(duration)
+        }
+
+        override fun sleepAsync(duration: Duration): CompletableFuture<Void> {
+            durations.add(duration)
+            return CompletableFuture.completedFuture(null)
+        }
+
+        override fun close() {}
+    }
+
+    private class TestResponse(
+        private val statusCode: Int,
+        private val headers: Headers,
+    ) : HttpResponse {
+        override fun statusCode(): Int = statusCode
+
+        override fun headers(): Headers = headers
+
+        override fun body(): InputStream = ByteArrayInputStream(ByteArray(0))
+
+        override fun close() {}
+    }
+}


### PR DESCRIPTION
## Summary

Treat negative or already-elapsed `Retry-After` delays as zero before passing them to the retry sleeper.

Fixes #853.

## Problem

`RetryingHttpClient` parses three server-directed retry-delay forms:

- `Retry-After-Ms` numeric milliseconds;
- `Retry-After` numeric seconds;
- `Retry-After` HTTP dates.

The parsed value is currently converted directly to `Duration` and passed to `Sleeper`.

That means values such as:

```text
Retry-After: -1
Retry-After-Ms: -1
Retry-After: Wed, 21 Oct 2015 07:28:00 GMT
```

can produce a negative duration. With the default sleeper, that can make a retryable response fail while trying to sleep instead of retrying immediately.

Past HTTP dates are especially normal under clock skew or network transit: once the requested instant has passed, the remaining delay is simply zero.

## Fix

Clamp the parsed nanosecond delay at the shared retry-delay boundary:

```kotlin
Duration.ofNanos(retryAfterNanos.toLong().coerceAtLeast(0L))
```

This is applied after all supported `Retry-After` parsing, so both synchronous and asynchronous retry paths receive the same non-negative duration.

Invalid/unparseable headers continue to fall back to the existing exponential backoff behavior.

## Regression coverage

Added focused sync/async coverage for:

- negative numeric `Retry-After` seconds;
- negative `Retry-After-Ms` milliseconds;
- an RFC 1123 HTTP date five seconds in the past.

All three cases require exactly `Duration.ZERO` and a successful retry.

## Validation

- branch is based directly on current upstream `main` at `6a46d024ed67e2be889a4c729837a664d5e7902c`;
- branch is 0 commits behind upstream;
- production diff is 4 additions / 2 deletions in `RetryingHttpClient.kt`;
- no retry-count, retryability, jitter, maximum-backoff, or response-close behavior changes.

Full repository validation is left to GitHub Actions because this environment does not have a complete local checkout/toolchain for the repository.

## Risk

Low. Positive server-directed delays are unchanged. Only negative parsed delays are normalized to zero, which is equivalent to the requested retry time already having elapsed.