### PR TITLE
fix: fail closed when protected X.509 verification cannot run

### DIFF
--- a/.github/workflows/x509-live-smoke.yml
+++ b/.github/workflows/x509-live-smoke.yml
@@ -119,7 +119,7 @@ jobs:
           if [[ "$missing_configuration" == true ]]; then
             echo '## X.509 live verification: NOT RUN' >> "$GITHUB_STEP_SUMMARY"
             echo 'Required protected-environment configuration was unavailable.' >> "$GITHUB_STEP_SUMMARY"
-            exit 0
+            exit 1
           fi
 
           ./gradlew :openai-java-client-okhttp:test \

--- a/docs/x509-live-verification.md
+++ b/docs/x509-live-verification.md
@@ -61,8 +61,8 @@ hard-coded HTTPS origins, both clients are direct and non-redirecting, and every
 
 ## Result meanings
 
-- **NOT RUN**: the dispatch input was false, or the protected job started but required enrolled
-  credentials were unavailable. This is not a pass.
+- **NOT RUN**: a disabled dispatch completes successfully without running the protected job. If a
+  requested protected run lacks required enrolled credentials, the job fails. Neither is a pass.
 - **REQUESTED**: the canonical `main` run passed the non-secret guard and awaits or entered the
   protected job. A deployment blocked or cancelled before environment approval remains requested
   and is not a pass; GitHub cannot run a later summary step while approval is pending.


### PR DESCRIPTION
## Summary

- Fail an explicitly requested protected X.509 verification when required protected configuration is unavailable, while preserving the existing fixed `NOT RUN` explanation.
- Clarify that disabled dispatches still complete successfully, while requested but unconfigured protected runs fail.
- Preserve environment approval, repository/main restrictions, least privilege, pinned actions, isolated Gradle state, and existing credential handling.

## Verification

- Executed the workflow's actual Bash steps with synthetic configuration: each missing required value and the all-missing case fail without invoking Gradle or disclosing configuration; configured and disabled runs retain their existing successful behavior.
- Parsed the workflow YAML and checked every embedded Bash script with `bash -n`.
- Ran `git diff --check` and completed two consecutive clean independent adversarial/security-review rounds.
