### PR TITLE
fix: upgrade WireMock's test-only Apache HttpComponents dependencies

### DIFF
--- a/buildSrc/src/main/kotlin/openai.wiremock-test.gradle.kts
+++ b/buildSrc/src/main/kotlin/openai.wiremock-test.gradle.kts
@@ -35,18 +35,30 @@ dependencies {
         testImplementation("com.github.jknack:handlebars:4.5.3") {
             because("WireMock's transitive 4.3.1 dependency is affected by CVE-2026-55760")
         }
-        testImplementation("org.apache.httpcomponents.client5:httpclient5:5.6.3") {
-            because("WireMock's transitive HTTP client is affected by CVE-2026-64607")
-        }
-        testImplementation("org.apache.httpcomponents.core5:httpcore5:5.4.3") {
-            because("WireMock's transitive HTTP core is affected by CVE-2026-54399")
-        }
-        testImplementation("org.apache.httpcomponents.core5:httpcore5-h2:5.4.3") {
-            because("WireMock's transitive HTTP/2 core is affected by CVE-2026-54428")
-        }
     }
 
     testImplementation(platform("org.eclipse.jetty:jetty-bom:12.0.36"))
     testImplementation(platform("org.eclipse.jetty.ee10:jetty-ee10-bom:12.0.36"))
     testImplementation("org.wiremock:wiremock-jetty12:3.13.2")
+}
+
+// API-compatibility source sets own their dependencies and do not extend testImplementation.
+configurations.matching {
+    it.name == "testImplementation" ||
+        it.name == "externalApiCompatibilityImplementation" ||
+        it.name == "proposedApiCompatibilityImplementation"
+}.configureEach {
+    val configurationName = name
+
+    project.dependencies.constraints {
+        add(configurationName, "org.apache.httpcomponents.client5:httpclient5:5.6.3") {
+            because("WireMock's transitive HTTP client is affected by CVE-2026-64607")
+        }
+        add(configurationName, "org.apache.httpcomponents.core5:httpcore5:5.4.3") {
+            because("WireMock's transitive HTTP core is affected by CVE-2026-54399")
+        }
+        add(configurationName, "org.apache.httpcomponents.core5:httpcore5-h2:5.4.3") {
+            because("WireMock's transitive HTTP/2 core is affected by CVE-2026-54428")
+        }
+    }
 }

--- a/buildSrc/src/main/kotlin/openai.wiremock-test.gradle.kts
+++ b/buildSrc/src/main/kotlin/openai.wiremock-test.gradle.kts
@@ -35,6 +35,15 @@ dependencies {
         testImplementation("com.github.jknack:handlebars:4.5.3") {
             because("WireMock's transitive 4.3.1 dependency is affected by CVE-2026-55760")
         }
+        testImplementation("org.apache.httpcomponents.client5:httpclient5:5.6.3") {
+            because("WireMock's transitive HTTP client is affected by CVE-2026-64607")
+        }
+        testImplementation("org.apache.httpcomponents.core5:httpcore5:5.4.3") {
+            because("WireMock's transitive HTTP core is affected by CVE-2026-54399")
+        }
+        testImplementation("org.apache.httpcomponents.core5:httpcore5-h2:5.4.3") {
+            because("WireMock's transitive HTTP/2 core is affected by CVE-2026-54428")
+        }
     }
 
     testImplementation(platform("org.eclipse.jetty:jetty-bom:12.0.36"))


### PR DESCRIPTION
## Summary

- Constrain WireMock's test-only Apache HttpComponents dependencies in the shared test convention: `httpclient5:5.6.3`, `httpcore5:5.4.3`, and `httpcore5-h2:5.4.3`.
- Address Dependabot alerts #133, #135, and #136 (CVE-2026-54399, CVE-2026-54428, and CVE-2026-64607) without changing published dependency graphs, public APIs, packaging, or Jackson compatibility.
- Apply the aligned versions consistently to the core, OkHttp client, and Bedrock test classpaths.

## Verification

- Ran the complete repository test suite against the OpenAPI mock server, the complete legacy-Jackson compatibility suite, and `buildSrc` tests: **12,151 test cases, zero failures/errors** (21 existing skips).
- Ran repository-wide Kotlin/Java lint, published-artifact integrity checks, version-support policy checks, and ProGuard/R8 compatibility checks.
- Executed all four published artifact runtime probes on **Java 8**, including all five Bedrock credential-provider paths, while building with Java 21.
- Verified all three affected test dependency graphs resolve the patched aligned versions.
- Compared the standard SDK, core, OkHttp client, and Bedrock runtime dependency trees against the audited baseline; all four are unchanged and contain no Apache HttpComponents.

```bash
./scripts/test \
  :openai-java-core:testJacksonCompatibility \
  :buildSrc:test \
  lintKotlin lintJava verifyVersionSupportPolicy \
  :openai-java-core:verifyCoreCompilationArtifact \
  :openai-java-runtime-compatibility:runRuntimeCompatibility \
  -PruntimeJavaVersion=8 \
  -Porg.gradle.java.installations.paths=<jdk21>,<jdk8>
```

Part of SDK-306.