### PR TITLE
fix(ci): preserve release source in Maven provenance

### DIFF
--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -366,6 +366,7 @@ jobs:
             --arg repository_id "$GITHUB_REPOSITORY_ID" \
             --arg repository_owner_id "$GITHUB_REPOSITORY_OWNER_ID" \
             --arg runner_environment "$RUNNER_ENVIRONMENT" \
+            --arg workflow_sha "$GITHUB_SHA" \
             --arg source_sha "$SOURCE_SHA" \
             --arg release_tag "$RELEASE_TAG" \
             --arg invocation_id \
@@ -389,6 +390,10 @@ jobs:
                   }
                 },
                 resolvedDependencies: [
+                  {
+                    uri: ("git+" + $repository + "@" + $workflow_ref),
+                    digest: { gitCommit: $workflow_sha }
+                  },
                   {
                     uri: ("git+" + $repository + "@refs/tags/" + $release_tag),
                     digest: { gitCommit: $source_sha }

--- a/buildSrc/src/test/kotlin/com/openai/gradle/GradleCacheTrustPolicyTest.kt
+++ b/buildSrc/src/test/kotlin/com/openai/gradle/GradleCacheTrustPolicyTest.kt
@@ -372,7 +372,7 @@ class GradleCacheTrustPolicyTest {
     }
 
     @Test
-    fun `retry provenance resolves the checked out historical tag not the newer workflow SHA`() {
+    fun `retry provenance records historical release source beside canonical workflow source`() {
         val workflow = Path.of("../.github/workflows/create-releases.yml").readText()
         val parsedWorkflow = parseWorkflow(workflow)
         val preparation =
@@ -469,14 +469,23 @@ class GradleCacheTrustPolicyTest {
         val workflowSource = external["workflow"] as Map<*, *>
         assertEquals("refs/heads/main", workflowSource["ref"])
         assertEquals(".github/workflows/create-releases.yml", workflowSource["path"])
-        val dependency = (definition["resolvedDependencies"] as List<*>).single() as Map<*, *>
+        val dependencies = definition["resolvedDependencies"] as List<*>
+        assertEquals(2, dependencies.size)
+        val workflowDependency = dependencies[0] as Map<*, *>
+        assertEquals(
+            "git+https://github.com/openai/openai-java@refs/heads/main",
+            workflowDependency["uri"],
+        )
+        val workflowDigest = workflowDependency["digest"] as Map<*, *>
+        assertEquals(workflowSha, workflowDigest["gitCommit"])
+        val releaseDependency = dependencies[1] as Map<*, *>
         assertEquals(
             "git+https://github.com/openai/openai-java@refs/tags/v1.2.3",
-            dependency["uri"],
+            releaseDependency["uri"],
         )
-        val digest = dependency["digest"] as Map<*, *>
-        assertEquals(sourceSha, digest["gitCommit"])
-        assertTrue(digest["gitCommit"] != workflowSha)
+        val releaseDigest = releaseDependency["digest"] as Map<*, *>
+        assertEquals(sourceSha, releaseDigest["gitCommit"])
+        assertTrue(releaseDigest["gitCommit"] != workflowSha)
         val details = predicate["runDetails"] as Map<*, *>
         val builder = details["builder"] as Map<*, *>
         assertEquals(
@@ -964,8 +973,11 @@ class GradleCacheTrustPolicyTest {
             preparation.environment.getValue("SOURCE_SHA"),
         )
         assertContains(preparationScript, "\"\$SOURCE_SHA\" != \"\$(git rev-parse HEAD)\"")
+        assertContains(preparationScript, "--arg workflow_sha \"\$GITHUB_SHA\"")
         assertContains(preparationScript, "--arg source_sha \"\$SOURCE_SHA\"")
         assertContains(preparationScript, "--arg workflow_ref \"\$GITHUB_REF\"")
+        assertContains(preparationScript, "uri: (\"git+\" + \$repository + \"@\" + \$workflow_ref)")
+        assertContains(preparationScript, "digest: { gitCommit: \$workflow_sha }")
         assertContains(
             preparationScript,
             "uri: (\"git+\" + \$repository + \"@refs/tags/\" + \$release_tag)",


### PR DESCRIPTION
## Summary
- keep the OIDC-authenticated workflow ref and SHA as the canonical first SLSA dependency so GitHub can persist Maven attestations
- retain the verified release tag and checked-out release commit as a second resolved dependency, including historical manual retries
- update workflow-policy coverage for both provenance identities

## Verification
- env JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home GRADLE_USER_HOME=/tmp/openai-java-gradle-950 ./gradlew :buildSrc:test
- env JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home GRADLE_USER_HOME=/tmp/openai-java-gradle-950 ./gradlew lintKotlin
- git diff --check

Fixes #950