### PR TITLE
test: move model regressions out of generated files

### DIFF
--- a/openai-java-core/src/test/kotlin/com/openai/models/chat/completions/ChatCompletionCreateParamsTest.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/models/chat/completions/ChatCompletionCreateParamsTest.kt
@@ -464,36 +464,4 @@ internal class ChatCompletionCreateParamsTest {
             )
         assertThat(body.model()).isEqualTo(ChatModel.GPT_5_4)
     }
-
-    @Test
-    fun structuredOutputsBuilder() {
-        class X(val s: String)
-
-        // Only interested in a few things:
-        // - Does the `Builder` type change when `responseFormat(Class<T>)` is called?
-        // - Are values already set on the "old" `Builder` preserved in the change-over?
-        // - Can new values be set on the "new" `Builder` alongside the "old" values?
-        val params =
-            ChatCompletionCreateParams.builder()
-                .addDeveloperMessage("dev message")
-                .model(ChatModel.GPT_4_1)
-                .responseFormat(X::class.java) // Creates and return a new builder.
-                .addSystemMessage("sys message")
-                .build()
-
-        val body = params.rawParams._body()
-
-        assertThat(params).isInstanceOf(StructuredChatCompletionCreateParams::class.java)
-        assertThat(params.responseType).isEqualTo(X::class.java)
-        assertThat(body.messages())
-            .containsExactly(
-                ChatCompletionMessageParam.ofDeveloper(
-                    ChatCompletionDeveloperMessageParam.builder().content("dev message").build()
-                ),
-                ChatCompletionMessageParam.ofSystem(
-                    ChatCompletionSystemMessageParam.builder().content("sys message").build()
-                ),
-            )
-        assertThat(body.model()).isEqualTo(ChatModel.GPT_4_1)
-    }
 }

--- a/openai-java-core/src/test/kotlin/com/openai/models/chat/completions/StructuredChatCompletionCreateParamsTest.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/models/chat/completions/StructuredChatCompletionCreateParamsTest.kt
@@ -30,6 +30,7 @@ import com.openai.models.ChatModel
 import com.openai.models.FunctionDefinition
 import com.openai.models.ResponseFormatJsonSchema
 import java.util.Optional
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
@@ -342,6 +343,38 @@ internal class StructuredChatCompletionCreateParamsTest {
         mock(ChatCompletionCreateParams.Builder::class.java)
     private val builderDelegator =
         StructuredChatCompletionCreateParams.builder<X>().inject(mockBuilderDelegate)
+
+    @Test
+    fun structuredOutputsBuilder() {
+        class X(val s: String)
+
+        // Only interested in a few things:
+        // - Does the `Builder` type change when `responseFormat(Class<T>)` is called?
+        // - Are values already set on the "old" `Builder` preserved in the change-over?
+        // - Can new values be set on the "new" `Builder` alongside the "old" values?
+        val params =
+            ChatCompletionCreateParams.builder()
+                .addDeveloperMessage("dev message")
+                .model(ChatModel.GPT_4_1)
+                .responseFormat(X::class.java) // Creates and return a new builder.
+                .addSystemMessage("sys message")
+                .build()
+
+        val body = params.rawParams._body()
+
+        assertThat(params).isInstanceOf(StructuredChatCompletionCreateParams::class.java)
+        assertThat(params.responseType).isEqualTo(X::class.java)
+        assertThat(body.messages())
+            .containsExactly(
+                ChatCompletionMessageParam.ofDeveloper(
+                    ChatCompletionDeveloperMessageParam.builder().content("dev message").build()
+                ),
+                ChatCompletionMessageParam.ofSystem(
+                    ChatCompletionSystemMessageParam.builder().content("sys message").build()
+                ),
+            )
+        assertThat(body.model()).isEqualTo(ChatModel.GPT_4_1)
+    }
 
     @Test
     fun allBuilderDelegateFunctionsExistInDelegator() {

--- a/openai-java-core/src/test/kotlin/com/openai/models/embeddings/EmbeddingTest.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/models/embeddings/EmbeddingTest.kt
@@ -18,32 +18,6 @@ internal class EmbeddingTest {
     }
 
     @Test
-    fun create_setThenAdd() {
-        val embedding =
-            Embedding.builder()
-                .embedding(EmbeddingValue.ofFloats(listOf(1.0f, 2.0f)))
-                .addEmbedding(3.0f)
-                .index(0L)
-                .build()
-
-        assertThat(embedding.embedding()).containsExactly(1.0f, 2.0f, 3.0f)
-        assertThat(embedding.index()).isEqualTo(0L)
-    }
-
-    @Test
-    fun create_addThenSet() {
-        val embedding =
-            Embedding.builder()
-                .addEmbedding(3.0f)
-                .embedding(EmbeddingValue.ofFloats(listOf(1.0f, 2.0f)))
-                .index(0L)
-                .build()
-
-        assertThat(embedding.embedding()).containsExactly(1.0f, 2.0f)
-        assertThat(embedding.index()).isEqualTo(0L)
-    }
-
-    @Test
     fun roundtrip() {
         val jsonMapper = jsonMapper()
         val embedding = Embedding.builder().addEmbedding(0.0f).index(0L).build()

--- a/openai-java-core/src/test/kotlin/com/openai/models/embeddings/EmbeddingValueTest.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/models/embeddings/EmbeddingValueTest.kt
@@ -6,6 +6,32 @@ import org.junit.jupiter.api.Test
 internal class EmbeddingValueTest {
 
     @Test
+    fun create_setThenAdd() {
+        val embedding =
+            Embedding.builder()
+                .embedding(EmbeddingValue.ofFloats(listOf(1.0f, 2.0f)))
+                .addEmbedding(3.0f)
+                .index(0L)
+                .build()
+
+        assertThat(embedding.embedding()).containsExactly(1.0f, 2.0f, 3.0f)
+        assertThat(embedding.index()).isEqualTo(0L)
+    }
+
+    @Test
+    fun create_addThenSet() {
+        val embedding =
+            Embedding.builder()
+                .addEmbedding(3.0f)
+                .embedding(EmbeddingValue.ofFloats(listOf(1.0f, 2.0f)))
+                .index(0L)
+                .build()
+
+        assertThat(embedding.embedding()).containsExactly(1.0f, 2.0f)
+        assertThat(embedding.index()).isEqualTo(0L)
+    }
+
+    @Test
     fun ofFloats() {
         val floats = listOf(1.0f, 2.0f, 3.0f, 4.0f)
 


### PR DESCRIPTION
## Summary

Move three handwritten regression tests into the existing SDK-owned test classes so the generated test files can match their verified generated snapshot. No assertions, test bodies, or existing destination parameterization are removed or changed:

- `ChatCompletionCreateParamsTest.structuredOutputsBuilder` → `StructuredChatCompletionCreateParamsTest.structuredOutputsBuilder`.
- `EmbeddingTest.create_setThenAdd` → `EmbeddingValueTest.create_setThenAdd`.
- `EmbeddingTest.create_addThenSet` → `EmbeddingValueTest.create_addThenSet`.

Production code, public API, generation metadata, and API-reference artifacts are unchanged. The custom-code report moves from 61 to 59 mixed files, with two customizations removed and all 59 others unchanged.

## Test Plan

### Automated

- Full formatting, lint, and SDK build, including Jackson compatibility: passed.
- All four affected test classes: 189 passed, no skips.
- Baseline and proposed API-compatibility compilation and public-signature checks: passed.
- Verbatim test-body comparison and exact generated-file comparison: passed.
