### PR TITLE
chore: update example Netty BOM to 4.1.137.Final

### DIFF
--- a/openai-java-example/build.gradle.kts
+++ b/openai-java-example/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
     implementation(project(":openai-java"))
     implementation(project(":openai-java-bedrock"))
     // Keep Azure Identity's Netty runtime aligned on a secure release.
-    implementation(platform("io.netty:netty-bom:4.1.136.Final"))
+    implementation(platform("io.netty:netty-bom:4.1.137.Final"))
     implementation("com.azure:azure-identity:1.18.4")
 }
 


### PR DESCRIPTION
## Summary

- Update the example module's Netty BOM from `4.1.136.Final` to `4.1.137.Final`.
- Keep Azure Identity's transitive Netty modules aligned through the existing platform dependency.
- Leave published SDK dependencies and Jackson compatibility fixtures unchanged.

## Verification

- Confirmed the official Netty `4.1.137.Final` BOM manages `netty-codec-http` at the same release.
- Verified the manifest contains exactly one Netty BOM declaration at `4.1.137.Final`.
- `git diff --check`.
- Full Gradle checks will run in CI; the local machine only has JDK 25, while this project requires JDK 21.