### PR TITLE
refactor: remove equivalent generated-source edits

### DIFF
--- a/openai-java-core/src/main/kotlin/com/openai/models/responses/ResponseStreamEvent.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/models/responses/ResponseStreamEvent.kt
@@ -2651,7 +2651,6 @@ private constructor(
                     generator.writeObject(value.customToolCallInputDelta)
                 value.customToolCallInputDone != null ->
                     generator.writeObject(value.customToolCallInputDone)
-
                 value._json != null -> generator.writeObject(value._json)
                 else -> throw IllegalStateException("Invalid ResponseStreamEvent")
             }

--- a/openai-java-core/src/main/kotlin/com/openai/services/blocking/ImageServiceImpl.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/services/blocking/ImageServiceImpl.kt
@@ -85,7 +85,9 @@ class ImageServiceImpl internal constructor(private val clientOptions: ClientOpt
         override fun withOptions(
             modifier: Consumer<ClientOptions.Builder>
         ): ImageService.WithRawResponse =
-            WithRawResponseImpl(clientOptions.toBuilder().apply(modifier::accept).build())
+            ImageServiceImpl.WithRawResponseImpl(
+                clientOptions.toBuilder().apply(modifier::accept).build()
+            )
 
         private val createVariationHandler: Handler<ImagesResponse> =
             jsonHandler<ImagesResponse>(clientOptions.jsonMapper)


### PR DESCRIPTION
## Summary

Remove two behavior-equivalent edits from generated Kotlin files: an extra blank line in `ResponseStreamEvent` serialization and an unqualified reference to `ImageServiceImpl.WithRawResponseImpl`. Both complete files now match the verified public generated snapshot. Serialization, request handling, public API, generation metadata, and API-reference artifacts are unchanged.

The custom-code report moves from 61 to 59 mixed files, with two customizations removed and all 59 others unchanged.

## Test Plan

### Automated

- Full formatting, lint, and SDK build, including Jackson compatibility: passed.
- `ResponseStreamEventTest`, `ResponseStreamEventValidationTest`, `ImageServiceTest`, and `ImageServiceAsyncTest`: 136 passed, four existing skips.
- Baseline and proposed API-compatibility compilation and public-signature checks: passed.
- Exact generated-file and before/after source comparison: passed.
