### PR TITLE
feat: support named data-residency endpoints

### DIFF
--- a/.castiron.stats.yml
+++ b/.castiron.stats.yml
@@ -1,6 +1,6 @@
 schema_version: 1
-generation_id: e8514744-7f30-4f27-b870-f605f56db09c
+generation_id: f61afbaf-40e3-45ab-8fc5-bd10b00c85d8
 openapi_spec_hash: dd725fb7d43ceec7fb2de6f8713d14b6
 openapi_transformed_spec_hash: 10930179c5f116288e24e0c6fda46559
-config_hash: 28f37c225c55c75547d4feb84ee71044
-codegen_sha: 7d6e5660decbae44c8ff9c1ef70e9e64b5e93cd5
+config_hash: 85382dd94c503b5d225adc7636a77c9f
+codegen_sha: f28bc6bb70715a949d0d5f3cc8c0912899bcaa85

--- a/openai-java-client-okhttp/src/main/kotlin/com/openai/client/okhttp/OpenAIOkHttpClient.kt
+++ b/openai-java-client-okhttp/src/main/kotlin/com/openai/client/okhttp/OpenAIOkHttpClient.kt
@@ -7,6 +7,7 @@ import com.openai.azure.AzureUrlPathMode
 import com.openai.client.OpenAIClient
 import com.openai.client.OpenAIClientImpl
 import com.openai.core.ClientOptions
+import com.openai.core.DataResidency
 import com.openai.core.LogLevel
 import com.openai.core.Sleeper
 import com.openai.core.Timeout
@@ -255,6 +256,19 @@ class OpenAIOkHttpClient private constructor() {
 
         /** Alias for calling [Builder.baseUrl] with `baseUrl.orElse(null)`. */
         fun baseUrl(baseUrl: Optional<String>) = baseUrl(baseUrl.getOrNull())
+
+        /**
+         * Selects an OpenAI endpoint for request-scoped data and compute residency.
+         *
+         * @see ClientOptions.Builder.dataResidency
+         */
+        fun dataResidency(dataResidency: DataResidency?) = apply {
+            clientOptions.dataResidency(dataResidency)
+        }
+
+        /** Alias for calling [dataResidency] with `dataResidency.orElse(null)`. */
+        fun dataResidency(dataResidency: Optional<DataResidency>) =
+            dataResidency(dataResidency.getOrNull())
 
         /**
          * Whether to call `validate` on every response before returning it.

--- a/openai-java-client-okhttp/src/main/kotlin/com/openai/client/okhttp/OpenAIOkHttpClientAsync.kt
+++ b/openai-java-client-okhttp/src/main/kotlin/com/openai/client/okhttp/OpenAIOkHttpClientAsync.kt
@@ -7,6 +7,7 @@ import com.openai.azure.AzureUrlPathMode
 import com.openai.client.OpenAIClientAsync
 import com.openai.client.OpenAIClientAsyncImpl
 import com.openai.core.ClientOptions
+import com.openai.core.DataResidency
 import com.openai.core.LogLevel
 import com.openai.core.Sleeper
 import com.openai.core.Timeout
@@ -255,6 +256,19 @@ class OpenAIOkHttpClientAsync private constructor() {
 
         /** Alias for calling [Builder.baseUrl] with `baseUrl.orElse(null)`. */
         fun baseUrl(baseUrl: Optional<String>) = baseUrl(baseUrl.getOrNull())
+
+        /**
+         * Selects an OpenAI endpoint for request-scoped data and compute residency.
+         *
+         * @see ClientOptions.Builder.dataResidency
+         */
+        fun dataResidency(dataResidency: DataResidency?) = apply {
+            clientOptions.dataResidency(dataResidency)
+        }
+
+        /** Alias for calling [dataResidency] with `dataResidency.orElse(null)`. */
+        fun dataResidency(dataResidency: Optional<DataResidency>) =
+            dataResidency(dataResidency.getOrNull())
 
         /**
          * Whether to call `validate` on every response before returning it.

--- a/openai-java-client-okhttp/src/test/kotlin/com/openai/client/okhttp/DataResidencyTest.kt
+++ b/openai-java-client-okhttp/src/test/kotlin/com/openai/client/okhttp/DataResidencyTest.kt
@@ -1,0 +1,69 @@
+package com.openai.client.okhttp
+
+import com.openai.client.OpenAIClient
+import com.openai.client.OpenAIClientAsync
+import com.openai.core.ClientOptions
+import com.openai.core.DataResidency
+import java.util.Optional
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+internal class DataResidencyTest {
+    @Test
+    fun syncAndAsyncBuildersExposeResidency() {
+        val sync =
+            OpenAIOkHttpClient.builder().apiKey("test").dataResidency(DataResidency.EU).build()
+        val async =
+            OpenAIOkHttpClientAsync.builder()
+                .apiKey("test")
+                .dataResidency(Optional.of(DataResidency.AE))
+                .build()
+        assertThat(baseUrl(sync)).isEqualTo("https://eu.api.openai.com/v1")
+        assertThat(baseUrl(async)).isEqualTo("https://ae.api.openai.com/v1")
+        assertThat(baseUrl(sync.withOptions { it.dataResidency(DataResidency.US) }))
+            .isEqualTo("https://us.api.openai.com/v1")
+        assertThat(baseUrl(async.withOptions { it.dataResidency(DataResidency.GLOBAL) }))
+            .isEqualTo(ClientOptions.PRODUCTION_URL)
+        assertThat(baseUrl(sync)).isEqualTo("https://eu.api.openai.com/v1")
+        assertThat(baseUrl(async)).isEqualTo("https://ae.api.openai.com/v1")
+        sync.close()
+        async.close()
+    }
+
+    @Test
+    fun publicBuildersRejectBothExplicitOptions() {
+        assertThrows<IllegalArgumentException> {
+            OpenAIOkHttpClient.builder()
+                .baseUrl("https://example.com")
+                .dataResidency(DataResidency.EU)
+        }
+        assertThrows<IllegalArgumentException> {
+            OpenAIOkHttpClient.builder()
+                .dataResidency(DataResidency.EU)
+                .baseUrl("https://example.com")
+        }
+        assertThrows<IllegalArgumentException> {
+            OpenAIOkHttpClientAsync.builder()
+                .baseUrl("https://example.com")
+                .dataResidency(DataResidency.EU)
+        }
+        assertThrows<IllegalArgumentException> {
+            OpenAIOkHttpClientAsync.builder()
+                .dataResidency(DataResidency.EU)
+                .baseUrl("https://example.com")
+        }
+    }
+
+    private fun baseUrl(client: OpenAIClient): String {
+        var result = ""
+        client.withOptions { result = it.build().baseUrl() }
+        return result
+    }
+
+    private fun baseUrl(client: OpenAIClientAsync): String {
+        var result = ""
+        client.withOptions { result = it.build().baseUrl() }
+        return result
+    }
+}

--- a/openai-java-core/src/main/kotlin/com/openai/core/ClientOptions.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/core/ClientOptions.kt
@@ -86,6 +86,7 @@ private constructor(
      */
     @get:JvmName("clock") val clock: Clock,
     private val baseUrl: String?,
+    private val dataResidencySelected: Boolean,
     /** Headers to send with the request. */
     @get:JvmName("headers") val headers: Headers,
     /** Query params to send with the request. */
@@ -200,6 +201,11 @@ private constructor(
         private var sleeper: Sleeper? = null
         private var clock: Clock = Clock.systemUTC()
         private var baseUrl: String? = null
+        // Retain only whether the resolved URL came from residency, not a competing URL value.
+        private var dataResidencySelected: Boolean = false
+        private var explicitBaseUrl: Boolean = false
+        private var explicitDataResidency: Boolean = false
+        private var inheritedAzureEndpoint: Boolean = false
         private var headers: Headers.Builder = Headers.builder()
         private var queryParams: QueryParams.Builder = QueryParams.builder()
         private var responseValidation: Boolean = false
@@ -226,6 +232,11 @@ private constructor(
             sleeper = clientOptions.sleeper
             clock = clientOptions.clock
             baseUrl = clientOptions.baseUrl
+            dataResidencySelected = clientOptions.dataResidencySelected
+            inheritedAzureEndpoint =
+                clientOptions.baseUrl?.let {
+                    AzureUrlCategory.categorizeBaseUrl(it, AzureUrlPathMode.AUTO).isAzure()
+                } ?: false
             headers = clientOptions.headers.toBuilder()
             queryParams = clientOptions.queryParams.toBuilder()
             responseValidation = clientOptions.responseValidation
@@ -327,10 +338,35 @@ private constructor(
          *
          * Defaults to the production environment: `https://api.openai.com/v1`.
          */
-        fun baseUrl(baseUrl: String?) = apply { this.baseUrl = baseUrl }
+        fun baseUrl(baseUrl: String?) = apply {
+            require(!explicitDataResidency) { "baseUrl and dataResidency are mutually exclusive" }
+            this.baseUrl = baseUrl
+            dataResidencySelected = false
+            explicitBaseUrl = true
+        }
 
         /** Alias for calling [Builder.baseUrl] with `baseUrl.orElse(null)`. */
         fun baseUrl(baseUrl: Optional<String>) = baseUrl(baseUrl.getOrNull())
+
+        /**
+         * Selects an OpenAI endpoint for request-scoped data and compute residency.
+         *
+         * Cannot be combined with [baseUrl] on the same builder or with third-party provider
+         * configuration. An inherited or environment-derived URL may be replaced. A null value
+         * leaves the endpoint unchanged. Availability is determined by the API.
+         */
+        fun dataResidency(dataResidency: DataResidency?) = apply {
+            if (dataResidency != null) {
+                require(!explicitBaseUrl) { "baseUrl and dataResidency are mutually exclusive" }
+                baseUrl = dataResidency.baseUrl
+                dataResidencySelected = true
+                explicitDataResidency = true
+            }
+        }
+
+        /** Alias for calling [dataResidency] with `dataResidency.orElse(null)`. */
+        fun dataResidency(dataResidency: Optional<DataResidency>) =
+            dataResidency(dataResidency.getOrNull())
 
         /**
          * Whether to call `validate` on every response before returning it.
@@ -581,7 +617,11 @@ private constructor(
         fun fromEnv() = apply {
             logLevel(LogLevel.fromEnv())
             (System.getProperty("openai.baseUrl") ?: System.getenv("OPENAI_BASE_URL"))?.let {
-                baseUrl(it)
+                if (!dataResidencySelected) {
+                    inheritedAzureEndpoint =
+                        AzureUrlCategory.categorizeBaseUrl(it, AzureUrlPathMode.AUTO).isAzure()
+                    baseUrl = it
+                }
             }
 
             val openAIKey = System.getProperty("openai.apiKey") ?: System.getenv("OPENAI_API_KEY")
@@ -638,6 +678,16 @@ private constructor(
          * @throws IllegalStateException if any required field is unset.
          */
         fun build(): ClientOptions {
+            require(
+                !dataResidencySelected ||
+                    (!inheritedAzureEndpoint &&
+                        httpRequestAuthenticator == null &&
+                        credential !is AzureApiKeyCredential &&
+                        azureServiceVersion == null &&
+                        azureUrlPathMode == AzureUrlPathMode.AUTO)
+            ) {
+                "dataResidency cannot be combined with third-party provider configuration"
+            }
             val httpClient = checkRequired("httpClient", httpClient)
             val streamHandlerExecutor =
                 streamHandlerExecutor
@@ -740,6 +790,7 @@ private constructor(
                 sleeper,
                 clock,
                 baseUrl,
+                dataResidencySelected,
                 headers.build(),
                 queryParams.build(),
                 responseValidation,

--- a/openai-java-core/src/main/kotlin/com/openai/core/DataResidency.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/core/DataResidency.kt
@@ -1,0 +1,22 @@
+// File generated from our OpenAPI spec by Castiron. See CONTRIBUTING.md for details.
+
+package com.openai.core
+
+/** Selects an OpenAI endpoint for request-scoped data and compute residency. */
+enum class DataResidency(private val value: String, internal val baseUrl: String) {
+
+    GLOBAL("global", "https://api.openai.com/v1"),
+    US("us", "https://us.api.openai.com/v1"),
+    EU("eu", "https://eu.api.openai.com/v1"),
+    AE("ae", "https://ae.api.openai.com/v1");
+
+    fun value(): String = value
+
+    companion object {
+        /** Returns the residency matching the lowercase configuration value. */
+        @JvmStatic
+        fun of(value: String): DataResidency =
+            values().firstOrNull { it.value == value }
+                ?: throw IllegalArgumentException("Unknown data residency: $value")
+    }
+}

--- a/openai-java-core/src/test/kotlin/com/openai/core/DataResidencyContractTest.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/core/DataResidencyContractTest.kt
@@ -1,0 +1,204 @@
+// File generated from our OpenAPI spec by Castiron. See CONTRIBUTING.md for details.
+
+package com.openai.core
+
+import com.openai.azure.AzureOpenAIServiceVersion
+import com.openai.azure.AzureUrlPathMode
+import com.openai.azure.credential.AzureApiKeyCredential
+import com.openai.client.OpenAIClientImpl
+import com.openai.core.http.HttpClient
+import com.openai.core.http.HttpRequest
+import com.openai.core.http.HttpRequestAuthenticator
+import java.util.Optional
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.mock
+
+internal class DataResidencyContractTest {
+    private val httpClient = mock<HttpClient>()
+
+    private fun builder() = ClientOptions.builder().httpClient(httpClient).apiKey("test-api-key")
+
+    @Test
+    fun mappings() {
+        val expected =
+            mapOf(
+                DataResidency.GLOBAL to "https://api.openai.com/v1",
+                DataResidency.US to "https://us.api.openai.com/v1",
+                DataResidency.EU to "https://eu.api.openai.com/v1",
+                DataResidency.AE to "https://ae.api.openai.com/v1",
+            )
+        expected.forEach { (residency, url) ->
+            assertThat(builder().dataResidency(residency).build().baseUrl()).isEqualTo(url)
+            assertThat(DataResidency.of(residency.value())).isEqualTo(residency)
+        }
+        for (value in listOf("", "other", "GLOBAL")) {
+            assertThrows<IllegalArgumentException> { DataResidency.of(value) }
+        }
+    }
+
+    @Test
+    fun explicitUrlConflictsInEitherOrder() {
+        for (initial in listOf(builder(), builder().build().toBuilder())) {
+            val thrown =
+                assertThrows<IllegalArgumentException> {
+                    initial.baseUrl("https://example.com/v1").dataResidency(DataResidency.EU)
+                }
+            assertThat(thrown.message).contains("mutually exclusive")
+        }
+        for (initial in listOf(builder(), builder().build().toBuilder())) {
+            val thrown =
+                assertThrows<IllegalArgumentException> {
+                    initial.dataResidency(DataResidency.EU).baseUrl("https://example.com/v1")
+                }
+            assertThat(thrown.message).contains("mutually exclusive")
+        }
+    }
+
+    @Test
+    fun explicitNullUrlStillConflictsInEitherOrder() {
+        assertThrows<IllegalArgumentException> {
+            builder().baseUrl(null as String?).dataResidency(DataResidency.EU)
+        }
+        assertThrows<IllegalArgumentException> {
+            builder().dataResidency(DataResidency.EU).baseUrl(null as String?)
+        }
+    }
+
+    @Test
+    fun copiesOnlyRetainTheResolvedUrl() {
+        val original = builder().baseUrl("https://example.com/v1").build()
+        val eu = original.toBuilder().dataResidency(DataResidency.EU).build()
+        val us = eu.toBuilder().dataResidency(DataResidency.US).build()
+        val global = us.toBuilder().dataResidency(DataResidency.GLOBAL).build()
+        assertThat(original.baseUrl()).isEqualTo("https://example.com/v1")
+        assertThat(eu.baseUrl()).isEqualTo("https://eu.api.openai.com/v1")
+        assertThat(us.baseUrl()).isEqualTo("https://us.api.openai.com/v1")
+        assertThat(global.baseUrl()).isEqualTo("https://api.openai.com/v1")
+        assertThat(eu.toBuilder().baseUrl("https://other.example/v1").build().baseUrl())
+            .isEqualTo("https://other.example/v1")
+        assertThat(eu.toBuilder().dataResidency(null as DataResidency?).build().baseUrl())
+            .isEqualTo(eu.baseUrl())
+        assertThat(eu.toBuilder().dataResidency(Optional.empty()).build().baseUrl())
+            .isEqualTo(eu.baseUrl())
+        assertThat(
+                builder()
+                    .dataResidency(null as DataResidency?)
+                    .baseUrl("https://example.com")
+                    .build()
+                    .baseUrl()
+            )
+            .isEqualTo("https://example.com")
+    }
+
+    @Test
+    fun environmentUrlIsInheritedAndDoesNotOverrideResidency() {
+        withBaseUrlProperty("https://example.com/v1") {
+            assertThat(builder().fromEnv().dataResidency(DataResidency.EU).build().baseUrl())
+                .isEqualTo("https://eu.api.openai.com/v1")
+            assertThat(builder().dataResidency(DataResidency.EU).fromEnv().build().baseUrl())
+                .isEqualTo("https://eu.api.openai.com/v1")
+            assertThrows<IllegalArgumentException> {
+                builder().baseUrl("https://other.example").fromEnv().dataResidency(DataResidency.EU)
+            }
+        }
+    }
+
+    @Test
+    fun rejectsThirdPartyProviderConfiguration() {
+        val authenticator =
+            object : HttpRequestAuthenticator {
+                override fun authenticate(request: HttpRequest): HttpRequest = request
+            }
+        val providers =
+            listOf<(ClientOptions.Builder) -> Unit>(
+                { it.credential(AzureApiKeyCredential.create("test-azure-key")) },
+                { it.azureServiceVersion(AzureOpenAIServiceVersion.latestStableVersion()) },
+                { it.azureUrlPathMode(AzureUrlPathMode.UNIFIED) },
+                { it.apiKey(null as String?).httpRequestAuthenticator(authenticator) },
+            )
+        for (provider in providers) {
+            for (first in listOf(true, false)) {
+                val options = builder()
+                if (first) options.dataResidency(DataResidency.EU)
+                provider(options)
+                if (!first) options.dataResidency(DataResidency.EU)
+                val thrown = assertThrows<IllegalArgumentException> { options.build() }
+                assertThat(thrown.message).contains("third-party provider")
+            }
+        }
+        val azure = builder().baseUrl("https://example.openai.azure.com/openai/v1").build()
+        assertThrows<IllegalArgumentException> {
+            azure.toBuilder().dataResidency(DataResidency.EU).build()
+        }
+        val bedrock =
+            builder().apiKey(null as String?).httpRequestAuthenticator(authenticator).build()
+        assertThrows<IllegalArgumentException> {
+            bedrock.toBuilder().dataResidency(DataResidency.EU).build()
+        }
+        withBaseUrlProperty("https://example.openai.azure.com/openai/v1") {
+            assertThrows<IllegalArgumentException> {
+                builder().fromEnv().dataResidency(DataResidency.EU).build()
+            }
+            assertThat(builder().dataResidency(DataResidency.EU).fromEnv().build().baseUrl())
+                .isEqualTo("https://eu.api.openai.com/v1")
+        }
+    }
+
+    @Test
+    fun copiedResidencyRejectsNewProviderConfiguration() {
+        val authenticator =
+            object : HttpRequestAuthenticator {
+                override fun authenticate(request: HttpRequest): HttpRequest = request
+            }
+        val providers =
+            listOf<(ClientOptions.Builder) -> Unit>(
+                { it.credential(AzureApiKeyCredential.create("test-azure-key")) },
+                { it.azureServiceVersion(AzureOpenAIServiceVersion.latestStableVersion()) },
+                { it.azureUrlPathMode(AzureUrlPathMode.LEGACY) },
+                { it.apiKey(null as String?).httpRequestAuthenticator(authenticator) },
+            )
+        val eu = builder().dataResidency(DataResidency.EU).build().toBuilder().build()
+        for (provider in providers) {
+            assertThrows<IllegalArgumentException> { eu.toBuilder().apply(provider).build() }
+            for (baseUrlFirst in listOf(true, false)) {
+                val replacement = eu.toBuilder()
+                if (baseUrlFirst) replacement.baseUrl("https://example.openai.azure.com/openai/v1")
+                provider(replacement)
+                if (!baseUrlFirst) replacement.baseUrl("https://example.openai.azure.com/openai/v1")
+                assertThat(replacement.build().baseUrl())
+                    .isEqualTo("https://example.openai.azure.com/openai/v1")
+            }
+        }
+        val client = OpenAIClientImpl(eu)
+        assertThrows<IllegalArgumentException> {
+            client.withOptions { it.credential(AzureApiKeyCredential.create("test-azure-key")) }
+        }
+        assertThrows<IllegalArgumentException> {
+            client.async().withOptions { it.azureUrlPathMode(AzureUrlPathMode.UNIFIED) }
+        }
+        withBaseUrlProperty("https://example.openai.azure.com/openai/v1") {
+            assertThat(eu.toBuilder().fromEnv().build().baseUrl()).isEqualTo(eu.baseUrl())
+            assertThrows<IllegalArgumentException> {
+                eu.toBuilder()
+                    .fromEnv()
+                    .credential(AzureApiKeyCredential.create("test-azure-key"))
+                    .build()
+            }
+            assertThat(builder().fromEnv().build().baseUrl())
+                .isEqualTo("https://example.openai.azure.com/openai/v1")
+        }
+    }
+
+    private fun withBaseUrlProperty(url: String, block: () -> Unit) {
+        val previous = System.getProperty("openai.baseUrl")
+        System.setProperty("openai.baseUrl", url)
+        try {
+            block()
+        } finally {
+            if (previous == null) System.clearProperty("openai.baseUrl")
+            else System.setProperty("openai.baseUrl", previous)
+        }
+    }
+}

--- a/openai-java-core/src/test/kotlin/com/openai/core/DataResidencyTest.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/core/DataResidencyTest.kt
@@ -1,0 +1,63 @@
+package com.openai.core
+
+import com.openai.client.OpenAIClientImpl
+import com.openai.core.http.Headers
+import com.openai.core.http.HttpClient
+import com.openai.core.http.HttpRequest
+import com.openai.core.http.HttpResponse
+import java.util.concurrent.CompletableFuture
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+
+internal class DataResidencyTest {
+    private val httpClient = mock<HttpClient>()
+
+    private fun builder() = ClientOptions.builder().httpClient(httpClient).apiKey("test-api-key")
+
+    @Test
+    fun syncAndAsyncCopiesRouteOnlyThroughTheUrl() {
+        val capture = CaptureClient()
+        val original = OpenAIClientImpl(builder().httpClient(capture).build())
+        val eu = original.withOptions { it.dataResidency(DataResidency.EU) }
+        eu.models().list()
+        eu.async().withOptions { it.dataResidency(DataResidency.US) }.models().list().join()
+        original.models().list()
+        assertThat(capture.requests.map { it.url() })
+            .containsExactly(
+                "https://eu.api.openai.com/v1/models",
+                "https://us.api.openai.com/v1/models",
+                "https://api.openai.com/v1/models",
+            )
+        capture.requests.forEach {
+            assertThat(it.body).isNull()
+            assertThat(it.headers.names()).noneMatch { name ->
+                name.contains("residency", ignoreCase = true)
+            }
+            assertThat(it.headers.values("Authorization")).containsExactly("Bearer test-api-key")
+        }
+    }
+
+    private class CaptureClient : HttpClient {
+        val requests = mutableListOf<HttpRequest>()
+
+        override fun execute(request: HttpRequest, requestOptions: RequestOptions): HttpResponse {
+            requests.add(request)
+            return object : HttpResponse {
+                override fun statusCode() = 200
+
+                override fun headers() =
+                    Headers.builder().put("Content-Type", "application/json").build()
+
+                override fun body() = """{"object":"list","data":[]}""".byteInputStream()
+
+                override fun close() {}
+            }
+        }
+
+        override fun executeAsync(request: HttpRequest, requestOptions: RequestOptions) =
+            CompletableFuture.completedFuture(execute(request, requestOptions))
+
+        override fun close() {}
+    }
+}


### PR DESCRIPTION
## Summary

Let applications select an OpenAI regional endpoint by name instead of assembling base URLs themselves. `DataResidency` supports `GLOBAL`, `US`, `EU`, and `AE` on synchronous and asynchronous client builders, including clients derived with `toBuilder()`.

Conflicting explicit endpoints and third-party provider combinations fail locally. This selects routing only; it does not change project eligibility or provide regional fallback.
