### PR TITLE
test: define X.509 workload identity wire contract

### DIFF
--- a/openai-java-client-okhttp/src/test/kotlin/com/openai/client/okhttp/X509WireTestInfrastructure.kt
+++ b/openai-java-client-okhttp/src/test/kotlin/com/openai/client/okhttp/X509WireTestInfrastructure.kt
@@ -1,0 +1,169 @@
+package com.openai.client.okhttp
+
+import java.net.Proxy
+import java.net.Socket
+import java.security.SecureRandom
+import java.security.cert.X509Certificate
+import java.util.concurrent.CopyOnWriteArrayList
+import javax.net.ssl.ExtendedSSLSession
+import javax.net.ssl.SNIHostName
+import javax.net.ssl.SSLContext
+import javax.net.ssl.SSLEngine
+import javax.net.ssl.SSLSocket
+import javax.net.ssl.X509ExtendedTrustManager
+import javax.net.ssl.X509TrustManager
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.RecordedRequest
+import okhttp3.mockwebserver.SocketPolicy
+import okhttp3.tls.HandshakeCertificates
+import okhttp3.tls.HeldCertificate
+
+/** Test-only certificate identity for the X.509 wire-contract suite. */
+internal class X509TestIdentity
+private constructor(val leaf: HeldCertificate, val root: HeldCertificate) {
+    fun clientHandshakeCertificates(
+        trustedServerRoots: Iterable<X509Certificate>
+    ): HandshakeCertificates =
+        HandshakeCertificates.Builder()
+            .heldCertificate(leaf)
+            .apply {
+                trustedServerRoots.forEach { certificate -> addTrustedCertificate(certificate) }
+            }
+            .build()
+
+    companion object {
+        fun create(commonName: String): X509TestIdentity {
+            val root =
+                HeldCertificate.Builder()
+                    .commonName("$commonName root")
+                    .certificateAuthority(1)
+                    .build()
+            val leaf = HeldCertificate.Builder().commonName(commonName).signedBy(root).build()
+            return X509TestIdentity(leaf, root)
+        }
+    }
+}
+
+/**
+ * A distinct mTLS peer that acts as an HTTP CONNECT proxy before negotiating TLS. This preserves
+ * the production authority and SNI while keeping every connection on loopback.
+ */
+internal class X509TestPeer(val authority: String, trustedClientRoot: X509Certificate) :
+    AutoCloseable {
+    private val serverRoot =
+        HeldCertificate.Builder().commonName("$authority test root").certificateAuthority(1).build()
+    private val serverLeaf =
+        HeldCertificate.Builder()
+            .commonName(authority)
+            .addSubjectAlternativeName(authority)
+            .signedBy(serverRoot)
+            .build()
+    private val recordingTrustManager =
+        RecordingClientTrustManager(
+            HandshakeCertificates.Builder()
+                .addTrustedCertificate(trustedClientRoot)
+                .build()
+                .trustManager
+        )
+    private val serverIdentity = HandshakeCertificates.Builder().heldCertificate(serverLeaf).build()
+    private val sslContext =
+        SSLContext.getInstance("TLS").apply {
+            init(arrayOf(serverIdentity.keyManager), arrayOf(recordingTrustManager), SecureRandom())
+        }
+
+    val server =
+        MockWebServer().apply {
+            useHttps(sslContext.socketFactory, true)
+            requireClientAuth()
+            start()
+        }
+
+    val proxy: Proxy
+        get() = server.toProxyAddress()
+
+    val serverRootCertificate: X509Certificate
+        get() = serverRoot.certificate
+
+    val requestedServerNames: List<String>
+        get() = recordingTrustManager.requestedServerNames.toList()
+
+    fun enqueue(response: MockResponse) {
+        server.enqueue(MockResponse().setSocketPolicy(SocketPolicy.UPGRADE_TO_SSL_AT_END))
+        server.enqueue(response)
+    }
+
+    fun takeRequest(): RecordedRequest = server.takeRequest()
+
+    override fun close() {
+        server.close()
+    }
+}
+
+internal inline fun <T> OkHttpClient.useTestClient(block: (OkHttpClient) -> T): T =
+    try {
+        block(this)
+    } finally {
+        connectionPool.evictAll()
+        dispatcher.executorService.shutdownNow()
+        cache?.close()
+    }
+
+private class RecordingClientTrustManager(private val delegate: X509TrustManager) :
+    X509ExtendedTrustManager() {
+    val requestedServerNames = CopyOnWriteArrayList<String>()
+
+    override fun checkClientTrusted(
+        chain: Array<out X509Certificate>,
+        authType: String,
+        socket: Socket,
+    ) {
+        recordRequestedServerNames((socket as? SSLSocket)?.handshakeSession)
+        delegate.checkClientTrusted(chain, authType)
+    }
+
+    override fun checkClientTrusted(
+        chain: Array<out X509Certificate>,
+        authType: String,
+        engine: SSLEngine,
+    ) {
+        recordRequestedServerNames(engine.handshakeSession)
+        delegate.checkClientTrusted(chain, authType)
+    }
+
+    override fun checkClientTrusted(chain: Array<out X509Certificate>, authType: String) {
+        delegate.checkClientTrusted(chain, authType)
+    }
+
+    override fun checkServerTrusted(
+        chain: Array<out X509Certificate>,
+        authType: String,
+        socket: Socket,
+    ) {
+        delegate.checkServerTrusted(chain, authType)
+    }
+
+    override fun checkServerTrusted(
+        chain: Array<out X509Certificate>,
+        authType: String,
+        engine: SSLEngine,
+    ) {
+        delegate.checkServerTrusted(chain, authType)
+    }
+
+    override fun checkServerTrusted(chain: Array<out X509Certificate>, authType: String) {
+        delegate.checkServerTrusted(chain, authType)
+    }
+
+    override fun getAcceptedIssuers(): Array<X509Certificate> = delegate.acceptedIssuers
+
+    private fun recordRequestedServerNames(session: javax.net.ssl.SSLSession?) {
+        val extendedSession = session as? ExtendedSSLSession ?: return
+        extendedSession.requestedServerNames.filterIsInstance<SNIHostName>().mapTo(
+            requestedServerNames
+        ) { serverName ->
+            serverName.asciiName
+        }
+    }
+}

--- a/openai-java-client-okhttp/src/test/kotlin/com/openai/client/okhttp/X509WorkloadIdentityWireContractTest.kt
+++ b/openai-java-client-okhttp/src/test/kotlin/com/openai/client/okhttp/X509WorkloadIdentityWireContractTest.kt
@@ -1,0 +1,215 @@
+package com.openai.client.okhttp
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import java.net.Proxy
+import java.security.cert.X509Certificate
+import javax.net.ssl.SSLPeerUnverifiedException
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.RecordedRequest
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+/**
+ * Executable wire contract for the X.509 workload-identity implementation introduced by later PRs.
+ * This is deliberately independent of SDK production code.
+ *
+ * The bearer is not certificate-bound. The exchange and API TLS connections may present different
+ * certificates that are each independently accepted by their destination.
+ */
+internal class X509WorkloadIdentityWireContractTest {
+    private val jsonMapper = ObjectMapper()
+
+    @Test
+    fun referenceFlowUsesExactAuthoritiesAndIndependentClientCertificates() {
+        val exchangeIdentity = X509TestIdentity.create("exchange identity")
+        val apiIdentity = X509TestIdentity.create("api identity")
+        X509TestPeer(AUTH_HOST, exchangeIdentity.root.certificate).use { authPeer ->
+            X509TestPeer(API_HOST, apiIdentity.root.certificate).use { apiPeer ->
+                authPeer.enqueue(
+                    MockResponse()
+                        .setHeader("Content-Type", "application/json")
+                        .setBody(TOKEN_RESPONSE)
+                )
+                apiPeer.enqueue(
+                    MockResponse()
+                        .setHeader("Content-Type", "application/json")
+                        .setBody("""{"object":"list","data":[]}""")
+                )
+
+                val accessToken =
+                    mtlsClient(
+                            exchangeIdentity,
+                            listOf(authPeer.serverRootCertificate),
+                            authPeer.proxy,
+                        )
+                        .useTestClient(::exchangeToken)
+                mtlsClient(apiIdentity, listOf(apiPeer.serverRootCertificate), apiPeer.proxy)
+                    .useTestClient { client -> callApi(client, accessToken) }
+
+                val authConnect = authPeer.takeRequest()
+                val exchangeRequest = authPeer.takeRequest()
+                val apiConnect = apiPeer.takeRequest()
+                val apiRequest = apiPeer.takeRequest()
+                assertConnectAuthority(authConnect, AUTH_AUTHORITY)
+                assertConnectAuthority(apiConnect, API_AUTHORITY)
+                assertThat(exchangeRequest.method).isEqualTo("POST")
+                assertThat(exchangeRequest.path).isEqualTo("/oauth/token")
+                assertThat(exchangeRequest.getHeader("Authorization")).isNull()
+                assertThat(exchangeRequest.getHeader("Content-Type")).startsWith("application/json")
+                assertThat(jsonMapper.readTree(exchangeRequest.body.readUtf8()))
+                    .isEqualTo(jsonMapper.readTree(TOKEN_REQUEST))
+                assertThat(apiRequest.method).isEqualTo("GET")
+                assertThat(apiRequest.path).isEqualTo("/v1/files")
+                assertThat(apiRequest.getHeader("Authorization")).isEqualTo("Bearer $ACCESS_TOKEN")
+                assertPresentedCertificate(exchangeRequest, exchangeIdentity.leaf.certificate)
+                assertPresentedCertificate(apiRequest, apiIdentity.leaf.certificate)
+                assertThat(authPeer.requestedServerNames).containsExactly(AUTH_HOST)
+                assertThat(apiPeer.requestedServerNames).containsExactly(API_HOST)
+            }
+        }
+    }
+
+    @Test
+    fun referenceClientsDoNotFollowRedirectsOnEitherLeg() {
+        val identity = X509TestIdentity.create("redirect test identity")
+        X509TestPeer(AUTH_HOST, identity.root.certificate).use { authPeer ->
+            X509TestPeer(API_HOST, identity.root.certificate).use { apiPeer ->
+                authPeer.enqueue(MockResponse().setResponseCode(307).setHeader("Location", API_URL))
+                authPeer.enqueue(MockResponse())
+                apiPeer.enqueue(MockResponse().setResponseCode(307).setHeader("Location", AUTH_URL))
+                apiPeer.enqueue(MockResponse())
+
+                mtlsClient(identity, listOf(authPeer.serverRootCertificate), authPeer.proxy)
+                    .useTestClient { client ->
+                        client.newCall(tokenRequest()).execute().use { response ->
+                            assertThat(response.code).isEqualTo(307)
+                        }
+                    }
+                mtlsClient(identity, listOf(apiPeer.serverRootCertificate), apiPeer.proxy)
+                    .useTestClient { client ->
+                        client.newCall(apiRequest(ACCESS_TOKEN)).execute().use { response ->
+                            assertThat(response.code).isEqualTo(307)
+                        }
+                    }
+
+                assertThat(authPeer.server.requestCount).isEqualTo(2)
+                assertThat(apiPeer.server.requestCount).isEqualTo(2)
+                assertConnectAuthority(authPeer.takeRequest(), AUTH_AUTHORITY)
+                assertThat(authPeer.takeRequest().path).isEqualTo("/oauth/token")
+                assertConnectAuthority(apiPeer.takeRequest(), API_AUTHORITY)
+                assertThat(apiPeer.takeRequest().path).isEqualTo("/v1/files")
+            }
+        }
+    }
+
+    @Test
+    fun tlsPeerCannotImpersonateAnotherAuthority() {
+        val identity = X509TestIdentity.create("authority test identity")
+        X509TestPeer(AUTH_HOST, identity.root.certificate).use { authPeer ->
+            authPeer.enqueue(MockResponse())
+            val client =
+                mtlsClient(identity, listOf(authPeer.serverRootCertificate), authPeer.proxy)
+
+            client.useTestClient {
+                assertThatThrownBy {
+                        it.newCall(apiRequest(ACCESS_TOKEN)).execute().use { response ->
+                            response.body?.string()
+                        }
+                    }
+                    .isInstanceOf(SSLPeerUnverifiedException::class.java)
+            }
+            assertThat(authPeer.server.requestCount).isEqualTo(1)
+            assertConnectAuthority(authPeer.takeRequest(), API_AUTHORITY)
+            assertThat(authPeer.requestedServerNames).containsExactly(API_HOST)
+        }
+    }
+
+    private fun exchangeToken(client: OkHttpClient): String {
+        client.newCall(tokenRequest()).execute().use { response ->
+            assertThat(response.code).isEqualTo(200)
+            val body = jsonMapper.readTree(requireNotNull(response.body).string())
+            assertThat(body.path("issued_token_type").asText()).isEqualTo(ACCESS_TOKEN_TYPE)
+            assertThat(body.path("token_type").asText()).isEqualTo("Bearer")
+            assertThat(body.path("expires_in").asLong()).isEqualTo(3600)
+            return body.path("access_token").asText()
+        }
+    }
+
+    private fun callApi(client: OkHttpClient, accessToken: String) {
+        client.newCall(apiRequest(accessToken)).execute().use { response ->
+            assertThat(response.code).isEqualTo(200)
+        }
+    }
+
+    private fun mtlsClient(
+        identity: X509TestIdentity,
+        trustedServerRoots: Iterable<X509Certificate>,
+        proxy: Proxy,
+    ): OkHttpClient {
+        val handshakeCertificates = identity.clientHandshakeCertificates(trustedServerRoots)
+        return OkHttpClient.Builder()
+            .sslSocketFactory(
+                handshakeCertificates.sslSocketFactory(),
+                handshakeCertificates.trustManager,
+            )
+            .proxy(proxy)
+            .followRedirects(false)
+            .followSslRedirects(false)
+            .build()
+    }
+
+    private fun tokenRequest(): Request =
+        Request.Builder().url(AUTH_URL).post(TOKEN_REQUEST.toRequestBody(JSON_MEDIA_TYPE)).build()
+
+    private fun apiRequest(accessToken: String): Request =
+        Request.Builder()
+            .url("$API_URL/v1/files")
+            .header("Authorization", "Bearer $accessToken")
+            .get()
+            .build()
+
+    private fun assertConnectAuthority(request: RecordedRequest, authority: String) {
+        assertThat(request.requestLine).isEqualTo("CONNECT $authority HTTP/1.1")
+    }
+
+    private fun assertPresentedCertificate(request: RecordedRequest, expected: X509Certificate) {
+        assertThat(requireNotNull(request.handshake).peerCertificates).containsExactly(expected)
+    }
+
+    private companion object {
+        const val AUTH_HOST = "mtls.auth.openai.com"
+        const val API_HOST = "mtls.api.openai.com"
+        const val AUTH_AUTHORITY = "$AUTH_HOST:443"
+        const val API_AUTHORITY = "$API_HOST:443"
+        const val AUTH_URL = "https://$AUTH_HOST/oauth/token"
+        const val API_URL = "https://$API_HOST"
+        const val ACCESS_TOKEN = "test-x509-access-token"
+        const val ACCESS_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:access_token"
+        val TOKEN_REQUEST =
+            """
+            {
+              "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+              "subject_token_type": "urn:openai:params:oauth:token-type:x509",
+              "identity_provider_id": "idp_test",
+              "service_account_id": "svc_acct_test"
+            }
+            """
+                .trimIndent()
+        val TOKEN_RESPONSE =
+            """
+            {
+              "access_token": "$ACCESS_TOKEN",
+              "issued_token_type": "$ACCESS_TOKEN_TYPE",
+              "token_type": "Bearer",
+              "expires_in": 3600
+            }
+            """
+                .trimIndent()
+        val JSON_MEDIA_TYPE = "application/json".toMediaType()
+    }
+}


### PR DESCRIPTION
## Summary

- Add an executable, production-independent wire contract for global X.509 workload identity federation.
- Add loopback MockWebServer infrastructure that preserves production CONNECT authorities and TLS SNI while remaining offline.
- Exercise independent token-exchange and API client certificates, redirect refusal, and hostname verification.

This is PR 1 of the X.509 WIF stack. It deliberately establishes the externally observable protocol before introducing production transport or public API code.

## Contract established

- `POST https://mtls.auth.openai.com/oauth/token`
- JSON content type and exactly these request fields:
  - `grant_type`
  - `subject_token_type`
  - `identity_provider_id`
  - `service_account_id`
- No `subject_token` and no bearer credential on the exchange request
- Bearer credential plus an independently accepted client certificate on `mtls.api.openai.com`
- Representative bodyless API call uses documented mTLS-supported `GET /v1/files`
- Exchange and API client certificates may differ
- HTTP and HTTPS redirects are disabled on both legs
- Native hostname verification and exact CONNECT/SNI authorities remain active

## Non-goals

- No production implementation
- No public API
- No generated-source changes
- No EU/data-residency behavior
- No new dependency or build configuration

## Compatibility

Test-only change. No production behavior or public surface changes, and no generated custom-code budget increase.

## Validation

- `:openai-java-client-okhttp:cleanTest :openai-java-client-okhttp:test --no-build-cache`
  - `BUILD SUCCESSFUL`
  - X.509 contract: 3 tests, 0 failures, 0 errors, 0 skipped
- Exact repository Kotlin formatter dry run: clean
- `git diff --check`: clean
- Custom-code budget: 1,610 / 2,000; 390 lines headroom
- Three independent final-snapshot reviews: no remaining findings
- Two-pass independent review validation: no remaining findings
- Thermo-nuclear maintainability review: pass
- Final incremental Codex Security diff scan: complete coverage, zero findings

## Documentation alignment

- [X.509 workload identity federation guide](https://developers.openai.com/api/docs/guides/workload-identity-federation/x509)
- [OpenAI Mutual TLS Beta Program endpoint list](https://help.openai.com/en/articles/10876024-openai-mutual-tls-beta-program)
