### PR TITLE
fix: percent-encode spaces in request path URLs

### DIFF
--- a/openai-java-core/src/main/kotlin/com/openai/core/http/HttpRequest.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/core/http/HttpRequest.kt
@@ -21,7 +21,7 @@ private constructor(
             if (!endsWith("/")) {
                 append("/")
             }
-            append(URLEncoder.encode(segment, "UTF-8"))
+            append(URLEncoder.encode(segment, "UTF-8").replace("+", "%20"))
         }
 
         if (queryParams.isEmpty()) {

--- a/openai-java-core/src/test/kotlin/com/openai/core/http/HttpRequestTest.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/core/http/HttpRequestTest.kt
@@ -34,13 +34,21 @@ internal class HttpRequestTest {
                 .build(),
             expectedUrl = "https://api.example.com/users/123/profile",
         ),
-        PATH_SEGMENT_WITH_SPECIAL_CHARS(
+        PATH_SEGMENT_WITH_SPACE(
             HttpRequest.builder()
                 .method(HttpMethod.GET)
                 .baseUrl("https://api.example.com")
                 .addPathSegment("user name")
                 .build(),
-            expectedUrl = "https://api.example.com/user+name",
+            expectedUrl = "https://api.example.com/user%20name",
+        ),
+        PATH_SEGMENT_WITH_LITERAL_PLUS(
+            HttpRequest.builder()
+                .method(HttpMethod.GET)
+                .baseUrl("https://api.example.com")
+                .addPathSegment("a+b")
+                .build(),
+            expectedUrl = "https://api.example.com/a%2Bb",
         ),
         SINGLE_QUERY_PARAM(
             HttpRequest.builder()


### PR DESCRIPTION
## Summary

Make `HttpRequest.url()` encode spaces in path segments as `%20` instead of `+`, matching URL path semantics and the URL actually constructed by the OkHttp transport.

Fixes #886.

## Problem

`HttpRequest.url()` currently uses `URLEncoder` for both path segments and query parameters.

For query parameters, form encoding is appropriate and a space becomes `+`.

For path segments, however, `+` is a literal plus character. A request containing:

```kotlin
.addPathSegment("user name")
```

currently renders as:

```text
https://api.example.com/user+name
```

The OkHttp transport itself constructs the request with `HttpUrl.Builder.addPathSegment`, so the actual wire URL uses:

```text
https://api.example.com/user%20name
```

`LoggingHttpClient` prints `request.url()`, which means SDK logs can show a different request target from the one actually sent.

## Fix

Keep the existing `URLEncoder` behavior for query components, but normalize the encoded path-segment space representation:

```kotlin
URLEncoder.encode(segment, "UTF-8").replace("+", "%20")
```

A literal plus remains unambiguous because `URLEncoder` already encodes it as `%2B` before the replacement is applied.

## Regression coverage

Updated `HttpRequestTest` to verify:

- a path segment containing a space renders with `%20`;
- a literal `+` path character renders as `%2B`;
- the existing query-space case remains `hello+world`.

## Validation

- branch is based directly on current upstream `main` at `cf942a40074291290634321ad9fe21e514030b4c`;
- branch is 0 commits behind upstream;
- production diff is exactly 1 addition / 1 deletion in `HttpRequest.kt`;
- the actual OkHttp request-construction path is unchanged.

Full repository validation is left to GitHub Actions.

## Risk

Low. This changes only the diagnostic/string rendering of path-segment spaces. Query encoding and transport request construction are unchanged.