### PR TITLE
fix(ci): reduce Maven publish runner pressure

### DIFF
--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -292,6 +292,9 @@ jobs:
       - name: Compile the openai-java-core project
         run: ./gradlew :openai-java-core:compileJava :openai-java-core:compileTestJava -x test
 
+      - name: Stop pre-GraalVM Gradle daemon
+        run: ./gradlew --stop
+
       - name: Run the mock server
         run: ./scripts/mock --daemon
 
@@ -462,6 +465,7 @@ jobs:
           ./gradlew publishAndReleaseToMavenCentral \
             "${publish_exclusions[@]}" \
             --stacktrace \
+            --no-parallel \
             --no-configuration-cache
 
       - name: Verify attested Maven artifacts

--- a/buildSrc/src/test/kotlin/com/openai/gradle/GradleCacheTrustPolicyTest.kt
+++ b/buildSrc/src/test/kotlin/com/openai/gradle/GradleCacheTrustPolicyTest.kt
@@ -228,6 +228,27 @@ class GradleCacheTrustPolicyTest {
     }
 
     @Test
+    fun `publishing releases obsolete daemons and serializes documentation generation`() {
+        val workflow = Path.of("../.github/workflows/create-releases.yml").readText()
+        assertPublishingRunnerStabilityPolicy(workflow)
+
+        listOf(
+                workflow.replaceFirst(
+                    "      - name: Stop pre-GraalVM Gradle daemon\n" +
+                        "        run: ./gradlew --stop\n\n",
+                    "",
+                ),
+                workflow.replaceFirst("            --no-parallel \\\n", ""),
+            )
+            .forEach { poisonedWorkflow ->
+                assertTrue(poisonedWorkflow != workflow)
+                assertFailsWith<AssertionError> {
+                    assertPublishingRunnerStabilityPolicy(poisonedWorkflow)
+                }
+            }
+    }
+
+    @Test
     fun `publishing attests every released artifact before exposing signing secrets`() {
         val workflow = Path.of("../.github/workflows/create-releases.yml").readText()
         assertPublishingProvenancePolicy(workflow)
@@ -933,6 +954,33 @@ class GradleCacheTrustPolicyTest {
         )
 
         assertPublishingProvenancePolicy(workflow)
+    }
+
+    private fun assertPublishingRunnerStabilityPolicy(workflow: String) {
+        val publishSteps = parseWorkflow(workflow).job("publish").steps
+        val compilation =
+            publishSteps.indexOfFirst { it.name == "Compile the openai-java-core project" }
+        val daemonStop = publishSteps.indexOfFirst { it.name == "Stop pre-GraalVM Gradle daemon" }
+        val graalVm = publishSteps.indexOfFirst { it.name == "Set up GraalVM" }
+
+        assertTrue(
+            compilation >= 0 && daemonStop > compilation && graalVm > daemonStop,
+            "Stop the build-JDK Gradle daemon before switching to GraalVM.",
+        )
+        assertEquals("./gradlew --stop", publishSteps[daemonStop].run)
+
+        val publication =
+            requireNotNull(publishSteps.single { it.name == "Publish to Maven Central" }.run)
+        val serializedInvocation =
+            "./gradlew publishAndReleaseToMavenCentral \\\n" +
+                "  \"\${publish_exclusions[@]}\" \\\n" +
+                "  --stacktrace \\\n" +
+                "  --no-parallel \\\n" +
+                "  --no-configuration-cache"
+        assertTrue(
+            publication.contains(serializedInvocation),
+            "Serialize Dokka publication tasks to keep the standard runner within memory limits.",
+        )
     }
 
     private fun assertPublishingProvenancePolicy(workflow: String) {


### PR DESCRIPTION
## Summary
- stop the pre-GraalVM Gradle daemon before switching JVMs in the Maven publish job
- serialize only the final publish graph so concurrent Dokka tasks do not exhaust the standard runner
- add policy coverage that locks both stability controls to their intended workflow positions

## Context
Follow-up to #951. The provenance fix is working, but three guarded v4.53.0 recovery attempts were canceled during the cold Gradle/Dokka publication phase. Logs show the first Gradle daemon remains alive after the JVM switch and multiple Dokka tasks start concurrently during publication.

## Verification
- JAVA_HOME=/opt/homebrew/Cellar/openjdk@21/21.0.12/libexec/openjdk.jdk/Contents/Home GRADLE_USER_HOME=/tmp/openai-java-gradle-950 ./gradlew :buildSrc:test lintKotlin --no-daemon
- git diff --check
- security diff review: clean
- adversarial review: round 1 found and fixed a test-coverage gap; rounds 2 and 3 clean

## Security
- preserves the fresh private release Gradle User Home and cache-disabled setup
- preserves tag/source verification, provenance attestation, digest continuity, SHA-pinned actions, and publish-step-only signing secrets
- adds no permissions, actions, cache restore, artifact handoff, or runner dependency