### PR TITLE
fix: preserve response headers on parsing and stream errors

### DIFF
--- a/openai-java-core/src/main/kotlin/com/openai/core/handlers/JsonHandler.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/core/handlers/JsonHandler.kt
@@ -15,6 +15,6 @@ internal inline fun <reified T> jsonHandler(jsonMapper: JsonMapper): Handler<T> 
             try {
                 jsonMapper.readValue(response.body(), jacksonTypeRef())
             } catch (e: Exception) {
-                throw OpenAIInvalidDataException("Error reading response", e)
+                throw OpenAIInvalidDataException("Error reading response", e, response.headers())
             }
     }

--- a/openai-java-core/src/main/kotlin/com/openai/core/handlers/StreamHandler.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/core/handlers/StreamHandler.kt
@@ -2,6 +2,7 @@
 
 package com.openai.core.handlers
 
+import com.openai.core.http.Headers
 import com.openai.core.http.HttpResponse
 import com.openai.core.http.HttpResponse.Handler
 import com.openai.core.http.PhantomReachableClosingStreamResponse
@@ -30,7 +31,7 @@ internal fun <T> streamHandler(
                                     // We wrap the `lines` instead of the top-level sequence because
                                     // we only want to catch `IOException` from the reader; not from
                                     // the user's own code.
-                                    IOExceptionWrappingSequence(lines),
+                                    IOExceptionWrappingSequence(lines, response.headers()),
                                 )
                             }
                         }
@@ -53,7 +54,10 @@ internal fun <T> streamHandler(
     }
 
 /** A sequence that catches, wraps, and rethrows [IOException] as [OpenAIIoException]. */
-private class IOExceptionWrappingSequence<T>(private val sequence: Sequence<T>) : Sequence<T> {
+private class IOExceptionWrappingSequence<T>(
+    private val sequence: Sequence<T>,
+    private val headers: Headers,
+) : Sequence<T> {
 
     override fun iterator(): Iterator<T> {
         val iterator = sequence.iterator()
@@ -63,14 +67,14 @@ private class IOExceptionWrappingSequence<T>(private val sequence: Sequence<T>) 
                 try {
                     iterator.next()
                 } catch (e: IOException) {
-                    throw OpenAIIoException("Stream failed", e)
+                    throw OpenAIIoException("Stream failed", e, headers)
                 }
 
             override fun hasNext(): Boolean =
                 try {
                     iterator.hasNext()
                 } catch (e: IOException) {
-                    throw OpenAIIoException("Stream failed", e)
+                    throw OpenAIIoException("Stream failed", e, headers)
                 }
         }
     }

--- a/openai-java-core/src/main/kotlin/com/openai/errors/OpenAIInvalidDataException.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/errors/OpenAIInvalidDataException.kt
@@ -1,5 +1,15 @@
 package com.openai.errors
 
+import com.openai.core.http.Headers
+import java.util.Optional
+
 class OpenAIInvalidDataException
 @JvmOverloads
-constructor(message: String? = null, cause: Throwable? = null) : OpenAIException(message, cause)
+constructor(
+    message: String? = null,
+    cause: Throwable? = null,
+    private val headers: Headers? = null,
+) : OpenAIException(message, cause) {
+
+    fun headers(): Optional<Headers> = Optional.ofNullable(headers)
+}

--- a/openai-java-core/src/main/kotlin/com/openai/errors/OpenAIInvalidDataException.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/errors/OpenAIInvalidDataException.kt
@@ -5,11 +5,13 @@ import java.util.Optional
 
 class OpenAIInvalidDataException
 @JvmOverloads
-constructor(
-    message: String? = null,
-    cause: Throwable? = null,
-    private val headers: Headers? = null,
-) : OpenAIException(message, cause) {
+constructor(message: String? = null, cause: Throwable? = null) : OpenAIException(message, cause) {
 
-    fun headers(): Optional<Headers> = Optional.ofNullable(headers)
+    private var responseHeaders: Headers? = null
+
+    internal constructor(message: String?, cause: Throwable?, headers: Headers) : this(message, cause) {
+        responseHeaders = headers
+    }
+
+    fun headers(): Optional<Headers> = Optional.ofNullable(responseHeaders)
 }

--- a/openai-java-core/src/main/kotlin/com/openai/errors/OpenAIIoException.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/errors/OpenAIIoException.kt
@@ -1,5 +1,15 @@
 package com.openai.errors
 
+import com.openai.core.http.Headers
+import java.util.Optional
+
 class OpenAIIoException
 @JvmOverloads
-constructor(message: String? = null, cause: Throwable? = null) : OpenAIException(message, cause)
+constructor(
+    message: String? = null,
+    cause: Throwable? = null,
+    private val headers: Headers? = null,
+) : OpenAIException(message, cause) {
+
+    fun headers(): Optional<Headers> = Optional.ofNullable(headers)
+}

--- a/openai-java-core/src/main/kotlin/com/openai/errors/OpenAIIoException.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/errors/OpenAIIoException.kt
@@ -5,11 +5,13 @@ import java.util.Optional
 
 class OpenAIIoException
 @JvmOverloads
-constructor(
-    message: String? = null,
-    cause: Throwable? = null,
-    private val headers: Headers? = null,
-) : OpenAIException(message, cause) {
+constructor(message: String? = null, cause: Throwable? = null) : OpenAIException(message, cause) {
 
-    fun headers(): Optional<Headers> = Optional.ofNullable(headers)
+    private var responseHeaders: Headers? = null
+
+    internal constructor(message: String?, cause: Throwable?, headers: Headers) : this(message, cause) {
+        responseHeaders = headers
+    }
+
+    fun headers(): Optional<Headers> = Optional.ofNullable(responseHeaders)
 }

--- a/openai-java-core/src/test/kotlin/com/openai/core/handlers/JsonHandlerTest.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/core/handlers/JsonHandlerTest.kt
@@ -1,0 +1,39 @@
+package com.openai.core.handlers
+
+import com.fasterxml.jackson.databind.json.JsonMapper
+import com.openai.core.http.Headers
+import com.openai.core.http.HttpResponse
+import com.openai.errors.OpenAIInvalidDataException
+import java.io.InputStream
+import kotlin.test.Test
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.assertThrows
+
+internal class JsonHandlerTest {
+
+    @Test
+    fun jsonHandler_whenBodyCannotBeRead_exposesResponseHeaders() {
+        val headers = Headers.builder().put("x-request-id", "req_123").build()
+        val handler = jsonHandler<Map<String, Any>>(JsonMapper.builder().build())
+
+        val error =
+            assertThrows<OpenAIInvalidDataException> {
+                handler.handle(httpResponse("{".byteInputStream(), headers))
+            }
+
+        assertThat(error).hasMessage("Error reading response")
+        assertThat(error.headers()).contains(headers)
+    }
+
+    private fun httpResponse(body: InputStream, headers: Headers): HttpResponse =
+        object : HttpResponse {
+
+            override fun statusCode(): Int = 200
+
+            override fun headers(): Headers = headers
+
+            override fun body(): InputStream = body
+
+            override fun close() {}
+        }
+}

--- a/openai-java-core/src/test/kotlin/com/openai/core/handlers/StreamHandlerTest.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/core/handlers/StreamHandlerTest.kt
@@ -43,12 +43,15 @@ internal class StreamHandlerTest {
 
     @Test
     fun streamHandler_whenReaderThrowsIOException_wrapsException() {
+        val headers = Headers.builder().put("x-request-id", "req_123").build()
         val handler = streamHandler<String> { _, lines -> lines.forEach {} }
-        val streamResponse = handler.handle(httpResponse("a\nb\nc\n".byteInputStream().throwing()))
+        val streamResponse =
+            handler.handle(httpResponse("a\nb\nc\n".byteInputStream().throwing(), headers))
 
         val e = assertThrows<OpenAIIoException> { streamResponse.stream().forEach {} }
         assertThat(e).hasMessage("Stream failed")
         assertThat(e).hasCauseInstanceOf(IOException::class.java)
+        assertThat(e.headers()).contains(headers)
     }
 
     @Test
@@ -68,12 +71,15 @@ internal class StreamHandlerTest {
         assertThat(e).isSameAs(ioException)
     }
 
-    private fun httpResponse(body: InputStream): HttpResponse =
+    private fun httpResponse(
+        body: InputStream,
+        headers: Headers = Headers.builder().build(),
+    ): HttpResponse =
         object : HttpResponse {
 
             override fun statusCode(): Int = 0
 
-            override fun headers(): Headers = Headers.builder().build()
+            override fun headers(): Headers = headers
 
             override fun body(): InputStream = body
 


### PR DESCRIPTION
This pull request preserves available HTTP response headers when response parsing or streaming fails, so callers can inspect diagnostics such as `x-request-id`.

## Problem

`OpenAIInvalidDataException` and `OpenAIIoException` currently carry only a message and cause. This drops response metadata even in error paths where an `HttpResponse` already exists:

- `JsonHandler` wraps body read/deserialization failures as `OpenAIInvalidDataException`.
- `StreamHandler` wraps reader `IOException`s as `OpenAIIoException`.

That makes production debugging harder because callers cannot recover response headers such as `x-request-id`.

## Changes

- add optional `headers()` accessors to `OpenAIInvalidDataException` and `OpenAIIoException`
- keep the existing two-parameter primary constructors unchanged
- use internal secondary constructors only when response headers are available
- attach `response.headers()` when JSON body parsing fails
- attach response headers when a streaming reader fails
- leave pre-response transport failures unchanged, where no response headers exist
- add focused regression coverage for both error paths

## Compatibility

The original primary constructor signatures and Kotlin default-argument ABI remain unchanged, and the existing Java overloads are preserved. The new header metadata is additive and optional.

## Validation

- verified the branch is based on upstream `main` at `95f4a1173c119ad08a049d752ec67de251434938`
- verified the diff is limited to the two exception types, the JSON/stream handlers, and focused tests
- focused regression tests are included for `x-request-id` propagation
- full repository validation is left to GitHub Actions because this environment does not have a complete local checkout/toolchain

Fixes #690