### PR TITLE
fix: close non-success responses in error handler

### DIFF
--- a/openai-java-core/src/main/kotlin/com/openai/core/handlers/ErrorHandler.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/core/handlers/ErrorHandler.kt
@@ -42,50 +42,35 @@ internal fun errorHandler(
     errorBodyHandler: Handler<JsonField<ErrorObject>>
 ): Handler<HttpResponse> =
     object : Handler<HttpResponse> {
-        override fun handle(response: HttpResponse): HttpResponse =
-            when (val statusCode = response.statusCode()) {
-                in 200..299 -> response
-                400 ->
-                    throw BadRequestException.builder()
-                        .headers(response.headers())
-                        .error(errorBodyHandler.handle(response))
-                        .build()
-                401 ->
-                    throw UnauthorizedException.builder()
-                        .headers(response.headers())
-                        .error(errorBodyHandler.handle(response))
-                        .build()
-                403 ->
-                    throw PermissionDeniedException.builder()
-                        .headers(response.headers())
-                        .error(errorBodyHandler.handle(response))
-                        .build()
-                404 ->
-                    throw NotFoundException.builder()
-                        .headers(response.headers())
-                        .error(errorBodyHandler.handle(response))
-                        .build()
-                422 ->
-                    throw UnprocessableEntityException.builder()
-                        .headers(response.headers())
-                        .error(errorBodyHandler.handle(response))
-                        .build()
-                429 ->
-                    throw RateLimitException.builder()
-                        .headers(response.headers())
-                        .error(errorBodyHandler.handle(response))
-                        .build()
-                in 500..599 ->
-                    throw InternalServerException.builder()
-                        .statusCode(statusCode)
-                        .headers(response.headers())
-                        .error(errorBodyHandler.handle(response))
-                        .build()
-                else ->
-                    throw UnexpectedStatusCodeException.builder()
-                        .statusCode(statusCode)
-                        .headers(response.headers())
-                        .error(errorBodyHandler.handle(response))
-                        .build()
+        override fun handle(response: HttpResponse): HttpResponse {
+            val statusCode = response.statusCode()
+            if (statusCode in 200..299) {
+                return response
             }
+
+            return response.use {
+                val headers = response.headers()
+                val error = errorBodyHandler.handle(response)
+                throw when (statusCode) {
+                    400 -> BadRequestException.builder().headers(headers).error(error).build()
+                    401 -> UnauthorizedException.builder().headers(headers).error(error).build()
+                    403 -> PermissionDeniedException.builder().headers(headers).error(error).build()
+                    404 -> NotFoundException.builder().headers(headers).error(error).build()
+                    422 -> UnprocessableEntityException.builder().headers(headers).error(error).build()
+                    429 -> RateLimitException.builder().headers(headers).error(error).build()
+                    in 500..599 ->
+                        InternalServerException.builder()
+                            .statusCode(statusCode)
+                            .headers(headers)
+                            .error(error)
+                            .build()
+                    else ->
+                        UnexpectedStatusCodeException.builder()
+                            .statusCode(statusCode)
+                            .headers(headers)
+                            .error(error)
+                            .build()
+                }
+            }
+        }
     }

--- a/openai-java-core/src/test/kotlin/com/openai/core/handlers/ErrorHandlerResponseCloseTest.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/core/handlers/ErrorHandlerResponseCloseTest.kt
@@ -1,0 +1,84 @@
+package com.openai.core.handlers
+
+import com.openai.core.JsonField
+import com.openai.core.JsonMissing
+import com.openai.core.http.Headers
+import com.openai.core.http.HttpResponse
+import com.openai.errors.OpenAIException
+import com.openai.models.ErrorObject
+import java.io.ByteArrayInputStream
+import java.io.InputStream
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+internal class ErrorHandlerResponseCloseTest {
+
+    @ParameterizedTest
+    @ValueSource(ints = [400, 401, 403, 404, 418, 422, 429, 500])
+    fun closesEveryNonSuccessResponse(statusCode: Int) {
+        val response = RecordingResponse(statusCode)
+        val handler =
+            errorHandler(
+                object : HttpResponse.Handler<JsonField<ErrorObject>> {
+                    override fun handle(response: HttpResponse): JsonField<ErrorObject> =
+                        JsonMissing.of()
+                }
+            )
+
+        assertThrows<OpenAIException> { handler.handle(response) }
+
+        assertThat(response.closed).isTrue()
+    }
+
+    @Test
+    fun closesResponseWhenErrorBodyHandlerThrows() {
+        val failure = IllegalStateException("error body failed")
+        val response = RecordingResponse(400)
+        val handler =
+            errorHandler(
+                object : HttpResponse.Handler<JsonField<ErrorObject>> {
+                    override fun handle(response: HttpResponse): JsonField<ErrorObject> {
+                        throw failure
+                    }
+                }
+            )
+
+        val thrown = assertThrows<IllegalStateException> { handler.handle(response) }
+
+        assertThat(thrown).isSameAs(failure)
+        assertThat(response.closed).isTrue()
+    }
+
+    @Test
+    fun leavesSuccessfulResponseOpenForCaller() {
+        val response = RecordingResponse(200)
+        val handler =
+            errorHandler(
+                object : HttpResponse.Handler<JsonField<ErrorObject>> {
+                    override fun handle(response: HttpResponse): JsonField<ErrorObject> =
+                        error("error body handler must not run for successful responses")
+                }
+            )
+
+        assertThat(handler.handle(response)).isSameAs(response)
+        assertThat(response.closed).isFalse()
+    }
+
+    private class RecordingResponse(private val statusCode: Int) : HttpResponse {
+        var closed = false
+            private set
+
+        override fun statusCode(): Int = statusCode
+
+        override fun headers(): Headers = Headers.builder().build()
+
+        override fun body(): InputStream = ByteArrayInputStream(ByteArray(0))
+
+        override fun close() {
+            closed = true
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Make the shared HTTP error handler close every non-2xx `HttpResponse` before propagating a typed service exception or an error-body parsing failure.

Fixes #745.

## Problem

Generated service methods generally call the shared `errorHandler.handle(response)` before entering their later `response.use { ... }` parsing block.

For 2xx responses, that is correct: the handler returns the response and the service owns its eventual close.

For non-2xx responses, however, `errorHandler` currently reads the status/headers/body and throws a typed exception without closing the response. Because the exception is thrown before the service reaches its own `use` block, the non-success response can remain open.

The same leak can occur if the supplied error-body handler itself throws while parsing the response.

## Fix

Keep successful response ownership unchanged, but put the complete non-success path inside `response.use { ... }`:

1. return 2xx responses directly and leave them open for the caller;
2. for every other status, enter `response.use`;
3. capture headers and parse the error body;
4. construct and throw the same status-specific exception as before.

`use` closes the response whether typed exception construction succeeds or error-body parsing throws first.

The status-to-exception mapping is unchanged:

- 400 -> `BadRequestException`
- 401 -> `UnauthorizedException`
- 403 -> `PermissionDeniedException`
- 404 -> `NotFoundException`
- 422 -> `UnprocessableEntityException`
- 429 -> `RateLimitException`
- 5xx -> `InternalServerException`
- all other non-2xx statuses -> `UnexpectedStatusCodeException`

## Regression coverage

Added focused tests that verify:

- representative status codes from every error branch close the response;
- a failure thrown by the error-body handler still closes the response and propagates the original failure;
- a 200 response is returned unchanged and remains open for caller-owned parsing.

## Validation

- branch is based directly on current upstream `main` at `6a46d024ed67e2be889a4c729837a664d5e7902c`;
- branch is 0 commits behind upstream;
- changes are limited to the shared error handler and focused ownership regressions;
- successful-response parsing and exception type selection are unchanged.

Full repository validation is left to GitHub Actions because this environment does not have a complete local checkout/toolchain for the repository.

## Risk

Low. The ownership change applies only to responses that are already being rejected. Successful responses remain open exactly as before, and callers still receive the same typed exceptions for each status class.