### PR TITLE
feat: support OkHttp application interceptors

### DIFF
--- a/openai-java-client-okhttp/build.gradle.kts
+++ b/openai-java-client-okhttp/build.gradle.kts
@@ -21,7 +21,7 @@ listOf(configurations.testCompileClasspath, configurations.testRuntimeClasspath)
 dependencies {
     api(project(":openai-java-core"))
 
-    implementation("com.squareup.okhttp3:okhttp:4.12.0")
+    api("com.squareup.okhttp3:okhttp:4.12.0")
 
     testImplementation(kotlin("test"))
     testImplementation("org.assertj:assertj-core:3.27.7")

--- a/openai-java-client-okhttp/src/main/kotlin/com/openai/client/okhttp/OkHttpClient.kt
+++ b/openai-java-client-okhttp/src/main/kotlin/com/openai/client/okhttp/OkHttpClient.kt
@@ -29,6 +29,7 @@ import okhttp3.ConnectionPool
 import okhttp3.Dispatcher
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.Interceptor
 import okhttp3.MediaType
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.Request
@@ -120,6 +121,7 @@ internal constructor(@JvmSynthetic internal val okHttpClient: okhttp3.OkHttpClie
         private var sslSocketFactory: SSLSocketFactory? = null
         private var trustManager: X509TrustManager? = null
         private var hostnameVerifier: HostnameVerifier? = null
+        private val interceptors: MutableList<Interceptor> = mutableListOf()
 
         fun timeout(timeout: Timeout) = apply { this.timeout = timeout }
 
@@ -135,6 +137,9 @@ internal constructor(@JvmSynthetic internal val okHttpClient: okhttp3.OkHttpClie
         fun proxyAuthenticator(proxyAuthenticator: ProxyAuthenticator?) = apply {
             this.proxyAuthenticator = proxyAuthenticator
         }
+
+        /** Adds an application interceptor to the underlying OkHttp transport. */
+        fun addInterceptor(interceptor: Interceptor) = apply { interceptors.add(interceptor) }
 
         /**
          * Sets the maximum number of idle connections kept by the underlying [ConnectionPool].
@@ -187,6 +192,8 @@ internal constructor(@JvmSynthetic internal val okHttpClient: okhttp3.OkHttpClie
                     .callTimeout(timeout.request())
                     .proxy(proxy)
                     .apply {
+                        interceptors.forEach(::addInterceptor)
+
                         proxyAuthenticator?.let { auth ->
                             proxyAuthenticator { route, response ->
                                 auth

--- a/openai-java-client-okhttp/src/test/kotlin/com/openai/client/okhttp/OkHttpClientTest.kt
+++ b/openai-java-client-okhttp/src/test/kotlin/com/openai/client/okhttp/OkHttpClientTest.kt
@@ -5,6 +5,7 @@ import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo
 import com.github.tomakehurst.wiremock.junit5.WireMockTest
 import com.openai.core.http.HttpMethod
 import com.openai.core.http.HttpRequest
+import okhttp3.Interceptor
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -40,5 +41,41 @@ internal class OkHttpClientTest {
 
         // Should have cancelled the underlying call
         assertThat(call.isCanceled()).isTrue()
+    }
+
+    @Test
+    fun execute_runsConfiguredApplicationInterceptor() {
+        stubFor(get(urlPathEqualTo("/something")).willReturn(ok()))
+        val client =
+            OkHttpClient.builder()
+                .addInterceptor(
+                    Interceptor { chain ->
+                        chain.proceed(
+                            chain
+                                .request()
+                                .newBuilder()
+                                .header("X-Test-Interceptor", "applied")
+                                .build()
+                        )
+                    }
+                )
+                .build()
+
+        client
+            .execute(
+                HttpRequest.builder()
+                    .method(HttpMethod.GET)
+                    .baseUrl(baseUrl)
+                    .addPathSegment("something")
+                    .build()
+            )
+            .use { assertThat(it.statusCode()).isEqualTo(200) }
+
+        verify(
+            1,
+            getRequestedFor(urlPathEqualTo("/something"))
+                .withHeader("X-Test-Interceptor", equalTo("applied")),
+        )
+        client.close()
     }
 }


### PR DESCRIPTION
## Summary

Add application-interceptor support to the SDK's public OkHttp transport builder so users can customise requests and responses without copying the SDK's `HttpClient` implementation.

Fixes #339.

## Problem

The SDK currently exposes several OkHttp transport settings, but there is no supported way to register an OkHttp `Interceptor`. The documented workaround is to copy the SDK's OkHttp transport implementation and maintain a local fork just to add interceptors.

That is unnecessarily heavy for common use cases such as request tagging, custom observability, organisation-specific headers, response inspection, and integration with existing OkHttp middleware.

## Fix

Add a Java-callable builder method:

```java
OkHttpClient.builder().addInterceptor(interceptor)
```

Configured interceptors are registered as standard OkHttp application interceptors when the underlying transport is built. Multiple calls preserve registration order, matching OkHttp's normal semantics.

The existing public construction path can then use the customised transport directly through `ClientOptions` and `OpenAIClientImpl`, without copying SDK source.

## Regression coverage

Extended `OkHttpClientTest` with a WireMock-backed test that:

- installs an application interceptor;
- has the interceptor add a request header;
- performs a real SDK transport request;
- verifies WireMock received the interceptor-added header.

## Validation

- branch is based on current upstream `main` at `81134d727946fb84cc48db98e6c8c53c8a8d22ab`;
- branch is 0 commits behind upstream;
- production diff is 7 additions in `OkHttpClient.kt`;
- existing proxy, timeout, TLS, connection-pool, cancellation, and retry behaviour is unchanged.

Full repository validation is left to GitHub Actions.

## Risk

Low. No interceptor is installed by default, so existing clients behave exactly as before. The new behaviour is entirely opt-in and delegates interceptor semantics to OkHttp.