### PR TITLE
feat(core): expose request body content streams

### DIFF
--- a/openai-java-core/src/main/kotlin/com/openai/core/http/HttpRequestBodies.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/core/http/HttpRequestBodies.kt
@@ -11,6 +11,8 @@ import com.openai.errors.OpenAIInvalidDataException
 import java.io.ByteArrayInputStream
 import java.io.InputStream
 import java.io.OutputStream
+import java.io.SequenceInputStream
+import java.util.Collections
 import java.util.UUID
 import kotlin.jvm.optionals.getOrNull
 
@@ -20,6 +22,8 @@ internal inline fun <reified T> json(jsonMapper: JsonMapper, value: T): HttpRequ
         private val bytes: ByteArray by lazy { jsonMapper.writeValueAsBytes(value) }
 
         override fun writeTo(outputStream: OutputStream) = outputStream.write(bytes)
+
+        override fun content(): InputStream = bytes.inputStream()
 
         override fun contentType(): String = "application/json"
 
@@ -60,6 +64,8 @@ internal fun multipartFormData(
                                     outputStream.write(byteArray)
                                 }
 
+                                override fun content(): InputStream = byteArray.inputStream()
+
                                 override fun contentType(): String = field.contentType
 
                                 override fun contentLength(): Long = byteArray.size.toLong()
@@ -74,6 +80,8 @@ internal fun multipartFormData(
                                 override fun writeTo(outputStream: OutputStream) {
                                     bytes.copyTo(outputStream)
                                 }
+
+                                override fun content(): InputStream = bytes
 
                                 override fun contentType(): String = field.contentType
 
@@ -145,6 +153,36 @@ private constructor(private val boundary: String, private val parts: List<Part>)
         outputStream.write(boundaryBytes)
         outputStream.write(DASHDASH)
         outputStream.write(CRLF)
+    }
+
+    // This must remain in sync with `writeTo`.
+    override fun content(): InputStream {
+        val streams = mutableListOf<InputStream>()
+
+        parts.forEach { part ->
+            streams.add(DASHDASH.inputStream())
+            streams.add(boundaryBytes.inputStream())
+            streams.add(CRLF.inputStream())
+
+            streams.add(CONTENT_DISPOSITION.inputStream())
+            streams.add(part.contentDisposition.toByteArray().inputStream())
+            streams.add(CRLF.inputStream())
+
+            streams.add(CONTENT_TYPE.inputStream())
+            streams.add(part.contentType.toByteArray().inputStream())
+            streams.add(CRLF.inputStream())
+
+            streams.add(CRLF.inputStream())
+            streams.add(part.body.content())
+            streams.add(CRLF.inputStream())
+        }
+
+        streams.add(DASHDASH.inputStream())
+        streams.add(boundaryBytes.inputStream())
+        streams.add(DASHDASH.inputStream())
+        streams.add(CRLF.inputStream())
+
+        return SequenceInputStream(Collections.enumeration(streams))
     }
 
     override fun contentType(): String = contentType

--- a/openai-java-core/src/main/kotlin/com/openai/core/http/HttpRequestBody.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/core/http/HttpRequestBody.kt
@@ -1,11 +1,26 @@
 package com.openai.core.http
 
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
 import java.io.OutputStream
 import java.lang.AutoCloseable
 
 interface HttpRequestBody : AutoCloseable {
 
     fun writeTo(outputStream: OutputStream)
+
+    /**
+     * Returns the request body content as an input stream.
+     *
+     * The default implementation buffers the bytes produced by [writeTo] so existing third-party
+     * implementations remain compatible. Implementations backed by an existing byte array or stream
+     * should override this method to avoid buffering.
+     */
+    fun content(): InputStream {
+        val outputStream = ByteArrayOutputStream()
+        writeTo(outputStream)
+        return outputStream.toByteArray().inputStream()
+    }
 
     fun contentType(): String?
 

--- a/openai-java-core/src/test/java/com/openai/core/http/HttpRequestBodyJavaTest.java
+++ b/openai-java-core/src/test/java/com/openai/core/http/HttpRequestBodyJavaTest.java
@@ -1,0 +1,51 @@
+package com.openai.core.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+
+final class HttpRequestBodyJavaTest {
+
+    @Test
+    void contentIsJavaDefaultMethod() throws Exception {
+        assertThat(HttpRequestBody.class.getMethod("content").isDefault()).isTrue();
+
+        HttpRequestBody body =
+                new HttpRequestBody() {
+                    @Override
+                    public void writeTo(OutputStream outputStream) {
+                        try {
+                            outputStream.write("body".getBytes(StandardCharsets.UTF_8));
+                        } catch (IOException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+
+                    @Override
+                    public String contentType() {
+                        return "text/plain";
+                    }
+
+                    @Override
+                    public long contentLength() {
+                        return 4L;
+                    }
+
+                    @Override
+                    public boolean repeatable() {
+                        return true;
+                    }
+
+                    @Override
+                    public void close() {}
+                };
+
+        try (InputStream content = body.content()) {
+            assertThat(content.readAllBytes()).isEqualTo("body".getBytes(StandardCharsets.UTF_8));
+        }
+    }
+}

--- a/openai-java-core/src/test/java/com/openai/core/http/HttpRequestBodyJavaTest.java
+++ b/openai-java-core/src/test/java/com/openai/core/http/HttpRequestBodyJavaTest.java
@@ -45,7 +45,10 @@ final class HttpRequestBodyJavaTest {
                 };
 
         try (InputStream content = body.content()) {
-            assertThat(content.readAllBytes()).isEqualTo("body".getBytes(StandardCharsets.UTF_8));
+            byte[] bytes = new byte[4];
+            assertThat(content.read(bytes)).isEqualTo(bytes.length);
+            assertThat(bytes).isEqualTo("body".getBytes(StandardCharsets.UTF_8));
+            assertThat(content.read()).isEqualTo(-1);
         }
     }
 }

--- a/openai-java-core/src/test/kotlin/com/openai/core/http/HttpRequestBodyContentTest.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/core/http/HttpRequestBodyContentTest.kt
@@ -1,0 +1,78 @@
+package com.openai.core.http
+
+import com.openai.core.MultipartField
+import com.openai.core.jsonMapper
+import java.io.ByteArrayOutputStream
+import java.io.OutputStream
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+internal class HttpRequestBodyContentTest {
+
+    @Test
+    fun content_defaultsToWriteTo() {
+        val body =
+            object : HttpRequestBody {
+                override fun writeTo(outputStream: OutputStream) {
+                    outputStream.write("body".toByteArray())
+                }
+
+                override fun contentType(): String = "text/plain"
+
+                override fun contentLength(): Long = 4L
+
+                override fun repeatable(): Boolean = true
+
+                override fun close() {}
+            }
+
+        body.content().use { content -> assertThat(content.readBytes()).isEqualTo("body".toByteArray()) }
+    }
+
+    @Test
+    fun multipartContent_matchesWriteTo() {
+        val body =
+            multipartFormData(
+                jsonMapper(),
+                mapOf(
+                    "field" to
+                        MultipartField.builder<String>()
+                            .value("value")
+                            .contentType("text/plain")
+                            .build(),
+                    "binary" to
+                        MultipartField.builder<ByteArray>()
+                            .value("abc".toByteArray())
+                            .contentType("application/octet-stream")
+                            .build(),
+                ),
+            )
+
+        val output = ByteArrayOutputStream()
+        body.writeTo(output)
+
+        body.content().use { content -> assertThat(content.readBytes()).isEqualTo(output.toByteArray()) }
+    }
+
+    @Test
+    fun multipartContent_streamsInputStreamParts() {
+        val body =
+            multipartFormData(
+                jsonMapper(),
+                mapOf(
+                    "data" to
+                        MultipartField.builder<java.io.InputStream>()
+                            .value("stream content".byteInputStream().buffered())
+                            .contentType("application/octet-stream")
+                            .build()
+                ),
+            )
+
+        val content = body.content().use { it.readBytes().toString(Charsets.UTF_8) }
+
+        assertThat(body.repeatable()).isFalse()
+        assertThat(content).contains("Content-Disposition: form-data; name=\"data\"")
+        assertThat(content).contains("Content-Type: application/octet-stream")
+        assertThat(content).contains("stream content")
+    }
+}


### PR DESCRIPTION
## Summary

Add `HttpRequestBody.content(): InputStream` so custom HTTP client implementations can consume request bodies directly as streams.

Addresses the request-body portion of #664.

## Problem

`HttpResponse.body()` already exposes an `InputStream`, but `HttpRequestBody` only exposes `writeTo(OutputStream)`. Custom `HttpClient` adapters therefore have to bridge the push-style request body API themselves.

## Changes

- add a JVM-default `content(): InputStream` method to `HttpRequestBody`
- keep existing third-party implementations compatible by providing a default fallback based on `writeTo`
- override the fallback for built-in JSON and multipart bodies
- stream multipart framing with `SequenceInputStream`, so `InputStream`-backed file parts are not buffered into memory
- add focused Kotlin regression coverage for fallback behavior and byte-for-byte multipart parity
- add a Java-facing regression proving existing implementations do not need to implement the new method

## Compatibility

The repository compiles Kotlin interfaces with `-Xjvm-default=all`, so the new method is emitted as a Java default interface method. Existing Java and Kotlin implementations are not required to add an override.

The fallback implementation buffers only for third-party bodies that do not override `content()`. Built-in SDK request bodies override it, including streaming multipart bodies.

## Validation

- branch is based directly on current upstream `main` at `715a30468d3232a5df4f6c6bec8b2175404eb8b9`
- branch is 0 commits behind upstream
- diff is limited to `HttpRequestBody`, built-in request-body implementations, and focused tests
- focused regression tests are included for Kotlin and Java callers
- full repository validation is left to GitHub Actions because this environment does not have a complete local checkout/toolchain

Addresses #664