### PR TITLE
chore: set a 2,000-line custom-code budget

### DIFF
--- a/.castiron-ratchet.json
+++ b/.castiron-ratchet.json
@@ -1,0 +1,4 @@
+{
+  "schema_version": 1,
+  "max_custom_patch_lines": 2000
+}


### PR DESCRIPTION
## Summary

Set a 2,000-line ceiling on additions **plus** deletions in the remaining custom patch against verified generated output. This is the budget-only foundation for the same rollout approved in [Python #3714](https://github.com/openai/openai-python/pull/3714) and [Python #3715](https://github.com/openai/openai-python/pull/3715).

The ceiling is based on the upcoming compatible WebSocket event regeneration: **+1,158 / −181 = 1,339 lines**, leaving **661 lines** of headroom. Current public main still carries the old large event customization; seeding a temporary 55k allowance would retain that accident as the policy.

This policy-only PR can merge now. Its tooling companion will remain **draft and must not merge until the fixed generation reaches public main**.

Only `.castiron-ratchet.json` changes here. The stacked tooling PR will use the base-branch allowance, so a PR cannot raise its own budget. Future increases require a separate budget-only PR, explicit justification, and a human approving review; agents cannot approve them.

No workflow, CODEOWNERS, or ruleset changes are included. Ruleset enforcement is a separate, later decision.

Tooling companion: https://github.com/openai/openai-java/pull/925
