### PR TITLE
fix: always close retry sleeper after delegate failure

### DIFF
--- a/openai-java-core/src/main/kotlin/com/openai/core/http/RetryingHttpClient.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/core/http/RetryingHttpClient.kt
@@ -131,7 +131,18 @@ private constructor(
     }
 
     override fun close() {
-        httpClient.close()
+        try {
+            httpClient.close()
+        } catch (httpClientFailure: Throwable) {
+            try {
+                sleeper.close()
+            } catch (sleeperFailure: Throwable) {
+                if (sleeperFailure !== httpClientFailure) {
+                    httpClientFailure.addSuppressed(sleeperFailure)
+                }
+            }
+            throw httpClientFailure
+        }
         sleeper.close()
     }
 

--- a/openai-java-core/src/test/kotlin/com/openai/core/http/RetryingHttpClientCloseTest.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/core/http/RetryingHttpClientCloseTest.kt
@@ -1,0 +1,73 @@
+package com.openai.core.http
+
+import com.openai.core.Sleeper
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+internal class RetryingHttpClientCloseTest {
+
+    @Test
+    fun closeClosesDelegateAndSleeper() {
+        val delegate = mock<HttpClient>()
+        val sleeper = mock<Sleeper>()
+        val client = client(delegate, sleeper)
+
+        client.close()
+
+        verify(delegate).close()
+        verify(sleeper).close()
+    }
+
+    @Test
+    fun closeStillClosesSleeperWhenDelegateCloseFails() {
+        val delegateFailure = IllegalStateException("delegate close failed")
+        val delegate = mock<HttpClient>()
+        val sleeper = mock<Sleeper>()
+        doThrow(delegateFailure).whenever(delegate).close()
+        val client = client(delegate, sleeper)
+
+        val thrown = runCatching { client.close() }.exceptionOrNull()
+
+        assertThat(thrown).isSameAs(delegateFailure)
+        verify(sleeper).close()
+    }
+
+    @Test
+    fun closeSuppressesSleeperFailureWhenBothCloseOperationsFail() {
+        val delegateFailure = IllegalStateException("delegate close failed")
+        val sleeperFailure = IllegalArgumentException("sleeper close failed")
+        val delegate = mock<HttpClient>()
+        val sleeper = mock<Sleeper>()
+        doThrow(delegateFailure).whenever(delegate).close()
+        doThrow(sleeperFailure).whenever(sleeper).close()
+        val client = client(delegate, sleeper)
+
+        val thrown = runCatching { client.close() }.exceptionOrNull()
+
+        assertThat(thrown).isSameAs(delegateFailure)
+        assertThat(thrown!!.suppressed).containsExactly(sleeperFailure)
+        verify(sleeper).close()
+    }
+
+    @Test
+    fun closePropagatesSleeperFailureWhenDelegateClosesSuccessfully() {
+        val sleeperFailure = IllegalStateException("sleeper close failed")
+        val delegate = mock<HttpClient>()
+        val sleeper = mock<Sleeper>()
+        doThrow(sleeperFailure).whenever(sleeper).close()
+        val client = client(delegate, sleeper)
+
+        val thrown = runCatching { client.close() }.exceptionOrNull()
+
+        assertThat(thrown).isSameAs(sleeperFailure)
+        verify(delegate).close()
+        verify(sleeper).close()
+    }
+
+    private fun client(delegate: HttpClient, sleeper: Sleeper): HttpClient =
+        RetryingHttpClient.builder().httpClient(delegate).sleeper(sleeper).build()
+}


### PR DESCRIPTION
## Summary

Ensure `RetryingHttpClient.close()` always attempts to close its owned `Sleeper`, even when closing the delegate `HttpClient` throws.

Fixes #890.

## Problem

`RetryingHttpClient` owns both its transport and sleeper, but currently closes them sequentially:

```kotlin
override fun close() {
    httpClient.close()
    sleeper.close()
}
```

If `httpClient.close()` throws, sleeper cleanup is skipped entirely.

The default sleeper owns a `Timer`, and custom sleepers can own other resources, so a transport cleanup failure can cause a second independent resource leak.

## Fix

Mirror the failure-preserving cleanup pattern already used by `AuthenticatingHttpClient`:

- attempt transport close first;
- if it fails, still attempt sleeper close;
- propagate the transport failure as the primary exception;
- attach a distinct sleeper failure as suppressed;
- when transport close succeeds, propagate any sleeper-close failure normally.

No retry execution behavior is changed.

## Regression coverage

Added focused tests verifying:

1. normal close closes both delegate and sleeper;
2. delegate-close failure still closes the sleeper and remains the propagated failure;
3. if both fail, the sleeper failure is attached as suppressed;
4. a sleeper-only failure propagates normally after a successful delegate close.

## Validation

- branch is based on current upstream `main` at `cf942a40074291290634321ad9fe21e514030b4c`;
- branch is 0 commits behind upstream;
- production diff is 12 additions / 1 deletion in `RetryingHttpClient.kt`;
- retry classification, backoff, request execution, and async behavior are unchanged.

Full repository validation is left to GitHub Actions.

## Risk

Low. Successful close behavior is unchanged. The change only guarantees that both owned cleanup paths are attempted when one fails.