### PR TITLE
test(x509): verify live issuer through production token exchange

### DIFF
--- a/docs/x509-live-verification.md
+++ b/docs/x509-live-verification.md
@@ -2,14 +2,16 @@
 
 The Java SDK has two separate X.509 verification layers:
 
-- `X509TransportTest` runs in ordinary CI with an ephemeral PKI and real TLS. It verifies one fixed
-  certificate alias on the issuer and API legs, exact SNI and authorities, the token-exchange wire
-  shape, bearer placement, redirect refusal, hostname verification, server trust, and response
+- `X509TransportTest` runs in ordinary CI with an ephemeral PKI and real TLS. It verifies the
+  production `X509TokenExchange`, including issuer-provided token lifetimes above one hour, one
+  fixed certificate alias on the issuer and API legs, exact SNI and authorities, the token-exchange
+  wire shape, bearer placement, redirect refusal, hostname verification, server trust, and response
   cleanup.
 - `X509LiveVerificationTest` is an explicitly enabled production probe. It performs the exact
-  issuer exchange and then calls `GET https://mtls.api.openai.com/v1/models` with both the returned
-  bearer and the enrolled client certificate. It uses the existing raw transport capability, so it
-  remains useful before higher-level X.509 client integration lands.
+  issuer exchange through the production `X509TokenExchange` and then calls
+  `GET https://mtls.api.openai.com/v1/models` with both the returned bearer and the enrolled client
+  certificate. It uses the existing fixed-origin transport capability, so it remains useful before
+  higher-level X.509 client integration lands.
 
 Ordinary tests never use live credentials. A skipped live test is **not** production evidence.
 
@@ -66,8 +68,8 @@ hard-coded HTTPS origins, both clients are direct and non-redirecting, and every
 - **REQUESTED**: the canonical `main` run passed the non-secret guard and awaits or entered the
   protected job. A deployment blocked or cancelled before environment approval remains requested
   and is not a pass; GitHub cannot run a later summary step while approval is pending.
-- **PASSED**: exactly one enabled live test obtained a valid short-lived bearer from the issuer and
-  completed the approved mTLS model-list request. Only the protected job writes this result.
+- **PASSED**: exactly one enabled live test obtained a valid bearer from the issuer and completed
+  the approved mTLS model-list request. Only the protected job writes this result.
 - Any other conclusion is a failure or infrastructure interruption and must not be reported as
   production verification.
 
@@ -118,9 +120,10 @@ the enrolled client certificate is not end-to-end evidence.
 ## Safe teardown
 
 For a one-off fixture, first disable the exact provider subject mapping or its dedicated service
-account so that it cannot mint new bearers. Allow already issued credentials to expire within their
-one-hour maximum, or follow the environment owner's approved revocation procedure. Then remove the
-five secrets from `x509-live-smoke` and delete the environment if it has no continuing owner.
+account so that it cannot mint new bearers. Allow already issued credentials to expire according to
+their issuer-provided lifetimes, which may exceed one hour, or follow the environment owner's
+approved revocation procedure. Then remove the five secrets from `x509-live-smoke` and delete the
+environment if it has no continuing owner.
 
 Deactivate or remove the public trust root only after the environment owner confirms that no other
 mapping, SDK, or test fixture depends on it; never tear down a shared root as part of this runbook.

--- a/openai-java-client-okhttp/src/test/kotlin/com/openai/client/okhttp/X509LiveVerificationTest.kt
+++ b/openai-java-client-okhttp/src/test/kotlin/com/openai/client/okhttp/X509LiveVerificationTest.kt
@@ -1,15 +1,13 @@
 package com.openai.client.okhttp
 
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.json.JsonMapper
 import com.openai.core.Timeout
 import com.openai.core.http.Headers
 import com.openai.core.http.HttpMethod
 import com.openai.core.http.HttpRequest
-import com.openai.core.http.HttpRequestBody
 import com.openai.core.http.HttpResponse
+import com.openai.errors.UnexpectedStatusCodeException
 import java.io.ByteArrayInputStream
-import java.io.OutputStream
+import java.io.IOException
 import java.net.Socket
 import java.security.KeyStore
 import java.security.Principal
@@ -31,14 +29,12 @@ import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
 /**
  * Explicitly opt-in verification against the enrolled production issuer and mTLS API.
  *
- * This deliberately uses the raw, fixed-origin transport capability so the live gate remains useful
- * before higher-level X.509 client integration exists. It never logs response bodies, tokens,
- * certificate material, aliases, or enrollment identifiers.
+ * This uses the production token exchange over the fixed-origin transport capability so the live
+ * gate remains useful before higher-level X.509 client integration exists. It never logs response
+ * bodies, tokens, certificate material, aliases, or enrollment identifiers.
  */
 @EnabledIfEnvironmentVariable(named = "OPENAI_X509_LIVE_TEST", matches = "1")
 internal class X509LiveVerificationTest {
-    private val jsonMapper = JsonMapper()
-
     @Test
     fun enrolledCertificateCompletesIssuerAndApiLegs() {
         LiveConfiguration.fromEnvironment().use { configuration ->
@@ -68,7 +64,15 @@ internal class X509LiveVerificationTest {
                     .build()
 
             transport.bind(LIVE_TIMEOUT).use { bound ->
-                val accessToken = exchangeToken(bound.exchangeClient, configuration)
+                val accessToken =
+                    X509LiveDiagnostics.issuerExchange {
+                        X509TokenExchange(
+                                configuration.identityProviderId,
+                                configuration.serviceAccountId,
+                                bound.exchangeClient,
+                            )
+                            .use { exchange -> exchange.execute().value }
+                    }
                 recordingKeyManager.requireClientAliasSelection("issuer exchange")
                 verifyApi(bound.apiClient, accessToken)
                 recordingKeyManager.requireClientAliasSelection("mTLS API")
@@ -78,44 +82,10 @@ internal class X509LiveVerificationTest {
         println("X.509 live verification passed: issuer exchange and mTLS API request completed.")
     }
 
-    private fun exchangeToken(client: OkHttpClient, configuration: LiveConfiguration): String {
-        val exchange =
-            X509LiveRequests.exchange(
-                jsonMapper,
-                configuration.identityProviderId,
-                configuration.serviceAccountId,
-            )
-
-        return execute(client, exchange.request, "issuer exchange").use { response ->
-            requireSuccessful(response, "issuer exchange")
-            val body = readJson(response, "issuer exchange")
-            validateTokenResponse(body)
-        }
-    }
-
     private fun verifyApi(client: OkHttpClient, accessToken: String) {
         execute(client, X509LiveRequests.api(accessToken), "mTLS API").use { response ->
             requireSuccessful(response, "mTLS API")
         }
-    }
-
-    private fun validateTokenResponse(body: JsonNode): String {
-        check(body.isObject) { "The issuer exchange returned an invalid response shape." }
-        check(body.path("token_type").asText() == "Bearer") {
-            "The issuer exchange returned an unexpected token type."
-        }
-        check(body.path("issued_token_type").asText() == ACCESS_TOKEN_TYPE) {
-            "The issuer exchange returned an unexpected issued token type."
-        }
-        val expiresIn = body.path("expires_in")
-        check(expiresIn.isIntegralNumber && expiresIn.asLong() in 1..MAX_TOKEN_TTL_SECONDS) {
-            "The issuer exchange returned an invalid token lifetime."
-        }
-        val accessToken = body.path("access_token")
-        check(accessToken.isTextual && BEARER_TOKEN.matches(accessToken.asText())) {
-            "The issuer exchange returned an invalid bearer token."
-        }
-        return accessToken.asText()
     }
 
     private fun requireSuccessful(response: HttpResponse, stage: String) =
@@ -128,9 +98,6 @@ internal class X509LiveVerificationTest {
             throw IllegalStateException("$stage failed before receiving an HTTP response.")
         }
 
-    private fun readJson(response: HttpResponse, stage: String): JsonNode =
-        X509LiveDiagnostics.readJson(jsonMapper, response, stage)
-
     private fun defaultTrustManager(): X509TrustManager =
         TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())
             .apply { init(null as KeyStore?) }
@@ -140,9 +107,6 @@ internal class X509LiveVerificationTest {
             ?: error("The JVM default trust store did not provide an X.509 trust manager.")
 
     private companion object {
-        const val ACCESS_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:access_token"
-        const val MAX_TOKEN_TTL_SECONDS = 3600L
-        val BEARER_TOKEN = Regex("^[A-Za-z0-9\\-._~+/]+=*$")
         val LIVE_TIMEOUT =
             Timeout.builder()
                 .connect(Duration.ofSeconds(20))
@@ -154,32 +118,7 @@ internal class X509LiveVerificationTest {
 }
 
 internal object X509LiveRequests {
-    private const val EXCHANGE_URL = "https://mtls.auth.openai.com/oauth/token"
     private const val API_ORIGIN = "https://mtls.api.openai.com"
-    private const val TOKEN_EXCHANGE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:token-exchange"
-    private const val X509_SUBJECT_TOKEN_TYPE = "urn:openai:params:oauth:token-type:x509"
-
-    fun exchange(
-        jsonMapper: JsonMapper,
-        identityProviderId: String,
-        serviceAccountId: String,
-    ): X509LiveExchangeRequest {
-        val body =
-            ZeroizingJsonBody(
-                jsonMapper.writeValueAsBytes(
-                    linkedMapOf(
-                        "grant_type" to TOKEN_EXCHANGE_GRANT_TYPE,
-                        "subject_token_type" to X509_SUBJECT_TOKEN_TYPE,
-                        "identity_provider_id" to identityProviderId,
-                        "service_account_id" to serviceAccountId,
-                    )
-                )
-            )
-        return X509LiveExchangeRequest(
-            HttpRequest.builder().method(HttpMethod.POST).baseUrl(EXCHANGE_URL).body(body).build(),
-            body,
-        )
-    }
 
     fun api(accessToken: String): HttpRequest =
         HttpRequest.builder()
@@ -189,8 +128,6 @@ internal object X509LiveRequests {
             .putHeader("Authorization", "Bearer $accessToken")
             .build()
 }
-
-internal data class X509LiveExchangeRequest(val request: HttpRequest, val body: ZeroizingJsonBody)
 
 internal class HandshakeRecordingKeyManager(
     private val delegate: X509ExtendedKeyManager,
@@ -247,19 +184,20 @@ internal class HandshakeRecordingKeyManager(
 internal object X509LiveDiagnostics {
     private val safeRequestId = Regex("^[A-Za-z0-9._:-]{1,128}$")
 
+    fun <T> issuerExchange(action: () -> T): T =
+        try {
+            action()
+        } catch (error: UnexpectedStatusCodeException) {
+            throw IllegalStateException("issuer exchange failed with HTTP ${error.statusCode()}.")
+        } catch (_: Exception) {
+            throw IllegalStateException("issuer exchange failed before receiving a valid response.")
+        }
+
     fun requireSuccessful(response: HttpResponse, stage: String) {
         check(response.statusCode() in 200..299) {
             "$stage failed with HTTP ${response.statusCode()}${requestIdSuffix(response)}."
         }
     }
-
-    fun readJson(jsonMapper: JsonMapper, response: HttpResponse, stage: String): JsonNode =
-        try {
-            jsonMapper.readTree(response.body())
-                ?: throw IllegalStateException("$stage returned an empty JSON response.")
-        } catch (_: Exception) {
-            throw IllegalStateException("$stage returned invalid JSON${requestIdSuffix(response)}.")
-        }
 
     private fun requestIdSuffix(response: HttpResponse): String =
         response
@@ -271,6 +209,36 @@ internal object X509LiveDiagnostics {
 }
 
 internal class X509LiveVerificationDiagnosticsTest {
+    @Test
+    fun issuerExchangeFailuresNeverIncludeUnderlyingCauses() {
+        assertThatThrownBy {
+                X509LiveDiagnostics.issuerExchange {
+                    throw IOException("customer-data enrollment-id secret-token")
+                }
+            }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessage("issuer exchange failed before receiving a valid response.")
+            .hasNoCause()
+            .hasMessageNotContaining("customer-data")
+            .hasMessageNotContaining("enrollment-id")
+            .hasMessageNotContaining("secret-token")
+
+        val statusFailure =
+            UnexpectedStatusCodeException.builder()
+                .statusCode(403)
+                .headers(Headers.builder().put("x-request-id", "sensitive enrollment-id").build())
+                .cause(IOException("customer-data secret-token"))
+                .build()
+
+        assertThatThrownBy { X509LiveDiagnostics.issuerExchange { throw statusFailure } }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessage("issuer exchange failed with HTTP 403.")
+            .hasNoCause()
+            .hasMessageNotContaining("customer-data")
+            .hasMessageNotContaining("enrollment-id")
+            .hasMessageNotContaining("secret-token")
+    }
+
     @Test
     fun diagnosticsIncludeOnlySanitizedRequestIds() {
         val safeResponse = StubLiveResponse(403, "req_123-abc:456", "unused")
@@ -285,22 +253,6 @@ internal class X509LiveVerificationDiagnosticsTest {
             .hasMessage("mTLS API failed with HTTP 403.")
             .hasMessageNotContaining("sensitive")
             .hasMessageNotContaining("customer-data")
-    }
-
-    @Test
-    fun invalidIssuerBodiesAreNeverIncludedInDiagnostics() {
-        val response =
-            StubLiveResponse(200, "request id containing sensitive text", "customer-data")
-
-        response.use {
-            assertThatThrownBy {
-                    X509LiveDiagnostics.readJson(JsonMapper(), response, "issuer exchange")
-                }
-                .isInstanceOf(IllegalStateException::class.java)
-                .hasMessage("issuer exchange returned invalid JSON.")
-                .hasMessageNotContaining("sensitive")
-                .hasMessageNotContaining("customer-data")
-        }
     }
 }
 
@@ -357,25 +309,5 @@ private constructor(
             requiredEnvironment(name).also {
                 check(it.isNotBlank()) { "$name must not be blank for X.509 live verification." }
             }
-    }
-}
-
-internal class ZeroizingJsonBody(private val bytes: ByteArray) : HttpRequestBody {
-    private val contentLength = bytes.size.toLong()
-
-    var closed = false
-        private set
-
-    override fun writeTo(outputStream: OutputStream) = outputStream.write(bytes)
-
-    override fun contentType(): String = "application/json"
-
-    override fun contentLength(): Long = contentLength
-
-    override fun repeatable(): Boolean = false
-
-    override fun close() {
-        Arrays.fill(bytes, 0)
-        closed = true
     }
 }

--- a/openai-java-client-okhttp/src/test/kotlin/com/openai/client/okhttp/X509LiveVerificationTest.kt
+++ b/openai-java-client-okhttp/src/test/kotlin/com/openai/client/okhttp/X509LiveVerificationTest.kt
@@ -1,7 +1,9 @@
 package com.openai.client.okhttp
 
+import com.openai.core.RequestOptions
 import com.openai.core.Timeout
 import com.openai.core.http.Headers
+import com.openai.core.http.HttpClient
 import com.openai.core.http.HttpMethod
 import com.openai.core.http.HttpRequest
 import com.openai.core.http.HttpResponse
@@ -16,6 +18,7 @@ import java.security.cert.X509Certificate
 import java.time.Duration
 import java.util.Arrays
 import java.util.Base64
+import java.util.concurrent.CompletableFuture
 import java.util.concurrent.atomic.AtomicBoolean
 import javax.net.ssl.KeyManagerFactory
 import javax.net.ssl.SSLEngine
@@ -65,11 +68,11 @@ internal class X509LiveVerificationTest {
 
             transport.bind(LIVE_TIMEOUT).use { bound ->
                 val accessToken =
-                    X509LiveDiagnostics.issuerExchange {
+                    X509LiveDiagnostics.issuerExchange(bound.exchangeClient) { issuerClient ->
                         X509TokenExchange(
                                 configuration.identityProviderId,
                                 configuration.serviceAccountId,
-                                bound.exchangeClient,
+                                issuerClient,
                             )
                             .use { exchange -> exchange.execute().value }
                     }
@@ -184,11 +187,30 @@ internal class HandshakeRecordingKeyManager(
 internal object X509LiveDiagnostics {
     private val safeRequestId = Regex("^[A-Za-z0-9._:-]{1,128}$")
 
-    fun <T> issuerExchange(action: () -> T): T =
+    fun <T> issuerExchange(client: HttpClient, action: (HttpClient) -> T): T {
+        var requestId: String? = null
+        val capturingClient =
+            object : HttpClient by client {
+                override fun execute(request: HttpRequest): HttpResponse =
+                    client.execute(request).also { response ->
+                        requestId =
+                            response.requestId().orElse(null)?.takeIf(safeRequestId::matches)
+                    }
+            }
+
+        return issuerExchange({ requestId }) { action(capturingClient) }
+    }
+
+    fun <T> issuerExchange(action: () -> T): T = issuerExchange({ null }, action)
+
+    private fun <T> issuerExchange(requestId: () -> String?, action: () -> T): T =
         try {
             action()
         } catch (error: UnexpectedStatusCodeException) {
-            throw IllegalStateException("issuer exchange failed with HTTP ${error.statusCode()}.")
+            val requestIdSuffix = requestId()?.let { " (request_id=$it)" }.orEmpty()
+            throw IllegalStateException(
+                "issuer exchange failed with HTTP ${error.statusCode()}$requestIdSuffix."
+            )
         } catch (_: Exception) {
             throw IllegalStateException("issuer exchange failed before receiving a valid response.")
         }
@@ -209,6 +231,43 @@ internal object X509LiveDiagnostics {
 }
 
 internal class X509LiveVerificationDiagnosticsTest {
+    @Test
+    fun issuerFailuresPreserveOnlySafeRequestIdsFromProductionExchange() {
+        mapOf(
+                "req_123-abc:456" to " (request_id=req_123-abc:456)",
+                "request id containing sensitive text" to "",
+                "x".repeat(129) to "",
+            )
+            .forEach { (requestId, expectedSuffix) ->
+                val response =
+                    StubLiveResponse(
+                        403,
+                        requestId,
+                        """{"error":"invalid_grant","error_description":"customer-data"}""",
+                        mapOf(
+                            "Authorization" to "Bearer secret-token",
+                            "X-Customer" to "customer-data",
+                        ),
+                    )
+                val client = StubLiveClient(response)
+
+                assertThatThrownBy {
+                        X509LiveDiagnostics.issuerExchange(client) { issuerClient ->
+                            X509TokenExchange("idp_test", "svc_acct_test", issuerClient).use {
+                                exchange ->
+                                exchange.execute()
+                            }
+                        }
+                    }
+                    .isInstanceOf(IllegalStateException::class.java)
+                    .hasMessage("issuer exchange failed with HTTP 403$expectedSuffix.")
+                    .hasNoCause()
+                    .hasMessageNotContaining("sensitive")
+                    .hasMessageNotContaining("customer-data")
+                    .hasMessageNotContaining("secret-token")
+            }
+    }
+
     @Test
     fun issuerExchangeFailuresNeverIncludeUnderlyingCauses() {
         assertThatThrownBy {
@@ -256,9 +315,18 @@ internal class X509LiveVerificationDiagnosticsTest {
     }
 }
 
-private class StubLiveResponse(statusCode: Int, requestId: String, body: String) : HttpResponse {
+private class StubLiveResponse(
+    statusCode: Int,
+    requestId: String,
+    body: String,
+    additionalHeaders: Map<String, String> = emptyMap(),
+) : HttpResponse {
     private val statusCode = statusCode
-    private val headers = Headers.builder().put("x-request-id", requestId).build()
+    private val headers =
+        Headers.builder()
+            .put("x-request-id", requestId)
+            .apply { additionalHeaders.forEach { (name, value) -> put(name, value) } }
+            .build()
     private val body = ByteArrayInputStream(body.toByteArray(Charsets.UTF_8))
 
     override fun statusCode(): Int = statusCode
@@ -268,6 +336,18 @@ private class StubLiveResponse(statusCode: Int, requestId: String, body: String)
     override fun body(): ByteArrayInputStream = body
 
     override fun close() = body.close()
+}
+
+private class StubLiveClient(private val response: HttpResponse) : HttpClient {
+    override fun execute(request: HttpRequest, requestOptions: RequestOptions): HttpResponse =
+        response
+
+    override fun executeAsync(
+        request: HttpRequest,
+        requestOptions: RequestOptions,
+    ): CompletableFuture<HttpResponse> = CompletableFuture.completedFuture(response)
+
+    override fun close() = Unit
 }
 
 private class LiveConfiguration

--- a/openai-java-client-okhttp/src/test/kotlin/com/openai/client/okhttp/X509LiveVerificationTest.kt
+++ b/openai-java-client-okhttp/src/test/kotlin/com/openai/client/okhttp/X509LiveVerificationTest.kt
@@ -212,7 +212,10 @@ internal object X509LiveDiagnostics {
                 "issuer exchange failed with HTTP ${error.statusCode()}$requestIdSuffix."
             )
         } catch (_: Exception) {
-            throw IllegalStateException("issuer exchange failed before receiving a valid response.")
+            val requestIdSuffix = requestId()?.let { " (request_id=$it)" }.orEmpty()
+            throw IllegalStateException(
+                "issuer exchange failed before receiving a valid response$requestIdSuffix."
+            )
         }
 
     fun requireSuccessful(response: HttpResponse, stage: String) {
@@ -231,6 +234,42 @@ internal object X509LiveDiagnostics {
 }
 
 internal class X509LiveVerificationDiagnosticsTest {
+    @Test
+    fun malformedIssuerResponsesPreserveOnlySafeRequestIdsFromProductionExchange() {
+        mapOf(
+                "req_123-abc:456" to " (request_id=req_123-abc:456)",
+                "request id containing sensitive text" to "",
+                "x".repeat(129) to "",
+            )
+            .forEach { (requestId, expectedSuffix) ->
+                val response =
+                    StubLiveResponse(
+                        200,
+                        requestId,
+                        "customer-data secret-token",
+                        mapOf("Authorization" to "Bearer secret-token"),
+                    )
+                val client = StubLiveClient(response)
+
+                assertThatThrownBy {
+                        X509LiveDiagnostics.issuerExchange(client) { issuerClient ->
+                            X509TokenExchange("idp_test", "svc_acct_test", issuerClient).use {
+                                exchange ->
+                                exchange.execute()
+                            }
+                        }
+                    }
+                    .isInstanceOf(IllegalStateException::class.java)
+                    .hasMessage(
+                        "issuer exchange failed before receiving a valid response$expectedSuffix."
+                    )
+                    .hasNoCause()
+                    .hasMessageNotContaining("sensitive")
+                    .hasMessageNotContaining("customer-data")
+                    .hasMessageNotContaining("secret-token")
+            }
+    }
+
     @Test
     fun issuerFailuresPreserveOnlySafeRequestIdsFromProductionExchange() {
         mapOf(

--- a/openai-java-client-okhttp/src/test/kotlin/com/openai/client/okhttp/X509TransportTest.kt
+++ b/openai-java-client-okhttp/src/test/kotlin/com/openai/client/okhttp/X509TransportTest.kt
@@ -1,6 +1,5 @@
 package com.openai.client.okhttp
 
-import com.fasterxml.jackson.databind.json.JsonMapper
 import com.openai.core.Timeout
 import com.openai.core.http.HttpMethod
 import com.openai.core.http.HttpRequest
@@ -10,6 +9,7 @@ import java.security.KeyStore
 import java.security.Principal
 import java.security.PrivateKey
 import java.security.cert.X509Certificate
+import java.time.Duration
 import java.util.concurrent.CompletionException
 import javax.net.ssl.KeyManagerFactory
 import javax.net.ssl.SSLEngine
@@ -22,8 +22,6 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 
 internal class X509TransportTest {
-    private val jsonMapper = JsonMapper()
-
     @Test
     fun productionBindingIsDirectNonRetryingAndIsolated() {
         val pinned = X509TestIdentity.create("production binding identity")
@@ -82,19 +80,18 @@ internal class X509TransportTest {
                         recordingKeyManager,
                         listOf(authPeer.serverRootCertificate, apiPeer.serverRootCertificate),
                     )
-                val exchange = X509LiveRequests.exchange(jsonMapper, "idp_test", "svc_acct_test")
-
                 transport.bindForTest(Timeout.default(), authPeer.proxy, apiPeer.proxy).use { bound
                     ->
-                    val accessToken =
-                        bound.exchangeClient.execute(exchange.request).use { response ->
-                            assertThat(response.statusCode()).isEqualTo(200)
-                            jsonMapper.readTree(response.body()).path("access_token").asText()
+                    val token =
+                        X509TokenExchange("idp_test", "svc_acct_test", bound.exchangeClient).use {
+                            exchange ->
+                            exchange.execute()
                         }
+                    assertThat(token.expiresIn).isEqualTo(Duration.ofDays(1))
                     recordingKeyManager.requireClientAliasSelection("issuer exchange")
                     // Closing one path must not drain the other path's pool or dispatcher.
                     bound.exchangeClient.close()
-                    bound.apiClient.execute(X509LiveRequests.api(accessToken)).use { response ->
+                    bound.apiClient.execute(X509LiveRequests.api(token.value)).use { response ->
                         assertThat(response.statusCode()).isEqualTo(200)
                     }
                     recordingKeyManager.requireClientAliasSelection("mTLS API")
@@ -126,7 +123,6 @@ internal class X509TransportTest {
                     .doesNotContain(alternate.leaf.certificate)
                 assertThat(authPeer.requestedServerNames).containsExactly(AUTH_HOST)
                 assertThat(apiPeer.requestedServerNames).containsExactly(API_HOST)
-                assertThat(exchange.body.closed).isTrue()
             }
         }
     }
@@ -398,7 +394,7 @@ internal class X509TransportTest {
               "access_token": "$ACCESS_TOKEN",
               "issued_token_type": "urn:ietf:params:oauth:token-type:access_token",
               "token_type": "Bearer",
-              "expires_in": 3600
+              "expires_in": 86400
             }
             """
                 .trimIndent()


### PR DESCRIPTION
## Summary

- Run the protected live issuer leg through the production `X509TokenExchange` over the existing fixed-alias `X509Transport`, then preserve the real authenticated mTLS API request.
- Remove the duplicate live-only issuer request builder and response parser, including its incorrect one-hour token lifetime limit.
- Exercise the same production exchange over offline real TLS with a valid 24-hour token and preserve issuer-failure redaction, certificate-alias checks, pinned authorities, response cleanup, and live opt-in behavior.
- Update the verification runbook to describe production validation and issuer-provided token lifetimes during teardown.

## Scope

Only the live verification test, its directly related transport regression, and the verification runbook are changed. Production APIs, transport destination policy, the protected workflow, and other X.509 work are unchanged.

## Verification

```sh
./gradlew -Dorg.gradle.java.home=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home \
  :openai-java-client-okhttp:test \
  --tests '*X509TransportTest' \
  --tests '*X509TokenExchangeTest' \
  --tests '*X509LiveVerificationDiagnosticsTest' \
  --tests '*X509LiveVerificationTest' \
  --tests '*X509WorkloadIdentityWireContractTest' \
  :openai-java-client-okhttp:lintKotlin
```

- 37 offline tests passed; the explicitly opt-in live test was skipped without credentials.
- Two consecutive fresh-context, two-reviewer adversarial/security review rounds found no remaining in-scope blockers.

The protected production smoke requires its existing independently approved environment and was not run locally.
