### PR TITLE
fix: settle pending async sleeps on close

### DIFF
--- a/openai-java-core/src/main/kotlin/com/openai/core/DefaultSleeper.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/core/DefaultSleeper.kt
@@ -19,8 +19,10 @@ class DefaultSleeper : Sleeper {
         val task =
             object : TimerTask() {
                 override fun run() {
-                    if (synchronized(lock) { pending.remove(future) }) {
-                        future.complete(null)
+                    synchronized(lock) {
+                        if (pending.contains(future)) {
+                            future.complete(null)
+                        }
                     }
                 }
             }

--- a/openai-java-core/src/main/kotlin/com/openai/core/DefaultSleeper.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/core/DefaultSleeper.kt
@@ -8,21 +8,57 @@ import java.util.concurrent.CompletableFuture
 class DefaultSleeper : Sleeper {
 
     private val timer = Timer("DefaultSleeper", true)
+    private val lock = Any()
+    private val pending = mutableSetOf<CompletableFuture<Void>>()
+    private var closed = false
 
     override fun sleep(duration: Duration) = Thread.sleep(duration.toMillis())
 
     override fun sleepAsync(duration: Duration): CompletableFuture<Void> {
         val future = CompletableFuture<Void>()
-        timer.schedule(
+        val task =
             object : TimerTask() {
                 override fun run() {
-                    future.complete(null)
+                    if (synchronized(lock) { pending.remove(future) }) {
+                        future.complete(null)
+                    }
                 }
-            },
-            duration.toMillis(),
-        )
+            }
+
+        synchronized(lock) {
+            if (closed) {
+                future.cancel(false)
+                return future
+            }
+
+            pending.add(future)
+            future.whenComplete { _, _ ->
+                synchronized(lock) { pending.remove(future) }
+                task.cancel()
+            }
+
+            try {
+                timer.schedule(task, duration.toMillis())
+            } catch (throwable: Throwable) {
+                pending.remove(future)
+                throw throwable
+            }
+        }
+
         return future
     }
 
-    override fun close() = timer.cancel()
+    override fun close() {
+        val pendingFutures =
+            synchronized(lock) {
+                if (closed) {
+                    return
+                }
+                closed = true
+                timer.cancel()
+                pending.toList().also { pending.clear() }
+            }
+
+        pendingFutures.forEach { it.cancel(false) }
+    }
 }

--- a/openai-java-core/src/test/kotlin/com/openai/core/DefaultSleeperTest.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/core/DefaultSleeperTest.kt
@@ -1,0 +1,55 @@
+package com.openai.core
+
+import java.time.Duration
+import java.util.concurrent.TimeUnit
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+internal class DefaultSleeperTest {
+
+    @Test
+    fun closeCancelsPendingAsyncSleep() {
+        val sleeper = DefaultSleeper()
+        val future = sleeper.sleepAsync(Duration.ofHours(1))
+
+        sleeper.close()
+
+        assertThat(future.isDone).isTrue()
+        assertThat(future.isCancelled).isTrue()
+    }
+
+    @Test
+    fun completedAsyncSleepRemainsCompletedAfterClose() {
+        val sleeper = DefaultSleeper()
+        val future = sleeper.sleepAsync(Duration.ZERO)
+
+        future.get(1, TimeUnit.SECONDS)
+        sleeper.close()
+
+        assertThat(future.isDone).isTrue()
+        assertThat(future.isCancelled).isFalse()
+        assertThat(future.isCompletedExceptionally).isFalse()
+    }
+
+    @Test
+    fun closeIsIdempotent() {
+        val sleeper = DefaultSleeper()
+        val future = sleeper.sleepAsync(Duration.ofHours(1))
+
+        sleeper.close()
+        sleeper.close()
+
+        assertThat(future.isCancelled).isTrue()
+    }
+
+    @Test
+    fun sleepAsyncAfterCloseReturnsCancelledFuture() {
+        val sleeper = DefaultSleeper()
+        sleeper.close()
+
+        val call = runCatching { sleeper.sleepAsync(Duration.ofSeconds(1)) }
+
+        assertThat(call.isSuccess).isTrue()
+        assertThat(call.getOrThrow().isCancelled).isTrue()
+    }
+}


### PR DESCRIPTION
## Summary

Make `DefaultSleeper.close()` settle all pending `sleepAsync()` futures instead of abandoning them when its backing `Timer` is cancelled.

Fixes #889.

## Problem

`DefaultSleeper.sleepAsync()` completes its returned future from a scheduled `TimerTask`, while the old `close()` only called:

```kotlin
timer.cancel()
```

`Timer.cancel()` discards scheduled tasks that have not run. Their futures remain incomplete forever.

In the SDK this can strand an async retry chain if the client is closed while `RetryingHttpClient` is waiting on `sleeper.sleepAsync(backoffDuration)`.

A second edge case is `sleepAsync()` after close: `Timer.schedule()` throws synchronously because the timer has already been cancelled.

## Fix

`DefaultSleeper` now:

- tracks pending async sleep futures under a small lock;
- keeps a timer-fired future tracked until its completion state has been set, preventing `close()` from missing an incomplete future during the timer/close handoff;
- removes futures when they settle;
- marks itself closed and cancels the timer exactly once;
- cancels every still-pending future during close;
- returns an already-cancelled future for post-close `sleepAsync()` calls instead of throwing synchronously.

The synchronous `sleep()` path is unchanged.

## Regression coverage

Added tests verifying:

1. closing the sleeper cancels a long pending async sleep immediately;
2. a normally completed async sleep stays successfully completed after close;
3. repeated close is safe;
4. `sleepAsync()` after close returns a cancelled future without throwing from the method call.

## Review follow-up

The timer-fire-versus-close race identified in review is addressed by completing the future while holding the same lock used by `close()`, while leaving removal to the existing `whenComplete` callback. Therefore `close()` cannot observe the future as absent from `pending` before it is already settled.

No test-only production hook was added solely to force that narrow handoff. The existing lifecycle tests remain focused on externally observable behavior.

## Validation

- changes remain limited to `DefaultSleeper` and focused lifecycle tests;
- normal timer-driven completion remains unchanged for pending sleeps;
- the follow-up race fix is commit `1bd8c8d664e495b7676cef8c42f270de190403d0`;
- GitHub Actions on the fork require approval (`action_required`) rather than reporting a test failure.

## Risk

Low. The behavioral change is limited to sleeper shutdown: pending async waits now terminate deterministically instead of becoming permanently incomplete.