### PR TITLE
fix(ci): isolate trusted Gradle caches from pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,8 @@ jobs:
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
+        with:
+          cache-read-only: ${{ github.ref_name != github.event.repository.default_branch }}
 
       - name: Verify Maven Central credential transport
         run: |
@@ -78,6 +80,8 @@ jobs:
     name: CI / build + Jackson compatibility
     runs-on: ${{ vars.SDK_GHA_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 30
+    outputs:
+      gradle-cache-artifact-id: ${{ steps.gradle-cache-artifact.outputs.artifact-id }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -94,6 +98,8 @@ jobs:
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
+        with:
+          cache-read-only: ${{ github.ref_name != github.event.repository.default_branch }}
 
       - name: Build SDK and run compatibility tests
         env:
@@ -107,16 +113,16 @@ jobs:
         run: ./scripts/collect-gradle-build-cache "$CACHE_ARTIFACT_PATH"
 
       # setup-gradle's cross-run cache is read-only on pull requests. Publish this run's local
-      # build cache explicitly so downstream jobs can restore the exact compilation that passed.
+      # build cache as an immutable artifact for downstream jobs with the same trust boundary.
       - name: Upload exact-run Gradle build cache
+        id: gradle-cache-artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ci-gradle-build-cache-${{ github.run_id }}
+          name: ci-gradle-build-cache-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/ci-gradle-build-cache
           if-no-files-found: error
           retention-days: 1
           compression-level: 0
-          overwrite: true
 
   test:
     name: CI / tests
@@ -146,7 +152,8 @@ jobs:
       - name: Restore exact-run Gradle build cache
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: ci-gradle-build-cache-${{ github.run_id }}
+          artifact-ids: ${{ needs.build.outputs.gradle-cache-artifact-id }}
+          digest-mismatch: error
           path: ~/.gradle/caches/build-cache-1
 
       - name: Run tests
@@ -186,7 +193,8 @@ jobs:
       - name: Restore exact-run Gradle build cache
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: ci-gradle-build-cache-${{ github.run_id }}
+          artifact-ids: ${{ needs.build.outputs.gradle-cache-artifact-id }}
+          digest-mismatch: error
           path: ~/.gradle/caches/build-cache-1
 
       - name: Compile previous tests against the proposed SDK
@@ -234,6 +242,8 @@ jobs:
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
+        with:
+          cache-read-only: ${{ github.ref_name != github.event.repository.default_branch }}
 
       - name: Read version support policy
         id: matrix
@@ -278,13 +288,14 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
         with:
-          cache-read-only: ${{ needs.build.result == 'success' }}
+          cache-read-only: true
 
       - name: Restore exact-run Gradle build cache
         if: needs.build.result == 'success'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: ci-gradle-build-cache-${{ github.run_id }}
+          artifact-ids: ${{ needs.build.outputs.gradle-cache-artifact-id }}
+          digest-mismatch: error
           path: ~/.gradle/caches/build-cache-1
 
       - name: Run consumer compatibility smoke test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,7 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           artifact-ids: ${{ needs.build.outputs.gradle-cache-artifact-id }}
+          merge-multiple: true
           digest-mismatch: error
           path: ~/.gradle/caches/build-cache-1
 
@@ -194,6 +195,7 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           artifact-ids: ${{ needs.build.outputs.gradle-cache-artifact-id }}
+          merge-multiple: true
           digest-mismatch: error
           path: ~/.gradle/caches/build-cache-1
 
@@ -295,6 +297,7 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           artifact-ids: ${{ needs.build.outputs.gradle-cache-artifact-id }}
+          merge-multiple: true
           digest-mismatch: error
           path: ~/.gradle/caches/build-cache-1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
       - next
+  # GitHub's cache service confines this event's writes to refs/pull/<number>/merge,
+  # even when an untrusted PR changes this workflow or its cache policy tests.
   pull_request:
     branches:
       - main

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -268,8 +268,24 @@ jobs:
             8
             21
 
+      - name: Create isolated release Gradle User Home
+        env:
+          TRUSTED_GRADLE_USER_HOME: ${{ runner.temp }}/trusted-release-gradle-${{ github.run_id }}-${{ github.run_attempt }}
+        run: |
+          set -euo pipefail
+
+          if [[ -e "$TRUSTED_GRADLE_USER_HOME" || -L "$TRUSTED_GRADLE_USER_HOME" ]]; then
+            echo "::error::Release Gradle User Home already exists"
+            exit 1
+          fi
+
+          mkdir -m 700 "$TRUSTED_GRADLE_USER_HOME"
+          printf 'GRADLE_USER_HOME=%s\n' "$TRUSTED_GRADLE_USER_HOME" >> "$GITHUB_ENV"
+
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
+        with:
+          cache-disabled: true
 
       - name: Compile the openai-java-core project
         run: ./gradlew :openai-java-core:compileJava :openai-java-core:compileTestJava -x test

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,3 +34,36 @@ Sonatype tokens, and private signing keys before submitting a report.
 Please give the maintainers a reasonable opportunity to investigate and address the issue before public disclosure.
 
 Thank you for helping us keep this SDK and the systems it interacts with secure.
+
+## Gradle Build Cache Trust
+
+The Kotlin Gradle plugin used to build this SDK is affected by
+[CVE-2026-53914](https://github.com/advisories/GHSA-r937-wjx7-w2jp), which can
+execute code when malicious Kotlin build-cache metadata is deserialized. This is
+a build-tooling vulnerability; the affected plugin is not published as an SDK
+runtime dependency.
+
+Pull-request CI explicitly treats cross-run Gradle caches as read-only. Its
+compilation outputs are shared only between jobs in the same unprivileged
+workflow run and attempt through an immutable artifact, identified by the
+producing job's artifact ID and rejected if its SHA-256 digest does not match.
+These artifacts must never be restored by release, signing, or other
+secret-bearing jobs.
+
+Maven Central publishing instead creates a new, private Gradle User Home for
+each workflow run and attempt, refuses an existing directory or symbolic link,
+and disables all cross-run Gradle cache restoration and saving. Gradle invocations
+within the publishing job still reuse the trusted cache created by that job.
+This boundary assumes an ephemeral GitHub-hosted runner or an equivalently
+isolated, trusted self-hosted runner; it cannot protect a runner that untrusted
+code has already compromised.
+
+The first upstream fix is Kotlin `2.4.20-Beta1`; while no stable patched release
+is available, the production compiler must not be upgraded to that beta solely to
+close this alert. Cache isolation reduces the exposure but does not fix the
+vulnerable plugin: malicious trusted inputs, compromised upstream dependencies,
+or a compromised runner remain risks. Once a stable Kotlin release at or above
+`2.4.20` is available, upgrade both Kotlin plugin declarations in `buildSrc`,
+review Gradle and embedded Kotlin compatibility, and rerun publishing, Jackson
+compatibility, and the Java 8 consumer/runtime compatibility matrix before
+removing the temporary risk acceptance.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -43,8 +43,21 @@ execute code when malicious Kotlin build-cache metadata is deserialized. This is
 a build-tooling vulnerability; the affected plugin is not published as an SDK
 runtime dependency.
 
-Pull-request CI explicitly treats cross-run Gradle caches as read-only. Its
-compilation outputs are shared only between jobs in the same unprivileged
+The primary trust boundary is enforced by GitHub's cache service, not by code
+from a pull request. GitHub scopes every `pull_request` cache write to
+`refs/pull/<number>/merge`. These runs
+cannot write to the default-branch cache scope, and their entries cannot be
+restored by `main`, other pull requests, or privileged release workflows. See
+[GitHub's dependency cache access restrictions](https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching#restrictions-for-accessing-a-cache).
+
+Pull-request CI additionally requests read-only cross-run Gradle caches, but this
+input and its proposed tests are not a security boundary: an untrusted author can
+change either without bypassing GitHub's server-enforced cache scope. Changes to
+trusted default-branch workflows must pass the repository's externally enforced
+ruleset and the base branch's CODEOWNERS approval before they can affect trusted
+`push`, scheduled, or manual workflows.
+
+Compilation outputs are shared only between jobs in the same unprivileged
 workflow run and attempt through an immutable artifact, identified by the
 producing job's artifact ID and rejected if its SHA-256 digest does not match.
 These artifacts must never be restored by release, signing, or other

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -41,4 +41,7 @@ tasks.test {
     inputs
         .file(layout.projectDirectory.file("../.github/workflows/ci.yml"))
         .withPathSensitivity(PathSensitivity.RELATIVE)
+    inputs
+        .file(layout.projectDirectory.file("../.github/workflows/create-releases.yml"))
+        .withPathSensitivity(PathSensitivity.RELATIVE)
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -45,4 +45,7 @@ tasks.test {
     inputs
         .file(layout.projectDirectory.file("../.github/workflows/create-releases.yml"))
         .withPathSensitivity(PathSensitivity.RELATIVE)
+    inputs
+        .file(layout.projectDirectory.file("../SECURITY.md"))
+        .withPathSensitivity(PathSensitivity.RELATIVE)
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
 
     testImplementation(kotlin("test"))
     testImplementation("org.junit.jupiter:junit-jupiter:5.9.3")
+    testImplementation("org.yaml:snakeyaml:2.6")
 }
 
 tasks.test {

--- a/buildSrc/src/test/kotlin/com/openai/gradle/ApiCompatibilityCachePolicyTest.kt
+++ b/buildSrc/src/test/kotlin/com/openai/gradle/ApiCompatibilityCachePolicyTest.kt
@@ -33,7 +33,11 @@ class ApiCompatibilityCachePolicyTest {
         assertContains(testJob, "if: needs.build.result == 'success'")
         assertContains(testJob, "cache-read-only: true")
         assertContains(testJob, "name: Restore exact-run Gradle build cache")
-        assertContains(testJob, "name: ci-gradle-build-cache-\${{ github.run_id }}")
+        assertContains(
+            testJob,
+            "artifact-ids: \${{ needs.build.outputs.gradle-cache-artifact-id }}",
+        )
+        assertContains(testJob, "digest-mismatch: error")
     }
 
     @Test

--- a/buildSrc/src/test/kotlin/com/openai/gradle/GradleCacheTrustPolicyTest.kt
+++ b/buildSrc/src/test/kotlin/com/openai/gradle/GradleCacheTrustPolicyTest.kt
@@ -26,6 +26,27 @@ class GradleCacheTrustPolicyTest {
     }
 
     @Test
+    fun `untrusted CI cannot move outside GitHub enforced pull request cache scope`() {
+        val workflow = Path.of("../.github/workflows/ci.yml").readText()
+
+        listOf(
+                workflow.replaceFirst("\n  pull_request:\n", "\n  pull_request_target:\n"),
+                workflow.replaceFirst(
+                    "\n  workflow_dispatch:\n",
+                    "\n  workflow_run:\n" +
+                        "    workflows: [CI]\n" +
+                        "    types: [completed]\n" +
+                        "  workflow_dispatch:\n",
+                ),
+                "$workflow\n\"on\":\n  pull_request:\n",
+            )
+            .forEach { poisonedWorkflow ->
+                assertTrue(poisonedWorkflow != workflow)
+                assertFailsWith<AssertionError> { assertPullRequestCachePolicy(poisonedWorkflow) }
+            }
+    }
+
+    @Test
     fun `pull request cache policy rejects write-only overrides`() {
         val workflow = Path.of("../.github/workflows/ci.yml").readText()
 
@@ -177,6 +198,37 @@ class GradleCacheTrustPolicyTest {
     }
 
     @Test
+    fun `publishing rejects untrusted pull request and completion triggers`() {
+        val workflow = Path.of("../.github/workflows/create-releases.yml").readText()
+
+        listOf(
+                "  pull_request:\n    branches: [main]\n",
+                "  pull_request_target:\n    branches: [main]\n",
+                "  workflow_run:\n    workflows: [CI]\n    types: [completed]\n",
+            )
+            .forEach { untrustedTrigger ->
+                val poisonedWorkflow = workflow.replaceFirst("on:\n", "on:\n$untrustedTrigger")
+
+                assertTrue(poisonedWorkflow != workflow)
+                assertFailsWith<AssertionError> { assertPublishingCachePolicy(poisonedWorkflow) }
+            }
+    }
+
+    @Test
+    fun `documented cache trust boundary is enforced outside pull request code`() {
+        val securityPolicy = Path.of("../SECURITY.md").readText()
+
+        assertContains(securityPolicy, "`refs/pull/<number>/merge`")
+        assertContains(securityPolicy, "cannot write to the default-branch cache scope")
+        assertContains(securityPolicy, "not a security boundary")
+        assertContains(securityPolicy, "base branch's CODEOWNERS")
+        assertContains(
+            securityPolicy,
+            "https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching",
+        )
+    }
+
+    @Test
     fun `publishing rejects the complete GitHub cache action family`() {
         val workflow = Path.of("../.github/workflows/create-releases.yml").readText()
         val compilationStep = "      - name: Compile the openai-java-core project\n"
@@ -276,8 +328,17 @@ class GradleCacheTrustPolicyTest {
     }
 
     private fun assertPullRequestCachePolicy(workflow: String) {
+        val parsedWorkflow = parseWorkflow(workflow)
+        assertTrue(
+            "pull_request" in parsedWorkflow.events,
+            "Untrusted CI must use GitHub's server-enforced pull-request cache scope.",
+        )
+        assertTrue(
+            parsedWorkflow.events.all { it in setOf("push", "pull_request", "workflow_dispatch") },
+            "Untrusted CI must not run in a default-branch-context event such as pull_request_target.",
+        )
         val setupActions =
-            parseWorkflow(workflow).jobs.values.flatMap { job ->
+            parsedWorkflow.jobs.values.flatMap { job ->
                 val initializers = job.actions.filter { it.initializesGradle }
 
                 if (initializers.isNotEmpty()) {
@@ -314,7 +375,12 @@ class GradleCacheTrustPolicyTest {
     }
 
     private fun assertPublishingCachePolicy(workflow: String) {
-        val publishJob = parseWorkflow(workflow).job("publish")
+        val parsedWorkflow = parseWorkflow(workflow)
+        assertTrue(
+            parsedWorkflow.events.all { it in setOf("push", "schedule", "workflow_dispatch") },
+            "Privileged publishing must accept only trusted default-branch events.",
+        )
+        val publishJob = parsedWorkflow.job("publish")
         val isolation =
             publishJob.steps.indexOfFirst { it.name == "Create isolated release Gradle User Home" }
         val initializers =
@@ -376,8 +442,23 @@ class GradleCacheTrustPolicyTest {
                 ?: error("A GitHub Actions workflow must be a YAML mapping.")
         val jobs =
             document["jobs"] as? Map<*, *> ?: error("A GitHub Actions workflow must declare jobs.")
+        val eventDeclarations = document.entries.filter { (key, _) -> key == "on" || key == true }
+        assertEquals(
+            1,
+            eventDeclarations.size,
+            "A GitHub Actions workflow must have exactly one trigger declaration.",
+        )
+        val events =
+            eventDeclarations
+                .single()
+                .value
+                .workflowMapping("workflow events")
+                .keys
+                .map { it.workflowScalar("workflow event") }
+                .toSet()
 
         return Workflow(
+            events,
             jobs.entries.associate { (name, value) ->
                 val jobName = name.workflowScalar("job name")
                 val job = value.workflowMapping("job $jobName")
@@ -404,7 +485,7 @@ class GradleCacheTrustPolicyTest {
 
                 jobName to
                     WorkflowJob(jobName, job["outputs"].workflowScalars("job outputs"), steps)
-            }
+            },
         )
     }
 
@@ -443,7 +524,7 @@ class GradleCacheTrustPolicyTest {
             else -> error("$description must be a YAML scalar.")
         }
 
-    private data class Workflow(val jobs: Map<String, WorkflowJob>) {
+    private data class Workflow(val events: Set<String>, val jobs: Map<String, WorkflowJob>) {
         fun job(name: String): WorkflowJob =
             jobs[name] ?: error("GitHub Actions workflow is missing job $name.")
     }

--- a/buildSrc/src/test/kotlin/com/openai/gradle/GradleCacheTrustPolicyTest.kt
+++ b/buildSrc/src/test/kotlin/com/openai/gradle/GradleCacheTrustPolicyTest.kt
@@ -1,14 +1,19 @@
 package com.openai.gradle
 
+import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.io.path.readText
+import kotlin.io.path.writeText
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import org.junit.jupiter.api.io.TempDir
 
 class GradleCacheTrustPolicyTest {
+    @TempDir lateinit var temporaryDirectory: Path
+
     @Test
     fun `all pull request Gradle jobs keep cross-run caches read-only`() {
         val workflow = Path.of("../.github/workflows/ci.yml").readText()
@@ -73,6 +78,43 @@ class GradleCacheTrustPolicyTest {
                 restoreStep.contains("run-id:"),
                 "Cache artifacts must never be restored from another workflow run.",
             )
+        }
+    }
+
+    @Test
+    fun `artifact ID restores keep cache entries at the Gradle lookup path`() {
+        val workflow = Path.of("../.github/workflows/ci.yml").readText()
+        val cacheKey = "0123456789abcdef0123456789abcdef"
+        val cacheEntry = temporaryDirectory.resolve(cacheKey).apply { writeText("cached classes") }
+        val restoreSteps =
+            workflow.split("\n      - name: Restore exact-run Gradle build cache\n").drop(1).map {
+                it.substringBefore("\n      - name:")
+            }
+
+        assertEquals(3, restoreSteps.size)
+        restoreSteps.forEachIndexed { index, restoreStep ->
+            val mergeMultiple = restoreStep.contains("merge-multiple: true")
+
+            listOf(1, 2).forEach { selectedArtifactCount ->
+                val cacheRoot =
+                    temporaryDirectory
+                        .resolve("consumer-$index-$selectedArtifactCount")
+                        .resolve("build-cache-1")
+                val extractionRoot =
+                    if (mergeMultiple || selectedArtifactCount == 1) {
+                        cacheRoot
+                    } else {
+                        cacheRoot.resolve("ci-gradle-build-cache")
+                    }
+
+                Files.createDirectories(extractionRoot)
+                Files.copy(cacheEntry, extractionRoot.resolve(cacheKey))
+
+                assertTrue(
+                    Files.isRegularFile(cacheRoot.resolve(cacheKey)),
+                    "Gradle must find ID-selected cache entries directly in build-cache-1.",
+                )
+            }
         }
     }
 

--- a/buildSrc/src/test/kotlin/com/openai/gradle/GradleCacheTrustPolicyTest.kt
+++ b/buildSrc/src/test/kotlin/com/openai/gradle/GradleCacheTrustPolicyTest.kt
@@ -114,6 +114,36 @@ class GradleCacheTrustPolicyTest {
     }
 
     @Test
+    fun `pull request rejects every Gradle-owned initializer and writable cache override`() {
+        val workflow = Path.of("../.github/workflows/ci.yml").readText()
+        val protectedSetup = "      - name: Set up Gradle\n"
+        val actionRevision = "0723195856401067f7a2779048b490ace7a47d7c"
+
+        listOf(
+                "gradle/actions/dependency-submission@$actionRevision",
+                "GRADLE/Actions/Dependency-Submission@$actionRevision",
+                "\"gradle/actions/dependency-\\u0073ubmission@$actionRevision\"",
+                "gradle/actions/future-initializer@$actionRevision",
+                "gradle/future-gradle-action@$actionRevision",
+            )
+            .forEach { action ->
+                val poisonedWorkflow =
+                    workflow.replaceFirst(
+                        protectedSetup,
+                        "      - name: Initialize unprotected Gradle cache\n" +
+                            "        uses: $action\n" +
+                            "        with:\n" +
+                            "          cache-write-only: true\n" +
+                            "          gradle-home-cache-includes: init.d\n\n" +
+                            protectedSetup,
+                    )
+
+                assertTrue(poisonedWorkflow != workflow)
+                assertFailsWith<AssertionError> { assertPullRequestCachePolicy(poisonedWorkflow) }
+            }
+    }
+
+    @Test
     fun `exact-run cache artifacts are immutable identified and digest-verified`() {
         val workflow = Path.of("../.github/workflows/ci.yml").readText()
         val buildJob = parseWorkflow(workflow).job("build")
@@ -309,6 +339,69 @@ class GradleCacheTrustPolicyTest {
     }
 
     @Test
+    fun `publishing rejects Gradle-owned initializers before and after protected setup`() {
+        val workflow = Path.of("../.github/workflows/create-releases.yml").readText()
+        val protectedSetup = "      - name: Set up Gradle\n"
+        val compilationStep = "      - name: Compile the openai-java-core project\n"
+        val actionRevision = "0723195856401067f7a2779048b490ace7a47d7c"
+
+        listOf(protectedSetup, compilationStep).forEach { followingStep ->
+            listOf(
+                    "gradle/actions/dependency-submission@$actionRevision",
+                    "GRADLE/Actions/Dependency-Submission@$actionRevision",
+                    "\"gradle/actions/dependency-\\u0073ubmission@$actionRevision\"",
+                    "gradle/actions/future-initializer@$actionRevision",
+                    "gradle/future-gradle-action@$actionRevision",
+                )
+                .forEach { action ->
+                    val poisonedWorkflow =
+                        workflow.replaceFirst(
+                            followingStep,
+                            "      - name: Restore delegated Gradle cache\n" +
+                                "        uses: $action\n" +
+                                "        with:\n" +
+                                "          dependency-graph: download-and-submit\n" +
+                                "          dependency-graph-continue-on-failure: true\n" +
+                                "          gradle-home-cache-includes: init.d\n\n" +
+                                followingStep,
+                        )
+
+                    assertTrue(poisonedWorkflow != workflow)
+                    assertFailsWith<AssertionError> {
+                        assertPublishingCachePolicy(poisonedWorkflow)
+                    }
+                }
+        }
+    }
+
+    @Test
+    fun `publishing rejects unreviewed action capabilities and cache-enabled inputs`() {
+        val workflow = Path.of("../.github/workflows/create-releases.yml").readText()
+        val protectedSetup = "      - name: Set up Gradle\n"
+        val javaSetup = "          distribution: temurin\n          java-version: |\n"
+
+        listOf(
+                workflow.replaceFirst(
+                    protectedSetup,
+                    "      - name: Initialize third-party Gradle cache\n" +
+                        "        uses: third-party/gradle-cache@0123456789abcdef0123456789abcdef01234567\n" +
+                        "        with:\n" +
+                        "          cache: gradle\n\n" +
+                        protectedSetup,
+                ),
+                workflow.replaceFirst(javaSetup, "          cache: gradle\n$javaSetup"),
+                workflow.replaceFirst(
+                    "gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c",
+                    "gradle/actions/setup-gradle@v5",
+                ),
+            )
+            .forEach { poisonedWorkflow ->
+                assertTrue(poisonedWorkflow != workflow)
+                assertFailsWith<AssertionError> { assertPublishingCachePolicy(poisonedWorkflow) }
+            }
+    }
+
+    @Test
     fun `publishing decodes YAML-escaped cache action references`() {
         val workflow = Path.of("../.github/workflows/create-releases.yml").readText()
         val compilationStep = "      - name: Compile the openai-java-core project\n"
@@ -381,6 +474,31 @@ class GradleCacheTrustPolicyTest {
             "Privileged publishing must accept only trusted default-branch events.",
         )
         val publishJob = parsedWorkflow.job("publish")
+        val reviewedActionInputs =
+            mapOf(
+                "actions/checkout" to setOf("persist-credentials", "ref"),
+                "actions/setup-java" to setOf("distribution", "java-version"),
+                "gradle/actions/setup-gradle" to setOf("cache-disabled"),
+                "graalvm/setup-graalvm" to setOf("distribution", "java-version"),
+            )
+
+        publishJob.actions.forEach { action ->
+            val approvedInputs = reviewedActionInputs[action.repository]
+
+            assertTrue(
+                approvedInputs != null,
+                "Privileged publishing must reject unreviewed action ${action.repository}.",
+            )
+            assertTrue(
+                action.reference.substringAfterLast('@', "").matches(Regex("[0-9a-fA-F]{40}")),
+                "Privileged publishing action ${action.repository} must remain SHA-pinned.",
+            )
+            assertTrue(
+                action.inputs.keys.all { it in approvedInputs },
+                "Privileged publishing action ${action.repository} has unreviewed inputs.",
+            )
+        }
+
         val isolation =
             publishJob.steps.indexOfFirst { it.name == "Create isolated release Gradle User Home" }
         val initializers =
@@ -552,9 +670,6 @@ class GradleCacheTrustPolicyTest {
         val inputs: Map<String, String>,
     ) {
         val repository: String = reference.substringBefore('@').lowercase(Locale.ROOT)
-        val initializesGradle: Boolean =
-            repository == "gradle/actions/setup-gradle" ||
-                repository == "gradle/gradle-build-action" ||
-                repository.startsWith("gradle/gradle-build-action/")
+        val initializesGradle: Boolean = repository.substringBefore('/') == "gradle"
     }
 }

--- a/buildSrc/src/test/kotlin/com/openai/gradle/GradleCacheTrustPolicyTest.kt
+++ b/buildSrc/src/test/kotlin/com/openai/gradle/GradleCacheTrustPolicyTest.kt
@@ -1,0 +1,105 @@
+package com.openai.gradle
+
+import java.nio.file.Path
+import kotlin.io.path.readText
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class GradleCacheTrustPolicyTest {
+    @Test
+    fun `all pull request Gradle jobs keep cross-run caches read-only`() {
+        val workflow = Path.of("../.github/workflows/ci.yml").readText()
+        val setupCount =
+            workflow.lines().count { it.contains("uses: gradle/actions/setup-gradle@") }
+        val cachePolicies =
+            workflow
+                .lineSequence()
+                .map { it.trim() }
+                .filter { it.startsWith("cache-read-only:") }
+                .map { it.removePrefix("cache-read-only:").trim() }
+                .toList()
+
+        assertEquals(
+            setupCount,
+            cachePolicies.size,
+            "Every Gradle job must declare its cache policy.",
+        )
+        assertTrue(setupCount > 0, "The CI workflow must continue to exercise Gradle.")
+        assertTrue(
+            cachePolicies.all {
+                it == "true" ||
+                    it == "\${{ github.ref_name != github.event.repository.default_branch }}"
+            },
+            "Pull requests and all artifact-consuming jobs must not save cross-run caches.",
+        )
+    }
+
+    @Test
+    fun `exact-run cache artifacts are immutable identified and digest-verified`() {
+        val workflow = Path.of("../.github/workflows/ci.yml").readText()
+        val buildJob = workflow.substringAfter("\n  build:\n").substringBefore("\n  test:\n")
+
+        assertContains(
+            buildJob,
+            "gradle-cache-artifact-id: \${{ steps.gradle-cache-artifact.outputs.artifact-id }}",
+        )
+        assertContains(buildJob, "id: gradle-cache-artifact")
+        assertContains(
+            buildJob,
+            "name: ci-gradle-build-cache-\${{ github.run_id }}-\${{ github.run_attempt }}",
+        )
+        assertFalse(buildJob.contains("overwrite: true"), "Cache artifacts must remain immutable.")
+
+        val restoreSteps =
+            workflow.split("\n      - name: Restore exact-run Gradle build cache\n").drop(1).map {
+                it.substringBefore("\n      - name:")
+            }
+
+        assertEquals(3, restoreSteps.size, "All exact-run cache consumers must remain protected.")
+        restoreSteps.forEach { restoreStep ->
+            assertContains(
+                restoreStep,
+                "artifact-ids: \${{ needs.build.outputs.gradle-cache-artifact-id }}",
+            )
+            assertContains(restoreStep, "digest-mismatch: error")
+            assertFalse(
+                restoreStep.contains("github-token:"),
+                "Cache artifacts must stay scoped to the current workflow run.",
+            )
+            assertFalse(
+                restoreStep.contains("run-id:"),
+                "Cache artifacts must never be restored from another workflow run.",
+            )
+        }
+    }
+
+    @Test
+    fun `publishing creates a private fresh Gradle home and never restores shared caches`() {
+        val workflow = Path.of("../.github/workflows/create-releases.yml").readText()
+        val publishJob =
+            workflow.substringAfter("\n  publish:\n").substringBefore("\n  release_outcome:\n")
+        val isolation = publishJob.indexOf("name: Create isolated release Gradle User Home")
+        val setup = publishJob.indexOf("name: Set up Gradle")
+        val signing = publishJob.indexOf("GPG_SIGNING_KEY:")
+
+        assertTrue(isolation >= 0, "Create a fresh Gradle User Home before configuring Gradle.")
+        assertTrue(setup > isolation, "Set up Gradle only after the isolated home exists.")
+        assertTrue(signing > setup, "Configure isolated Gradle before exposing signing secrets.")
+        assertContains(
+            publishJob,
+            "trusted-release-gradle-\${{ github.run_id }}-\${{ github.run_attempt }}",
+        )
+        assertContains(
+            publishJob,
+            "[[ -e \"\$TRUSTED_GRADLE_USER_HOME\" || -L \"\$TRUSTED_GRADLE_USER_HOME\" ]]",
+        )
+        assertContains(publishJob, "mkdir -m 700 \"\$TRUSTED_GRADLE_USER_HOME\"")
+        assertContains(publishJob, "\"\$TRUSTED_GRADLE_USER_HOME\" >> \"\$GITHUB_ENV\"")
+        assertContains(publishJob, "cache-disabled: true")
+        assertFalse(publishJob.contains("actions/download-artifact@"))
+        assertFalse(publishJob.contains("actions/cache@"))
+    }
+}

--- a/buildSrc/src/test/kotlin/com/openai/gradle/GradleCacheTrustPolicyTest.kt
+++ b/buildSrc/src/test/kotlin/com/openai/gradle/GradleCacheTrustPolicyTest.kt
@@ -7,6 +7,7 @@ import kotlin.io.path.writeText
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import org.junit.jupiter.api.io.TempDir
@@ -17,28 +18,29 @@ class GradleCacheTrustPolicyTest {
     @Test
     fun `all pull request Gradle jobs keep cross-run caches read-only`() {
         val workflow = Path.of("../.github/workflows/ci.yml").readText()
-        val setupCount =
-            workflow.lines().count { it.contains("uses: gradle/actions/setup-gradle@") }
-        val cachePolicies =
-            workflow
-                .lineSequence()
-                .map { it.trim() }
-                .filter { it.startsWith("cache-read-only:") }
-                .map { it.removePrefix("cache-read-only:").trim() }
-                .toList()
+        assertPullRequestCachePolicy(workflow)
+    }
 
-        assertEquals(
-            setupCount,
-            cachePolicies.size,
-            "Every Gradle job must declare its cache policy.",
-        )
-        assertTrue(setupCount > 0, "The CI workflow must continue to exercise Gradle.")
-        assertTrue(
-            cachePolicies.all {
-                it == "true" ||
-                    it == "\${{ github.ref_name != github.event.repository.default_branch }}"
-            },
-            "Pull requests and all artifact-consuming jobs must not save cross-run caches.",
+    @Test
+    fun `pull request cache policy rejects write-only overrides`() {
+        val workflow = Path.of("../.github/workflows/ci.yml").readText()
+
+        listOf("true", "TRUE", "\${{ github.event_name == 'pull_request' }}").forEach { writeOnly ->
+            val poisonedWorkflow =
+                workflow.replaceFirst(
+                    "          cache-read-only: true",
+                    "          cache-read-only: true\n          cache-write-only: $writeOnly",
+                )
+
+            assertTrue(poisonedWorkflow != workflow)
+            assertFailsWith<AssertionError> { assertPullRequestCachePolicy(poisonedWorkflow) }
+        }
+
+        assertPullRequestCachePolicy(
+            workflow.replaceFirst(
+                "          cache-read-only: true",
+                "          cache-read-only: true\n          cache-write-only: false",
+            )
         )
     }
 
@@ -56,26 +58,31 @@ class GradleCacheTrustPolicyTest {
             buildJob,
             "name: ci-gradle-build-cache-\${{ github.run_id }}-\${{ github.run_attempt }}",
         )
-        assertFalse(buildJob.contains("overwrite: true"), "Cache artifacts must remain immutable.")
-
-        val restoreSteps =
-            workflow.split("\n      - name: Restore exact-run Gradle build cache\n").drop(1).map {
-                it.substringBefore("\n      - name:")
+        val uploadAction =
+            parseWorkflowActions(workflow).single {
+                it.job == "build" && it.repository == "actions/upload-artifact"
             }
+        assertFalse(
+            uploadAction.inputs["overwrite"].equals("true", ignoreCase = true),
+            "Cache artifacts must remain immutable.",
+        )
+
+        val restoreSteps = artifactRestoreActions(workflow)
 
         assertEquals(3, restoreSteps.size, "All exact-run cache consumers must remain protected.")
         restoreSteps.forEach { restoreStep ->
-            assertContains(
-                restoreStep,
-                "artifact-ids: \${{ needs.build.outputs.gradle-cache-artifact-id }}",
+            assertEquals(
+                "\${{ needs.build.outputs.gradle-cache-artifact-id }}",
+                restoreStep.inputs["artifact-ids"],
             )
-            assertContains(restoreStep, "digest-mismatch: error")
+            assertEquals("error", restoreStep.inputs["digest-mismatch"])
+            assertEquals("~/.gradle/caches/build-cache-1", restoreStep.inputs["path"])
             assertFalse(
-                restoreStep.contains("github-token:"),
+                "github-token" in restoreStep.inputs,
                 "Cache artifacts must stay scoped to the current workflow run.",
             )
             assertFalse(
-                restoreStep.contains("run-id:"),
+                "run-id" in restoreStep.inputs,
                 "Cache artifacts must never be restored from another workflow run.",
             )
         }
@@ -86,14 +93,12 @@ class GradleCacheTrustPolicyTest {
         val workflow = Path.of("../.github/workflows/ci.yml").readText()
         val cacheKey = "0123456789abcdef0123456789abcdef"
         val cacheEntry = temporaryDirectory.resolve(cacheKey).apply { writeText("cached classes") }
-        val restoreSteps =
-            workflow.split("\n      - name: Restore exact-run Gradle build cache\n").drop(1).map {
-                it.substringBefore("\n      - name:")
-            }
+        val restoreSteps = artifactRestoreActions(workflow)
 
         assertEquals(3, restoreSteps.size)
         restoreSteps.forEachIndexed { index, restoreStep ->
-            val mergeMultiple = restoreStep.contains("merge-multiple: true")
+            val mergeMultiple =
+                restoreStep.inputs["merge-multiple"].equals("true", ignoreCase = true)
 
             listOf(1, 2).forEach { selectedArtifactCount ->
                 val cacheRoot =
@@ -121,6 +126,60 @@ class GradleCacheTrustPolicyTest {
     @Test
     fun `publishing creates a private fresh Gradle home and never restores shared caches`() {
         val workflow = Path.of("../.github/workflows/create-releases.yml").readText()
+        assertPublishingCachePolicy(workflow)
+    }
+
+    @Test
+    fun `publishing rejects the complete GitHub cache action family`() {
+        val workflow = Path.of("../.github/workflows/create-releases.yml").readText()
+        val compilationStep = "      - name: Compile the openai-java-core project\n"
+
+        listOf(
+                "actions/cache",
+                "actions/cache/restore",
+                "actions/cache/save",
+                "Actions/CACHE/restore",
+            )
+            .forEach { action ->
+                val poisonedWorkflow =
+                    workflow.replaceFirst(
+                        compilationStep,
+                        "      - name: Restore untrusted cross-run cache\n" +
+                            "        uses: $action@0123456789abcdef0123456789abcdef01234567\n" +
+                            "        with:\n" +
+                            "          path: \${{ env.GRADLE_USER_HOME }}\n" +
+                            "          key: untrusted\n\n" +
+                            compilationStep,
+                    )
+
+                assertTrue(poisonedWorkflow != workflow)
+                assertFailsWith<AssertionError> { assertPublishingCachePolicy(poisonedWorkflow) }
+            }
+    }
+
+    private fun assertPullRequestCachePolicy(workflow: String) {
+        val setupActions =
+            parseWorkflowActions(workflow).filter { it.repository == "gradle/actions/setup-gradle" }
+
+        assertTrue(setupActions.isNotEmpty(), "The CI workflow must continue to exercise Gradle.")
+        setupActions.forEach { action ->
+            val readOnly = action.inputs["cache-read-only"]
+            val writeOnly = action.inputs["cache-write-only"]
+            val trustedReadOnly =
+                readOnly == "true" ||
+                    readOnly == "\${{ github.ref_name != github.event.repository.default_branch }}"
+            val effectivelyReadOnly =
+                trustedReadOnly &&
+                    (writeOnly == null || writeOnly.equals("false", ignoreCase = true))
+
+            assertTrue(
+                effectivelyReadOnly,
+                "Gradle cache for job ${action.job} must remain effectively read-only on pull requests.",
+            )
+        }
+    }
+
+    private fun assertPublishingCachePolicy(workflow: String) {
         val publishJob =
             workflow.substringAfter("\n  publish:\n").substringBefore("\n  release_outcome:\n")
         val isolation = publishJob.indexOf("name: Create isolated release Gradle User Home")
@@ -140,8 +199,113 @@ class GradleCacheTrustPolicyTest {
         )
         assertContains(publishJob, "mkdir -m 700 \"\$TRUSTED_GRADLE_USER_HOME\"")
         assertContains(publishJob, "\"\$TRUSTED_GRADLE_USER_HOME\" >> \"\$GITHUB_ENV\"")
-        assertContains(publishJob, "cache-disabled: true")
-        assertFalse(publishJob.contains("actions/download-artifact@"))
-        assertFalse(publishJob.contains("actions/cache@"))
+        val publishActions = parseWorkflowActions(workflow).filter { it.job == "publish" }
+        val setupAction = publishActions.single { it.repository == "gradle/actions/setup-gradle" }
+
+        assertEquals("true", setupAction.inputs["cache-disabled"])
+        assertFalse(
+            publishActions.any {
+                it.repository == "actions/download-artifact" ||
+                    it.repository == "actions/cache" ||
+                    it.repository.startsWith("actions/cache/")
+            },
+            "Privileged publishing must reject every cross-run artifact and GitHub cache action.",
+        )
     }
+
+    private fun artifactRestoreActions(workflow: String): List<WorkflowAction> =
+        parseWorkflowActions(workflow).filter { it.repository == "actions/download-artifact" }
+
+    private fun parseWorkflowActions(workflow: String): List<WorkflowAction> {
+        val actions = mutableListOf<WorkflowAction>()
+        var inJobs = false
+        var currentJob: String? = null
+        var currentAction: WorkflowActionBuilder? = null
+        var inInputs = false
+
+        fun finishStep() {
+            currentAction?.let { step ->
+                step.reference?.let { reference ->
+                    actions += WorkflowAction(step.job, reference, step.inputs.toMap())
+                }
+            }
+            currentAction = null
+            inInputs = false
+        }
+
+        workflow.lineSequence().forEach { line ->
+            val indentation = line.indexOfFirst { !it.isWhitespace() }
+            if (indentation < 0) return@forEach
+
+            val content = line.substring(indentation)
+            if (content.startsWith("#")) return@forEach
+
+            when {
+                indentation == 0 -> {
+                    finishStep()
+                    inJobs = content == "jobs:"
+                    if (!inJobs) currentJob = null
+                }
+
+                !inJobs -> Unit
+
+                indentation == 2 && content.endsWith(":") -> {
+                    finishStep()
+                    currentJob = content.removeSuffix(":")
+                }
+
+                indentation == 6 && content.startsWith("- ") -> {
+                    finishStep()
+                    currentJob?.let { job ->
+                        val step = WorkflowActionBuilder(job)
+                        val firstField = content.removePrefix("- ")
+                        if (firstField.startsWith("uses:")) {
+                            step.reference = firstField.workflowValue()
+                        }
+                        currentAction = step
+                    }
+                }
+
+                indentation == 8 && currentAction != null -> {
+                    inInputs = content == "with:"
+                    if (content.startsWith("uses:")) {
+                        currentAction?.reference = content.workflowValue()
+                    }
+                }
+
+                indentation == 10 && inInputs -> {
+                    val separator = content.indexOf(':')
+                    if (separator >= 0) {
+                        val key = content.substring(0, separator)
+                        val value = content.substring(separator + 1).trim().unquoted()
+                        check(currentAction?.inputs?.put(key, value) == null) {
+                            "Duplicate workflow action input: $key"
+                        }
+                    }
+                }
+            }
+        }
+
+        finishStep()
+        return actions
+    }
+
+    private fun String.workflowValue(): String =
+        substringAfter(':').substringBefore(" #").trim().unquoted()
+
+    private fun String.unquoted(): String = removeSurrounding("\"").removeSurrounding("'")
+
+    private data class WorkflowAction(
+        val job: String,
+        val reference: String,
+        val inputs: Map<String, String>,
+    ) {
+        val repository: String = reference.substringBefore('@').lowercase()
+    }
+
+    private data class WorkflowActionBuilder(
+        val job: String,
+        var reference: String? = null,
+        val inputs: MutableMap<String, String> = mutableMapOf(),
+    )
 }

--- a/buildSrc/src/test/kotlin/com/openai/gradle/GradleCacheTrustPolicyTest.kt
+++ b/buildSrc/src/test/kotlin/com/openai/gradle/GradleCacheTrustPolicyTest.kt
@@ -2,6 +2,7 @@ package com.openai.gradle
 
 import java.nio.file.Files
 import java.nio.file.Path
+import java.util.Locale
 import kotlin.io.path.readText
 import kotlin.io.path.writeText
 import kotlin.test.Test
@@ -11,6 +12,9 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import org.junit.jupiter.api.io.TempDir
+import org.yaml.snakeyaml.LoaderOptions
+import org.yaml.snakeyaml.Yaml
+import org.yaml.snakeyaml.constructor.SafeConstructor
 
 class GradleCacheTrustPolicyTest {
     @TempDir lateinit var temporaryDirectory: Path
@@ -45,23 +49,66 @@ class GradleCacheTrustPolicyTest {
     }
 
     @Test
+    fun `pull request cache policy rejects case-insensitive inputs and duplicates`() {
+        val workflow = Path.of("../.github/workflows/ci.yml").readText()
+
+        listOf(
+                "CACHE-WRITE-ONLY: true",
+                "CACHE-READ-ONLY: false",
+                "\"CACHE-\\u0052EAD-ONLY\": false",
+            )
+            .forEach { poisonedInput ->
+                val poisonedWorkflow =
+                    workflow.replaceFirst(
+                        "          cache-read-only: true",
+                        "          cache-read-only: true\n          $poisonedInput",
+                    )
+
+                assertTrue(poisonedWorkflow != workflow)
+                assertFailsWith<AssertionError> { assertPullRequestCachePolicy(poisonedWorkflow) }
+            }
+
+        assertPullRequestCachePolicy(
+            workflow.replaceFirst(
+                "          cache-read-only: true",
+                "          CACHE-READ-ONLY: true",
+            )
+        )
+    }
+
+    @Test
+    fun `pull request rejects Gradle setup aliases before the protected initializer`() {
+        val workflow = Path.of("../.github/workflows/ci.yml").readText()
+        val protectedSetup = "      - name: Set up Gradle\n"
+        val poisonedWorkflow =
+            workflow.replaceFirst(
+                protectedSetup,
+                "      - name: Initialize legacy Gradle cache\n" +
+                    "        uses: gradle/gradle-build-action@12318b01111bfa6462c00534ffa998f8b397b979\n\n" +
+                    protectedSetup,
+            )
+
+        assertTrue(poisonedWorkflow != workflow)
+        assertFailsWith<AssertionError> { assertPullRequestCachePolicy(poisonedWorkflow) }
+    }
+
+    @Test
     fun `exact-run cache artifacts are immutable identified and digest-verified`() {
         val workflow = Path.of("../.github/workflows/ci.yml").readText()
-        val buildJob = workflow.substringAfter("\n  build:\n").substringBefore("\n  test:\n")
+        val buildJob = parseWorkflow(workflow).job("build")
 
-        assertContains(
-            buildJob,
-            "gradle-cache-artifact-id: \${{ steps.gradle-cache-artifact.outputs.artifact-id }}",
+        assertEquals(
+            "\${{ steps.gradle-cache-artifact.outputs.artifact-id }}",
+            buildJob.outputs["gradle-cache-artifact-id"],
         )
-        assertContains(buildJob, "id: gradle-cache-artifact")
-        assertContains(
-            buildJob,
-            "name: ci-gradle-build-cache-\${{ github.run_id }}-\${{ github.run_attempt }}",
+        val uploadStep =
+            buildJob.steps.single { it.action?.repository == "actions/upload-artifact" }
+        assertEquals("gradle-cache-artifact", uploadStep.id)
+        val uploadAction = requireNotNull(uploadStep.action)
+        assertEquals(
+            "ci-gradle-build-cache-\${{ github.run_id }}-\${{ github.run_attempt }}",
+            uploadAction.inputs["name"],
         )
-        val uploadAction =
-            parseWorkflowActions(workflow).single {
-                it.job == "build" && it.repository == "actions/upload-artifact"
-            }
         assertFalse(
             uploadAction.inputs["overwrite"].equals("true", ignoreCase = true),
             "Cache artifacts must remain immutable.",
@@ -157,9 +204,96 @@ class GradleCacheTrustPolicyTest {
             }
     }
 
+    @Test
+    fun `publishing rejects case-insensitive duplicate cache disable inputs`() {
+        val workflow = Path.of("../.github/workflows/create-releases.yml").readText()
+
+        listOf("CACHE-DISABLED", "\"CACHE-\\u0044ISABLED\"").forEach { disabledInput ->
+            val poisonedWorkflow =
+                workflow.replaceFirst(
+                    "          cache-disabled: true",
+                    "          cache-disabled: true\n" +
+                        "          $disabledInput: false\n" +
+                        "          gradle-home-cache-includes: init.d",
+                )
+
+            assertTrue(poisonedWorkflow != workflow)
+            assertFailsWith<AssertionError> { assertPublishingCachePolicy(poisonedWorkflow) }
+        }
+
+        assertPublishingCachePolicy(
+            workflow.replaceFirst(
+                "          cache-disabled: true",
+                "          CACHE-DISABLED: true",
+            )
+        )
+    }
+
+    @Test
+    fun `publishing rejects legacy Gradle setup before the protected initializer`() {
+        val workflow = Path.of("../.github/workflows/create-releases.yml").readText()
+        val protectedSetup = "      - name: Set up Gradle\n"
+        val actionRevision = "12318b01111bfa6462c00534ffa998f8b397b979"
+
+        listOf(
+                "gradle/gradle-build-action@$actionRevision",
+                "GRADLE/Gradle-Build-Action@$actionRevision",
+                "\"gradle/gradle-\\u0062uild-action@$actionRevision\"",
+            )
+            .forEach { action ->
+                val poisonedWorkflow =
+                    workflow.replaceFirst(
+                        protectedSetup,
+                        "      - name: Restore legacy Gradle cache\n" +
+                            "        uses: $action\n" +
+                            "        with:\n" +
+                            "          gradle-home-cache-includes: init.d\n\n" +
+                            protectedSetup,
+                    )
+
+                assertTrue(poisonedWorkflow != workflow)
+                assertFailsWith<AssertionError> { assertPublishingCachePolicy(poisonedWorkflow) }
+            }
+    }
+
+    @Test
+    fun `publishing decodes YAML-escaped cache action references`() {
+        val workflow = Path.of("../.github/workflows/create-releases.yml").readText()
+        val compilationStep = "      - name: Compile the openai-java-core project\n"
+        val poisonedWorkflow =
+            workflow.replaceFirst(
+                compilationStep,
+                "      - name: Restore escaped attacker-controlled Gradle home\n" +
+                    "        uses: \"actions/\\u0063ache/restore@0057852bfaa89a56745cba8c7296529d2fc39830\"\n" +
+                    "        with:\n" +
+                    "          path: \${{ env.GRADLE_USER_HOME }}\n" +
+                    "          key: attacker-controlled-gradle-home\n\n" +
+                    compilationStep,
+            )
+
+        assertTrue(poisonedWorkflow != workflow)
+        assertFailsWith<AssertionError> { assertPublishingCachePolicy(poisonedWorkflow) }
+    }
+
     private fun assertPullRequestCachePolicy(workflow: String) {
         val setupActions =
-            parseWorkflowActions(workflow).filter { it.repository == "gradle/actions/setup-gradle" }
+            parseWorkflow(workflow).jobs.values.flatMap { job ->
+                val initializers = job.actions.filter { it.initializesGradle }
+
+                if (initializers.isNotEmpty()) {
+                    assertEquals(
+                        "gradle/actions/setup-gradle",
+                        initializers.first().repository,
+                        "The first Gradle initializer in job ${job.name} must enforce cache policy.",
+                    )
+                    assertTrue(
+                        initializers.all { it.repository == "gradle/actions/setup-gradle" },
+                        "Job ${job.name} must not use delegated Gradle setup aliases.",
+                    )
+                }
+
+                initializers
+            }
 
         assertTrue(setupActions.isNotEmpty(), "The CI workflow must continue to exercise Gradle.")
         setupActions.forEach { action ->
@@ -180,31 +314,46 @@ class GradleCacheTrustPolicyTest {
     }
 
     private fun assertPublishingCachePolicy(workflow: String) {
-        val publishJob =
-            workflow.substringAfter("\n  publish:\n").substringBefore("\n  release_outcome:\n")
-        val isolation = publishJob.indexOf("name: Create isolated release Gradle User Home")
-        val setup = publishJob.indexOf("name: Set up Gradle")
-        val signing = publishJob.indexOf("GPG_SIGNING_KEY:")
+        val publishJob = parseWorkflow(workflow).job("publish")
+        val isolation =
+            publishJob.steps.indexOfFirst { it.name == "Create isolated release Gradle User Home" }
+        val initializers =
+            publishJob.steps.mapIndexedNotNull { index, step ->
+                if (step.action?.initializesGradle == true) index to step else null
+            }
+        val signing = publishJob.steps.indexOfFirst { "GPG_SIGNING_KEY" in it.environment }
 
         assertTrue(isolation >= 0, "Create a fresh Gradle User Home before configuring Gradle.")
+        assertEquals(
+            1,
+            initializers.size,
+            "Privileged publishing must have exactly one protected Gradle initializer.",
+        )
+        val (setup, setupStep) = initializers.single()
+        val setupAction = requireNotNull(setupStep.action)
+        assertEquals(
+            "gradle/actions/setup-gradle",
+            setupAction.repository,
+            "The first effective release Gradle initializer must be the protected setup action.",
+        )
         assertTrue(setup > isolation, "Set up Gradle only after the isolated home exists.")
         assertTrue(signing > setup, "Configure isolated Gradle before exposing signing secrets.")
+        val isolationStep = publishJob.steps[isolation]
         assertContains(
-            publishJob,
+            isolationStep.environment.getValue("TRUSTED_GRADLE_USER_HOME"),
             "trusted-release-gradle-\${{ github.run_id }}-\${{ github.run_attempt }}",
         )
+        val isolationScript = requireNotNull(isolationStep.run)
         assertContains(
-            publishJob,
+            isolationScript,
             "[[ -e \"\$TRUSTED_GRADLE_USER_HOME\" || -L \"\$TRUSTED_GRADLE_USER_HOME\" ]]",
         )
-        assertContains(publishJob, "mkdir -m 700 \"\$TRUSTED_GRADLE_USER_HOME\"")
-        assertContains(publishJob, "\"\$TRUSTED_GRADLE_USER_HOME\" >> \"\$GITHUB_ENV\"")
-        val publishActions = parseWorkflowActions(workflow).filter { it.job == "publish" }
-        val setupAction = publishActions.single { it.repository == "gradle/actions/setup-gradle" }
+        assertContains(isolationScript, "mkdir -m 700 \"\$TRUSTED_GRADLE_USER_HOME\"")
+        assertContains(isolationScript, "\"\$TRUSTED_GRADLE_USER_HOME\" >> \"\$GITHUB_ENV\"")
 
         assertEquals("true", setupAction.inputs["cache-disabled"])
         assertFalse(
-            publishActions.any {
+            publishJob.actions.any {
                 it.repository == "actions/download-artifact" ||
                     it.repository == "actions/cache" ||
                     it.repository.startsWith("actions/cache/")
@@ -214,98 +363,117 @@ class GradleCacheTrustPolicyTest {
     }
 
     private fun artifactRestoreActions(workflow: String): List<WorkflowAction> =
-        parseWorkflowActions(workflow).filter { it.repository == "actions/download-artifact" }
+        parseWorkflow(workflow)
+            .jobs
+            .values
+            .flatMap { it.actions }
+            .filter { it.repository == "actions/download-artifact" }
 
-    private fun parseWorkflowActions(workflow: String): List<WorkflowAction> {
-        val actions = mutableListOf<WorkflowAction>()
-        var inJobs = false
-        var currentJob: String? = null
-        var currentAction: WorkflowActionBuilder? = null
-        var inInputs = false
+    private fun parseWorkflow(workflow: String): Workflow {
+        val options = LoaderOptions().apply { setAllowDuplicateKeys(false) }
+        val document =
+            Yaml(SafeConstructor(options)).load<Any>(workflow) as? Map<*, *>
+                ?: error("A GitHub Actions workflow must be a YAML mapping.")
+        val jobs =
+            document["jobs"] as? Map<*, *> ?: error("A GitHub Actions workflow must declare jobs.")
 
-        fun finishStep() {
-            currentAction?.let { step ->
-                step.reference?.let { reference ->
-                    actions += WorkflowAction(step.job, reference, step.inputs.toMap())
-                }
+        return Workflow(
+            jobs.entries.associate { (name, value) ->
+                val jobName = name.workflowScalar("job name")
+                val job = value.workflowMapping("job $jobName")
+                val steps =
+                    (job["steps"] as? List<*>)?.map { step ->
+                        val fields = step.workflowMapping("step in job $jobName")
+                        val action =
+                            fields["uses"]?.let { reference ->
+                                WorkflowAction(
+                                    jobName,
+                                    reference.workflowScalar("action reference"),
+                                    canonicalActionInputs(fields["with"], jobName),
+                                )
+                            }
+
+                        WorkflowStep(
+                            fields["name"]?.workflowScalar("step name"),
+                            fields["id"]?.workflowScalar("step ID"),
+                            action,
+                            fields["run"]?.workflowScalar("step script"),
+                            fields["env"].workflowScalars("step environment"),
+                        )
+                    } ?: emptyList()
+
+                jobName to
+                    WorkflowJob(jobName, job["outputs"].workflowScalars("job outputs"), steps)
             }
-            currentAction = null
-            inInputs = false
-        }
-
-        workflow.lineSequence().forEach { line ->
-            val indentation = line.indexOfFirst { !it.isWhitespace() }
-            if (indentation < 0) return@forEach
-
-            val content = line.substring(indentation)
-            if (content.startsWith("#")) return@forEach
-
-            when {
-                indentation == 0 -> {
-                    finishStep()
-                    inJobs = content == "jobs:"
-                    if (!inJobs) currentJob = null
-                }
-
-                !inJobs -> Unit
-
-                indentation == 2 && content.endsWith(":") -> {
-                    finishStep()
-                    currentJob = content.removeSuffix(":")
-                }
-
-                indentation == 6 && content.startsWith("- ") -> {
-                    finishStep()
-                    currentJob?.let { job ->
-                        val step = WorkflowActionBuilder(job)
-                        val firstField = content.removePrefix("- ")
-                        if (firstField.startsWith("uses:")) {
-                            step.reference = firstField.workflowValue()
-                        }
-                        currentAction = step
-                    }
-                }
-
-                indentation == 8 && currentAction != null -> {
-                    inInputs = content == "with:"
-                    if (content.startsWith("uses:")) {
-                        currentAction?.reference = content.workflowValue()
-                    }
-                }
-
-                indentation == 10 && inInputs -> {
-                    val separator = content.indexOf(':')
-                    if (separator >= 0) {
-                        val key = content.substring(0, separator)
-                        val value = content.substring(separator + 1).trim().unquoted()
-                        check(currentAction?.inputs?.put(key, value) == null) {
-                            "Duplicate workflow action input: $key"
-                        }
-                    }
-                }
-            }
-        }
-
-        finishStep()
-        return actions
+        )
     }
 
-    private fun String.workflowValue(): String =
-        substringAfter(':').substringBefore(" #").trim().unquoted()
+    private fun canonicalActionInputs(value: Any?, job: String): Map<String, String> {
+        val inputs = mutableMapOf<String, String>()
 
-    private fun String.unquoted(): String = removeSurrounding("\"").removeSurrounding("'")
+        value.workflowScalars("action inputs in job $job").forEach { (name, input) ->
+            val canonicalName = name.lowercase(Locale.ROOT)
+            assertFalse(
+                canonicalName in inputs,
+                "Duplicate case-insensitive workflow action input in job $job: $name",
+            )
+            inputs[canonicalName] = input
+        }
+
+        return inputs
+    }
+
+    private fun Any?.workflowScalars(description: String): Map<String, String> =
+        if (this == null) {
+            emptyMap()
+        } else {
+            workflowMapping(description).entries.associate { (key, value) ->
+                key.workflowScalar("$description key") to value.workflowScalar("$description value")
+            }
+        }
+
+    private fun Any?.workflowMapping(description: String): Map<*, *> =
+        this as? Map<*, *> ?: error("$description must be a YAML mapping.")
+
+    private fun Any?.workflowScalar(description: String): String =
+        when (this) {
+            is String -> this
+            is Number,
+            is Boolean -> toString()
+            else -> error("$description must be a YAML scalar.")
+        }
+
+    private data class Workflow(val jobs: Map<String, WorkflowJob>) {
+        fun job(name: String): WorkflowJob =
+            jobs[name] ?: error("GitHub Actions workflow is missing job $name.")
+    }
+
+    private data class WorkflowJob(
+        val name: String,
+        val outputs: Map<String, String>,
+        val steps: List<WorkflowStep>,
+    ) {
+        val actions: List<WorkflowAction>
+            get() = steps.mapNotNull { it.action }
+    }
+
+    private data class WorkflowStep(
+        val name: String?,
+        val id: String?,
+        val action: WorkflowAction?,
+        val run: String?,
+        val environment: Map<String, String>,
+    )
 
     private data class WorkflowAction(
         val job: String,
         val reference: String,
         val inputs: Map<String, String>,
     ) {
-        val repository: String = reference.substringBefore('@').lowercase()
+        val repository: String = reference.substringBefore('@').lowercase(Locale.ROOT)
+        val initializesGradle: Boolean =
+            repository == "gradle/actions/setup-gradle" ||
+                repository == "gradle/gradle-build-action" ||
+                repository.startsWith("gradle/gradle-build-action/")
     }
-
-    private data class WorkflowActionBuilder(
-        val job: String,
-        var reference: String? = null,
-        val inputs: MutableMap<String, String> = mutableMapOf(),
-    )
 }


### PR DESCRIPTION
## Summary

- Mitigate Dependabot alert #134 / CVE-2026-53914 without moving the production Kotlin compiler onto the only currently patched beta.
- Make every pull-request Gradle cache explicitly read-only and exchange exact-run compilation outputs only through immutable, run-and-attempt-scoped artifacts addressed by artifact ID with fail-closed SHA-256 digest validation.
- Give Maven Central publication and signing a fresh, private Gradle User Home, reject pre-existing paths and symlinks, and disable all cross-run Gradle cache restores/saves while preserving same-job cache reuse.
- Add focused workflow trust-boundary regression coverage and document the remaining build-tool risk, trusted-runner assumption, and stable Kotlin upgrade path.

Part of SDK-306; this PR intentionally does not close the broader dependency audit.

## Validation

- `./gradlew :buildSrc:test`
- `./gradlew build testClasses verifyVersionSupportPolicy :openai-java-core:testJacksonCompatibility :openai-java-runtime-compatibility:runRuntimeCompatibility lintKotlin -PruntimeJavaVersion=21`
- **12,154 passing tests, zero failures:** 14 build-logic tests; 12,091 core/Jackson tests; 44 Bedrock tests; 5 OkHttp-client tests.
- Ran all four real published-artifact consumer probes on **Java 17, 21, and 25**, while building with Java 21; published Java 8 runtime-floor checks also pass.
- Executed the actual CI cache collector and validated **28 regular, content-addressed cache entries**.
- Ran checksum-verified `actionlint` on both changed workflows.
- Executed the release isolation script against fresh directories, existing directories, existing regular files, and dangling symlinks; only a fresh private directory is accepted.
- Verified all six CI Gradle jobs declare safe cache policies, all three cache consumers stay unprivileged and current-run-scoped, and every restore uses the expected artifact ID plus digest enforcement.

## Risk and rollout

- Only privileged publication loses cross-run cache reuse; its existing 90-minute timeout and same-job Gradle cache remain unchanged. Ordinary CI retains its existing compilation-cache performance.
- Kotlin stays at `1.9.20`; `2.4.20-Beta1` is currently the first patched upstream release and is intentionally not used for production. Upgrade both build plugin declarations after a stable patched release is available and compatibility has been reviewed.
- Cache isolation assumes an ephemeral GitHub-hosted runner or an equivalently isolated, trusted self-hosted runner.
