### PR TITLE
fix: retry synchronous failures from async delegates

### DIFF
--- a/openai-java-core/src/main/kotlin/com/openai/core/http/RetryingHttpClient.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/core/http/RetryingHttpClient.kt
@@ -90,7 +90,14 @@ private constructor(
             val requestWithRetryCount =
                 if (shouldSendRetryCount) setRetryCountHeader(request, retries) else request
 
-            val responseFuture = httpClient.executeAsync(requestWithRetryCount, requestOptions)
+            val responseFuture =
+                try {
+                    httpClient.executeAsync(requestWithRetryCount, requestOptions)
+                } catch (throwable: Throwable) {
+                    CompletableFuture<HttpResponse>().also {
+                        it.completeExceptionally(throwable)
+                    }
+                }
             if (!isRetryable(requestWithRetryCount)) {
                 return responseFuture
             }

--- a/openai-java-core/src/test/kotlin/com/openai/core/http/RetryingHttpClientSynchronousAsyncFailureTest.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/core/http/RetryingHttpClientSynchronousAsyncFailureTest.kt
@@ -1,0 +1,130 @@
+package com.openai.core.http
+
+import com.openai.core.RequestOptions
+import com.openai.core.Sleeper
+import com.openai.errors.OpenAIRetryableException
+import java.io.ByteArrayInputStream
+import java.io.InputStream
+import java.time.Duration
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ExecutionException
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+internal class RetryingHttpClientSynchronousAsyncFailureTest {
+
+    private class RecordingSleeper : Sleeper {
+        val durations = mutableListOf<Duration>()
+
+        override fun sleep(duration: Duration) {
+            durations.add(duration)
+        }
+
+        override fun sleepAsync(duration: Duration): CompletableFuture<Void> {
+            durations.add(duration)
+            return CompletableFuture.completedFuture(null)
+        }
+
+        override fun close() {}
+    }
+
+    @Test
+    fun executeAsync_retriesSynchronousRetryableFailure() {
+        val attempts = mutableListOf<Int>()
+        var callCount = 0
+        val success = response(200)
+        val delegate =
+            object : HttpClient {
+                override fun execute(
+                    request: HttpRequest,
+                    requestOptions: RequestOptions,
+                ): HttpResponse = error("not used")
+
+                override fun executeAsync(
+                    request: HttpRequest,
+                    requestOptions: RequestOptions,
+                ): CompletableFuture<HttpResponse> {
+                    callCount++
+                    attempts.add(
+                        request.headers.values("X-Stainless-Retry-Count").single().toInt()
+                    )
+                    if (callCount == 1) {
+                        throw OpenAIRetryableException("retryable synchronous failure")
+                    }
+                    return CompletableFuture.completedFuture(success)
+                }
+
+                override fun close() {}
+            }
+        val sleeper = RecordingSleeper()
+        val client =
+            RetryingHttpClient.builder()
+                .httpClient(delegate)
+                .sleeper(sleeper)
+                .maxRetries(1)
+                .build()
+
+        val actual = client.executeAsync(request()).get()
+
+        assertThat(actual).isSameAs(success)
+        assertThat(callCount).isEqualTo(2)
+        assertThat(attempts).containsExactly(0, 1)
+        assertThat(sleeper.durations).hasSize(1)
+    }
+
+    @Test
+    fun executeAsync_returnsFailedFutureForSynchronousNonRetryableFailure() {
+        val failure = IllegalStateException("non-retryable synchronous failure")
+        var callCount = 0
+        val delegate =
+            object : HttpClient {
+                override fun execute(
+                    request: HttpRequest,
+                    requestOptions: RequestOptions,
+                ): HttpResponse = error("not used")
+
+                override fun executeAsync(
+                    request: HttpRequest,
+                    requestOptions: RequestOptions,
+                ): CompletableFuture<HttpResponse> {
+                    callCount++
+                    throw failure
+                }
+
+                override fun close() {}
+            }
+        val sleeper = RecordingSleeper()
+        val client =
+            RetryingHttpClient.builder()
+                .httpClient(delegate)
+                .sleeper(sleeper)
+                .maxRetries(2)
+                .build()
+
+        val call = runCatching { client.executeAsync(request()) }
+
+        assertThat(call.isSuccess).isTrue()
+        val thrown = assertThrows<ExecutionException> { call.getOrThrow().get() }
+        assertThat(thrown.cause).isSameAs(failure)
+        assertThat(callCount).isEqualTo(1)
+        assertThat(sleeper.durations).isEmpty()
+    }
+
+    private fun request(): HttpRequest =
+        HttpRequest.builder()
+            .method(HttpMethod.GET)
+            .baseUrl("https://api.example.com")
+            .build()
+
+    private fun response(statusCode: Int): HttpResponse =
+        object : HttpResponse {
+            override fun statusCode(): Int = statusCode
+
+            override fun headers(): Headers = Headers.builder().build()
+
+            override fun body(): InputStream = ByteArrayInputStream(ByteArray(0))
+
+            override fun close() {}
+        }
+}


### PR DESCRIPTION
## Summary

Route synchronous exceptions thrown by `HttpClient.executeAsync()` through `RetryingHttpClient`'s existing async retry machinery instead of letting them escape before retry handling is attached.

Fixes #888.

## Problem

`RetryingHttpClient.executeAsync()` currently calls its delegate directly:

```kotlin
val responseFuture = httpClient.executeAsync(requestWithRetryCount, requestOptions)
```

A custom `HttpClient` can throw synchronously from `executeAsync()` rather than returning an exceptionally completed future. In that case, the exception escapes before the existing `handleAsync` retry path runs.

That means synchronous `IOException`, `OpenAIIoException`, and `OpenAIRetryableException` failures bypass `maxRetries` entirely, even though the same failures are retryable when delivered asynchronously.

## Fix

Wrap the delegate call and convert a synchronous throwable into an exceptionally completed `CompletableFuture<HttpResponse>`.

The resulting future then flows through the existing retry handler unchanged, so:

- retryable synchronous failures use the normal backoff and retry-count logic;
- non-retryable synchronous failures are returned through the async API as failed futures;
- no duplicate retry policy is introduced.

## Regression coverage

Added focused tests for:

1. a synchronous `OpenAIRetryableException` followed by a successful response, verifying two attempts and retry-count headers `0` then `1`;
2. a synchronous non-retryable exception, verifying `executeAsync()` itself returns normally with an exceptionally completed future and no retry/backoff occurs.

## Validation

- branch is based on current upstream `main` at `cf942a40074291290634321ad9fe21e514030b4c`;
- branch is 0 commits behind upstream;
- production diff is 8 additions / 1 deletion in `RetryingHttpClient.kt`;
- retry classification, backoff, response handling, and synchronous `execute()` behavior are unchanged.

Full repository validation is left to GitHub Actions.

## Risk

Low. Existing delegates that already return futures are unaffected. The behavior changes only when an async delegate throws before returning a future.