### PR TITLE
fix: close workload identity delegate after auth cleanup failure

### DIFF
--- a/openai-java-core/src/main/kotlin/com/openai/core/http/WorkloadIdentityHttpClient.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/core/http/WorkloadIdentityHttpClient.kt
@@ -55,7 +55,18 @@ internal class WorkloadIdentityHttpClient(
     }
 
     override fun close() {
-        workloadIdentityAuth?.close()
+        try {
+            workloadIdentityAuth?.close()
+        } catch (authFailure: Throwable) {
+            try {
+                delegate.close()
+            } catch (delegateFailure: Throwable) {
+                if (delegateFailure !== authFailure) {
+                    authFailure.addSuppressed(delegateFailure)
+                }
+            }
+            throw authFailure
+        }
         delegate.close()
     }
 }

--- a/openai-java-core/src/test/kotlin/com/openai/core/http/WorkloadIdentityHttpClientTest.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/core/http/WorkloadIdentityHttpClientTest.kt
@@ -10,10 +10,12 @@ import java.util.concurrent.ExecutionException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argThat
+import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -132,6 +134,51 @@ internal class WorkloadIdentityHttpClientTest {
                 argThat { req -> req.headers.values("Authorization").contains("Bearer $token") },
                 any(),
             )
+    }
+
+    @Test
+    fun close_closesAuthAndDelegate() {
+        val workloadIdentityAuth = mock<WorkloadIdentityAuth>()
+        val delegateHttpClient = mock<HttpClient>()
+        val client = WorkloadIdentityHttpClient(delegateHttpClient, workloadIdentityAuth)
+
+        client.close()
+
+        verify(workloadIdentityAuth).close()
+        verify(delegateHttpClient).close()
+    }
+
+    @Test
+    fun close_whenAuthCloseFails_stillClosesDelegate() {
+        val authFailure = IllegalStateException("auth close failed")
+        val workloadIdentityAuth = mock<WorkloadIdentityAuth>()
+        val delegateHttpClient = mock<HttpClient>()
+        doThrow(authFailure).whenever(workloadIdentityAuth).close()
+        val client = WorkloadIdentityHttpClient(delegateHttpClient, workloadIdentityAuth)
+
+        val thrown = assertThrows<IllegalStateException> { client.close() }
+
+        assertThat(thrown).isSameAs(authFailure)
+        verify(workloadIdentityAuth).close()
+        verify(delegateHttpClient).close()
+    }
+
+    @Test
+    fun close_whenAuthAndDelegateCloseFail_suppressesDelegateFailure() {
+        val authFailure = IllegalStateException("auth close failed")
+        val delegateFailure = IllegalArgumentException("delegate close failed")
+        val workloadIdentityAuth = mock<WorkloadIdentityAuth>()
+        val delegateHttpClient = mock<HttpClient>()
+        doThrow(authFailure).whenever(workloadIdentityAuth).close()
+        doThrow(delegateFailure).whenever(delegateHttpClient).close()
+        val client = WorkloadIdentityHttpClient(delegateHttpClient, workloadIdentityAuth)
+
+        val thrown = assertThrows<IllegalStateException> { client.close() }
+
+        assertThat(thrown).isSameAs(authFailure)
+        assertThat(thrown.suppressed).containsExactly(delegateFailure)
+        verify(workloadIdentityAuth).close()
+        verify(delegateHttpClient).close()
     }
 
     private fun mockResponse(statusCode: Int, body: String): HttpResponse {


### PR DESCRIPTION
## Summary

Ensure `WorkloadIdentityHttpClient.close()` always attempts to close its delegate even when workload-identity authentication cleanup throws.

Fixes #882.

## Problem

The wrapper currently closes resources sequentially:

```kotlin
override fun close() {
    workloadIdentityAuth?.close()
    delegate.close()
}
```

A custom `SubjectTokenProvider` can implement `AutoCloseable`, and `WorkloadIdentityAuth.close()` delegates to it. If that cleanup throws, `delegate.close()` is skipped entirely.

That can leave the underlying HTTP transport, connection pool, executor, or other delegate-owned resources open.

The sibling `AuthenticatingHttpClient` already handles the same ownership problem correctly by attempting both closes and preserving failures through suppressed exceptions.

## Fix

Mirror that failure-preserving close pattern:

- attempt workload-identity cleanup first;
- if it fails, still attempt `delegate.close()`;
- propagate the auth failure as the primary exception;
- attach a distinct delegate-close failure as a suppressed exception;
- preserve normal delegate-close propagation when auth cleanup succeeds.

## Regression coverage

Extended `WorkloadIdentityHttpClientTest` to verify:

- normal close closes both auth and delegate resources;
- auth cleanup failure still closes the delegate and propagates the original auth failure;
- when both close operations fail, the delegate failure is retained as a suppressed exception.

## Validation

- branch is based directly on current upstream `main` at `cf942a40074291290634321ad9fe21e514030b4c`;
- branch is 0 commits behind upstream;
- production diff is 12 additions / 1 deletion in `WorkloadIdentityHttpClient.kt`;
- test style and failure semantics mirror the existing `AuthenticatingHttpClient` close coverage.

Full repository validation is left to GitHub Actions.

## Risk

Low. Successful close behavior is unchanged. The only behavioral change is that delegate cleanup is no longer skipped when workload-identity cleanup fails.