### PR TITLE
feat: expose immutable Headers map view

### DIFF
--- a/openai-java-core/src/main/kotlin/com/openai/core/http/Headers.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/core/http/Headers.kt
@@ -21,7 +21,20 @@ private constructor(
 
     fun names(): Set<String> = map.keys
 
+    /**
+     * Returns all values associated with [name], or an empty list when the header is absent.
+     *
+     * Names returned by [names] always have at least one value.
+     */
     fun values(name: String): List<String> = map[name].orEmpty()
+
+    /**
+     * Returns the immutable, case-insensitive mapping of header names to their values.
+     *
+     * The returned map and its value lists are the same immutable representation used by this
+     * [Headers] instance; mutating the returned data is not supported.
+     */
+    fun asMap(): Map<String, List<String>> = map
 
     fun toBuilder(): Builder = Builder().putAll(map)
 

--- a/openai-java-core/src/test/kotlin/com/openai/core/http/HeadersMapViewTest.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/core/http/HeadersMapViewTest.kt
@@ -1,0 +1,46 @@
+package com.openai.core.http
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+internal class HeadersMapViewTest {
+
+    @Test
+    fun asMapReturnsCaseInsensitiveImmutableHeaderMapping() {
+        val headers =
+            Headers.builder()
+                .put("X-Test", "one")
+                .put("x-test", "two")
+                .put("Other", "value")
+                .build()
+
+        val map = headers.asMap()
+
+        assertThat(map["X-TEST"]).containsExactly("one", "two")
+        assertThat(map["other"]).containsExactly("value")
+        assertThat(map).hasSize(2)
+    }
+
+    @Test
+    fun asMapDoesNotAllowMapMutation() {
+        val map = Headers.builder().put("X-Test", "value").build().asMap()
+
+        assertThatThrownBy {
+                @Suppress("UNCHECKED_CAST")
+                (map as MutableMap<String, List<String>>)["Other"] = listOf("value")
+            }
+            .isInstanceOf(UnsupportedOperationException::class.java)
+    }
+
+    @Test
+    fun asMapDoesNotAllowValueListMutation() {
+        val values = Headers.builder().put("X-Test", "value").build().asMap()["X-Test"]!!
+
+        assertThatThrownBy {
+                @Suppress("UNCHECKED_CAST")
+                (values as MutableList<String>).add("other")
+            }
+            .isInstanceOf(UnsupportedOperationException::class.java)
+    }
+}


### PR DESCRIPTION
## Summary

Expose the SDK's existing immutable header representation as `Headers.asMap()` and document the value guarantees of `Headers.values(...)`.

Addresses the header-conversion portion of #664.

## Problem

Custom `HttpClient` implementations commonly need to adapt SDK headers into another HTTP library. Today that requires a two-step traversal:

```java
headers.names().forEach(name -> {
    List<String> values = headers.values(name);
    // adapt name + values
});
```

Internally, `Headers` already stores exactly the desired `Map<String, List<String>>`, with case-insensitive name lookup and immutable value lists. The public API does not expose that representation directly.

The issue discussion also notes an undocumented guarantee: names returned by `names()` always have at least one value, while `values(name)` returns an empty list only for an absent header.

## Change

Add:

```java
Map<String, List<String>> headers = sourceHeaders.asMap();
```

`asMap()` returns the same immutable, case-insensitive representation held by the `Headers` instance. It does not copy or flatten multi-valued headers.

Also document the `values(name)` absent/present behaviour.

## Regression coverage

Added focused tests verifying that the returned map:

- preserves case-insensitive header lookup;
- preserves multiple values in insertion order;
- cannot be structurally mutated;
- exposes immutable value lists.

## Scope

- `Headers.kt`: 13 additions
- one focused test file
- no header construction, equality, serialisation, or request behaviour changes
- intentionally does not address the separate request-body convenience proposal in #664

## Validation

The branch is based on current upstream `main` at `81134d727946fb84cc48db98e6c8c53c8a8d22ab` and is 0 commits behind upstream.

## Risk

Low. This is an additive API over the immutable data structure already stored by `Headers`; existing behaviour is unchanged.