### PR TITLE
test: preserve large HTTP response payloads

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,3 +45,22 @@ The checker and effective budget come from main, not the PR. Keep default CODEOW
   SDK behavior and workflow, Gradle, or shell checks for signing, release, and publication logic.
 - Report suspected vulnerabilities privately through [SECURITY.md](SECURITY.md). Do not open public
   issues, discussions, or pull requests containing vulnerability details or secrets.
+
+## Large-payload compatibility
+
+Treat large payloads as a normal API contract, not evidence of malformed or
+hostile input. Responses, Chat Completions, and other APIs can legitimately
+return large `application/json` bodies and streaming events. Do not introduce
+new arbitrary fixed limits on bodies, events, or lines as a security or efficiency fix.
+Prefer incremental processing, amortized-linear buffering, timely cleanup, and
+caller cancellation. Any new rejection limit needs an explicit, owner-approved
+API contract and a review of existing supported payloads and transports.
+Preserve longstanding dependency limits unless changing them is explicitly in scope;
+regression fixtures should exercise payloads supported by recent SDK releases.
+
+Protect this behavior with focused, deterministic public-entrypoint tests using
+large synthetic payloads generated in memory, not committed captures or live
+image generation. Their high memory use is intentional: do not shrink the
+payloads or raise client limits to make the tests pass. Keep coverage to the main
+JSON and streaming categories, and run large cases sequentially to keep peak
+memory reasonable. The fixture size is a regression probe, not a new API maximum.

--- a/openai-java-client-okhttp/src/test/kotlin/com/openai/client/okhttp/LargePayloadContractTest.kt
+++ b/openai-java-client-okhttp/src/test/kotlin/com/openai/client/okhttp/LargePayloadContractTest.kt
@@ -1,0 +1,167 @@
+package com.openai.client.okhttp
+
+import com.openai.helpers.ChatCompletionAccumulator
+import com.openai.helpers.ResponseAccumulator
+import com.openai.models.chat.completions.ChatCompletionCreateParams
+import com.openai.models.responses.Response
+import com.openai.models.responses.ResponseCreateParams
+import java.util.concurrent.TimeUnit
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
+
+@Execution(ExecutionMode.SAME_THREAD)
+internal class LargePayloadContractTest {
+    // High memory use is INTENTIONAL: protect historically supported payloads against
+    // new arbitrary body, event, or line caps. 16 MiB + 1 catches new 8/16 MiB caps
+    // while staying below Jackson's longstanding 20,000,000-character string limit.
+    // Preserve that existing limit; do not shrink this fixture or raise client limits
+    // to make new restrictions pass. This is a regression probe, not an API maximum.
+    // Generate data in memory and keep these few cases sequential.
+    private val payloadSize = 16 * 1024 * 1024 + 1
+
+    @Test
+    fun blockingResponsesJsonPreservesLargeOutputText() {
+        val text = "x".repeat(payloadSize)
+        MockWebServer().use { server ->
+            server.enqueue(
+                MockResponse()
+                    .setHeader("Content-Type", "application/json")
+                    .setBody(responseJson(text))
+            )
+            val client = client(server)
+            try {
+                assertCompleteText(outputText(client.responses().create(params())), text)
+            } finally {
+                client.close()
+            }
+        }
+    }
+
+    @Test
+    fun streamingResponsesPreservesLargeFinalResponse() {
+        val text = "x".repeat(payloadSize)
+        val jsonText = "\"$text\""
+        MockWebServer().use { server ->
+            server.enqueue(
+                MockResponse()
+                    .setHeader("Content-Type", "text/event-stream")
+                    .setBody(
+                        "event: response.completed\ndata: " +
+                            """{"type":"response.completed","response":${responseJson(jsonText)},"sequence_number":1}""" +
+                            "\n\ndata: [DONE]\n\n"
+                    )
+            )
+            val client = client(server)
+            try {
+                val accumulator = ResponseAccumulator.create()
+                client.responses().createStreaming(params()).use { response ->
+                    val events = response.stream().iterator()
+                    accumulator.accumulate(events.next())
+                    assertThat(events.hasNext()).isFalse()
+                }
+                assertCompleteText(outputText(accumulator.response()), jsonText)
+                // Typed output uses a separate mapper; exercise it without another large fixture.
+                assertCompleteText(
+                    accumulator
+                        .response(String::class.java)
+                        .output()
+                        .single()
+                        .asMessage()
+                        .content()
+                        .single()
+                        .outputText()
+                        .get(),
+                    text,
+                )
+            } finally {
+                client.close()
+            }
+        }
+    }
+
+    @Test
+    fun asyncChatStreamPreservesLargeDeltaAndAccumulatedCompletion() {
+        val text = "x".repeat(payloadSize)
+        MockWebServer().use { server ->
+            server.enqueue(
+                MockResponse()
+                    .setHeader("Content-Type", "text/event-stream")
+                    .setBody(
+                        "data: " +
+                            chatChunk(text, "null") +
+                            "\n\n" +
+                            "data: " +
+                            chatChunk("end", "\"stop\"") +
+                            "\n\ndata: [DONE]\n\n"
+                    )
+            )
+            val client =
+                OpenAIOkHttpClientAsync.builder()
+                    .apiKey("test-key")
+                    .baseUrl(server.url("/").toString())
+                    .maxRetries(0)
+                    .build()
+            try {
+                val accumulator = ChatCompletionAccumulator.create()
+                var chunks = 0
+                client
+                    .chat()
+                    .completions()
+                    .createStreaming(
+                        ChatCompletionCreateParams.builder()
+                            .model("gpt-4o-mini")
+                            .addUserMessage("Hello")
+                            .build()
+                    )
+                    .subscribe { chunk ->
+                        if (chunks++ == 0) {
+                            assertCompleteText(
+                                chunk.choices().single().delta().content().get(),
+                                text,
+                            )
+                        }
+                        accumulator.accumulate(chunk)
+                    }
+                    .onCompleteFuture()
+                    .get(30, TimeUnit.SECONDS)
+                assertThat(chunks).isEqualTo(2)
+                assertCompleteText(
+                    accumulator.chatCompletion().choices().single().message().content().get(),
+                    text + "end",
+                )
+            } finally {
+                client.close()
+            }
+        }
+    }
+
+    private fun client(server: MockWebServer) =
+        OpenAIOkHttpClient.builder()
+            .apiKey("test-key")
+            .baseUrl(server.url("/").toString())
+            .maxRetries(0)
+            .build()
+
+    private fun params() =
+        ResponseCreateParams.builder().model("gpt-4o-mini").input("Hello").build()
+
+    private fun outputText(response: Response) =
+        response.output().single().asMessage().content().single().asOutputText().text()
+
+    private fun responseJson(text: String): String {
+        val escapedText = text.replace("\"", "\\\"")
+        return """{"id":"resp_test","object":"response","status":"completed","created_at":0,"model":"gpt-4o-mini","error":null,"incomplete_details":null,"instructions":null,"metadata":{},"parallel_tool_calls":true,"temperature":1,"tool_choice":"auto","tools":[],"top_p":1,"output":[{"type":"message","id":"msg_test","role":"assistant","status":"completed","content":[{"type":"output_text","text":"$escapedText","annotations":[],"logprobs":[]}]}]}"""
+    }
+
+    private fun chatChunk(text: String, finishReason: String) =
+        """{"id":"chatcmpl_test","object":"chat.completion.chunk","created":0,"model":"gpt-4o-mini","choices":[{"index":0,"delta":{"role":"assistant","content":"$text"},"finish_reason":$finishReason}]}"""
+
+    private fun assertCompleteText(actual: String, expected: String) {
+        // Do not dump tens of MiB into test output on failure.
+        assertThat(actual == expected).describedAs("complete large output text").isTrue()
+    }
+}


### PR DESCRIPTION
## Summary

Protect historically supported large HTTP responses against new SDK-side body, event, or line caps, following the guidance in [openai-node#2433](https://github.com/openai/openai-node/pull/2433).

Add three sequential, offline public-client cases with synthetic 16 MiB + 1 character payloads: Responses JSON `output_text`, a final Responses SSE snapshot through `ResponseAccumulator` (including typed output parsing), and an asynchronous Chat Completions SSE delta through `ChatCompletionAccumulator`. Compare the complete content without printing large fixtures on failure; no live API requests or recordings are involved.

The fixture deliberately stays below Jackson's longstanding 20,000,000-character string limit, inherited with the Jackson upgrade in [#7](https://github.com/openai/openai-java/pull/7). This preserves the existing contract while detecting new 8/16 MiB restrictions. Its high memory use is intentional, not a new API maximum. Add agent guidance to keep these probes and review any new rejection limits explicitly.

No production limits, dependencies, generated code, or custom-code budgets change.
