### PR TITLE
fix: upgrade Dokka's build-only jsoup dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,7 @@ plugins {
 }
 
 val dokkaJacksonVersion = "2.18.9"
+val dokkaJsoupVersion = "1.23.1"
 
 repositories {
     mavenCentral()
@@ -33,9 +34,9 @@ allprojects {
     group = "com.openai"
     version = "4.52.0" // x-release-please-version
 
-    // Dokka 2.1.0 depends on Jackson 2.15.3. Keep its isolated build-tool classpaths on a
-    // secure, internally aligned Jackson release without changing the SDK's published or
-    // compatibility-test dependency versions.
+    // Dokka 2.1.0 depends on Jackson 2.15.3 and jsoup 1.16.1. Keep its isolated build-tool
+    // classpaths on secure versions without changing the SDK's published or compatibility-test
+    // dependencies, and keep Jackson internally aligned.
     configurations.matching { it.name.startsWith("dokka") }.configureEach {
         resolutionStrategy.eachDependency {
             if (
@@ -44,6 +45,9 @@ allprojects {
             ) {
                 useVersion(dokkaJacksonVersion)
                 because("Dokka's build-only Jackson classpath must use a secure aligned release")
+            } else if (requested.group == "org.jsoup" && requested.name == "jsoup") {
+                useVersion(dokkaJsoupVersion)
+                because("Dokka's build-only jsoup classpath must use a secure release")
             }
         }
     }


### PR DESCRIPTION
## Summary

- Upgrade Dokka's isolated `org.jsoup:jsoup` dependency from `1.16.1` to `1.23.1`, addressing Dependabot alert #132 (CVE-2026-71497).
- Reuse the existing Dokka-only dependency resolution policy without adding jsoup to published SDK runtimes or changing Jackson alignment, Dokka V1 behavior, public APIs, or Java 8 consumer support.
- Keep this change scoped to the jsoup remediation identified in SDK-306.

## Verification

Validated with Java 21:

- Root, core, and Bedrock `dokkaJavadocPlugin` configurations resolve `org.jsoup:jsoup:1.23.1`.
- `:openai-java:runtimeClasspath` contains no jsoup dependency.
- `:openai-java-client-okhttp:dokkaJavadoc` generates Javadocs successfully.
- `:openai-java:verifyVersionSupportPolicy`, `:openai-java-client-okhttp:verifyVersionSupportPolicy`, and `:openai-java-bedrock:verifyVersionSupportPolicy` all pass.
- Full aggregated `:openai-java:dokkaJavadocJar` was also generated during implementation.

Part of SDK-306.