### PR TITLE
docs: correct client rate-limit guidance

### DIFF
--- a/openai-java-core/src/main/kotlin/com/openai/client/OpenAIClient.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/client/OpenAIClient.kt
@@ -35,9 +35,9 @@ import java.util.function.Consumer
  *
  * This client performs best when you create a single instance and reuse it for all interactions
  * with the REST API. This is because each client holds its own connection pool and thread pools.
- * Reusing connections and threads reduces latency and saves memory. The client also handles rate
- * limiting per client. This means that creating and using multiple instances at the same time will
- * not respect rate limits.
+ * Reusing connections and threads reduces latency and saves memory. Requests may be retried
+ * individually when the API returns a retryable response, but the client does not proactively
+ * coordinate API rate limits across requests or client instances.
  *
  * The threads and connections that are held will be released automatically if they remain idle. But
  * if you are writing an application that needs to aggressively release unused resources, then you

--- a/openai-java-core/src/main/kotlin/com/openai/client/OpenAIClientAsync.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/client/OpenAIClientAsync.kt
@@ -35,9 +35,9 @@ import java.util.function.Consumer
  *
  * This client performs best when you create a single instance and reuse it for all interactions
  * with the REST API. This is because each client holds its own connection pool and thread pools.
- * Reusing connections and threads reduces latency and saves memory. The client also handles rate
- * limiting per client. This means that creating and using multiple instances at the same time will
- * not respect rate limits.
+ * Reusing connections and threads reduces latency and saves memory. Requests may be retried
+ * individually when the API returns a retryable response, but the client does not proactively
+ * coordinate API rate limits across requests or client instances.
  *
  * The threads and connections that are held will be released automatically if they remain idle. But
  * if you are writing an application that needs to aggressively release unused resources, then you


### PR DESCRIPTION
## Summary

Correct the `OpenAIClient` and `OpenAIClientAsync` class-level documentation so it no longer claims that each client proactively handles API rate limiting.

Fixes #644.

## Problem

Both client interfaces currently say:

> The client also handles rate limiting per client. This means that creating and using multiple instances at the same time will not respect rate limits.

That implies client-wide proactive rate-limit coordination. The SDK does not implement that behavior. It can retry individual requests after retryable responses, including rate-limit responses, but it does not coordinate a shared rate budget across requests or across client instances.

The existing wording can therefore lead users to believe that reusing one client is required for correct API rate-limit accounting.

## Fix

Update the shared guidance in both synchronous and asynchronous client interfaces to state that:

- reusing a client is still recommended for connection-pool/thread-pool efficiency;
- individual requests may be retried when the API returns a retryable response;
- the client does not proactively coordinate API rate limits across requests or client instances.

## Scope

- `OpenAIClient.kt`: 3 additions / 3 deletions
- `OpenAIClientAsync.kt`: 3 additions / 3 deletions
- no API, runtime, retry, or transport behavior changes

## Validation

The branch is based on current upstream `main` at `81134d727946fb84cc48db98e6c8c53c8a8d22ab` and is 0 commits behind upstream.

## Risk

Minimal. Documentation only, with sync and async client guidance kept consistent.