### PR TITLE
Add npm dependency cooldown

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7


### PR DESCRIPTION
Minor, just aligns any local dev flows with Dependabot's cooldown.

Delay npm package resolution for seven days, including transitive dependencies of the pinned Steady CLI invocation.
