### PR TITLE
fix: preserve response input message roundtrips

### DIFF
--- a/openai-java-core/src/main/kotlin/com/openai/models/responses/EasyInputMessage.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/models/responses/EasyInputMessage.kt
@@ -150,7 +150,7 @@ private constructor(
         private var content: JsonField<Content>? = null
         private var role: JsonField<Role>? = null
         private var phase: JsonField<Phase> = JsonMissing.of()
-        private var type: JsonField<Type> = JsonMissing.of()
+        private var type: JsonField<Type> = JsonField.of(Type.MESSAGE)
         private var additionalProperties: MutableMap<String, JsonValue> = mutableMapOf()
 
         @JvmSynthetic

--- a/openai-java-core/src/main/kotlin/com/openai/models/responses/ResponseInputItem.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/models/responses/ResponseInputItem.kt
@@ -1218,18 +1218,33 @@ private constructor(
 
         override fun ObjectCodec.deserialize(node: JsonNode): ResponseInputItem {
             val json = JsonValue.fromJsonNode(node)
-            val type = json.asObject().getOrNull()?.get("type")?.asString()?.getOrNull()
+            val jsonObject = json.asObject().getOrNull()
+            val type = jsonObject?.get("type")?.asString()?.getOrNull()
 
             when (type) {
                 "message" -> {
+                    val role = jsonObject?.get("role")?.asString()?.getOrNull()
+                    val hasPhase = jsonObject?.containsKey("phase") == true
+                    val hasStructuredContent =
+                        jsonObject?.get("content")?.asArray()?.getOrNull() != null
+                    val isMessageRole = role == "user" || role == "system" || role == "developer"
+                    // These variants share a discriminator and become wire-identical in this
+                    // shape. Prefer the narrower Message; string content, assistant roles, and
+                    // phase-bearing messages remain EasyInputMessage.
+                    val preferMessage = hasStructuredContent && isMessageRole && !hasPhase
+                    val messageMatch =
+                        tryDeserialize(node, jacksonTypeRef<Message>())?.let {
+                            ResponseInputItem(message = it, _json = json)
+                        }
+                    val easyInputMessageMatch =
+                        tryDeserialize(node, jacksonTypeRef<EasyInputMessage>())?.let {
+                            ResponseInputItem(easyInputMessage = it, _json = json)
+                        }
+
                     val bestMatches =
                         sequenceOf(
-                                tryDeserialize(node, jacksonTypeRef<EasyInputMessage>())?.let {
-                                    ResponseInputItem(easyInputMessage = it, _json = json)
-                                },
-                                tryDeserialize(node, jacksonTypeRef<Message>())?.let {
-                                    ResponseInputItem(message = it, _json = json)
-                                },
+                                if (preferMessage) messageMatch else easyInputMessageMatch,
+                                if (preferMessage) easyInputMessageMatch else messageMatch,
                                 tryDeserialize(node, jacksonTypeRef<ResponseOutputMessage>())?.let {
                                     ResponseInputItem(responseOutputMessage = it, _json = json)
                                 },
@@ -1572,7 +1587,7 @@ private constructor(
             private var content: JsonField<MutableList<ResponseInputContent>>? = null
             private var role: JsonField<Role>? = null
             private var status: JsonField<Status> = JsonMissing.of()
-            private var type: JsonField<Type> = JsonMissing.of()
+            private var type: JsonField<Type> = JsonField.of(Type.MESSAGE)
             private var additionalProperties: MutableMap<String, JsonValue> = mutableMapOf()
 
             @JvmSynthetic

--- a/openai-java-core/src/test/kotlin/com/openai/models/responses/ResponseInputItemTest.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/models/responses/ResponseInputItemTest.kt
@@ -83,6 +83,26 @@ internal class ResponseInputItemTest {
     }
 
     @Test
+    fun ofEasyInputMessageRoundtripWithoutExplicitType() {
+        val jsonMapper = jsonMapper()
+        val responseInputItem =
+            ResponseInputItem.ofEasyInputMessage(
+                EasyInputMessage.builder()
+                    .content("string")
+                    .role(EasyInputMessage.Role.USER)
+                    .build()
+            )
+
+        val roundtrippedResponseInputItem =
+            jsonMapper.readValue(
+                jsonMapper.writeValueAsString(responseInputItem),
+                jacksonTypeRef<ResponseInputItem>(),
+            )
+
+        assertThat(roundtrippedResponseInputItem).isEqualTo(responseInputItem)
+    }
+
+    @Test
     fun ofMessage() {
         val message =
             ResponseInputItem.Message.builder()
@@ -162,6 +182,78 @@ internal class ResponseInputItemTest {
             )
 
         assertThat(roundtrippedResponseInputItem).isEqualTo(responseInputItem)
+    }
+
+    @Test
+    fun ofMessageRoundtripWithoutExplicitType() {
+        val jsonMapper = jsonMapper()
+        val responseInputItem =
+            ResponseInputItem.ofMessage(
+                ResponseInputItem.Message.builder()
+                    .addInputTextContent("Test")
+                    .role(ResponseInputItem.Message.Role.USER)
+                    .build()
+            )
+
+        val roundtrippedResponseInputItem =
+            jsonMapper.readValue(
+                jsonMapper.writeValueAsString(responseInputItem),
+                jacksonTypeRef<ResponseInputItem>(),
+            )
+
+        assertThat(roundtrippedResponseInputItem).isEqualTo(responseInputItem)
+    }
+
+    @Test
+    fun ofStructuredAssistantEasyInputMessageRoundtripWithoutPhase() {
+        val jsonMapper = jsonMapper()
+        val responseInputItem =
+            ResponseInputItem.ofEasyInputMessage(
+                EasyInputMessage.builder()
+                    .contentOfResponseInputMessageContentList(
+                        listOf(
+                            ResponseInputContent.ofInputText(
+                                ResponseInputText.builder().text("text").build()
+                            )
+                        )
+                    )
+                    .role(EasyInputMessage.Role.ASSISTANT)
+                    .type(EasyInputMessage.Type.MESSAGE)
+                    .build()
+            )
+
+        val roundtrippedResponseInputItem =
+            jsonMapper.readValue(
+                jsonMapper.writeValueAsString(responseInputItem),
+                jacksonTypeRef<ResponseInputItem>(),
+            )
+
+        assertThat(roundtrippedResponseInputItem).isEqualTo(responseInputItem)
+    }
+
+    @Test
+    fun deserializesStructuredNonAssistantMessagePayloadAsMessage() {
+        val jsonMapper = jsonMapper()
+        val responseInputItem =
+            jsonMapper.readValue(
+                """
+                {
+                  "type": "message",
+                  "role": "user",
+                  "content": [
+                    {
+                      "type": "input_text",
+                      "text": "text"
+                    }
+                  ]
+                }
+                """
+                    .trimIndent(),
+                jacksonTypeRef<ResponseInputItem>(),
+            )
+
+        assertThat(responseInputItem.message()).isPresent
+        assertThat(responseInputItem.easyInputMessage()).isEmpty
     }
 
     @Test


### PR DESCRIPTION
Closes #584.

`ResponseInputItem.Message.Builder` left its documented constant `type` unset, so serializing a user-built message omitted the union discriminator and deserializing it produced `_unknown`. `EasyInputMessage.Builder` had the same missing default.

This change:

- defaults both message builders to `type: "message"`
- makes structured, non-assistant message JSON without `phase` deserialize to the narrower `ResponseInputItem.Message` variant
- preserves `EasyInputMessage` preference for string content, assistant roles, phase-bearing messages, missing roles, and unknown/future roles
- adds roundtrip and discriminator-boundary coverage

The tie-break is necessary because a structured `EasyInputMessage` and `Message` with a `user`, `system`, or `developer` role and no `phase` are wire-identical. The new test documents `Message` as the canonical branch for that shape rather than leaving the choice implicit.

### Validation

- `./gradlew :openai-java-core:test --tests com.openai.models.responses.ResponseInputItemTest --tests com.openai.models.responses.EasyInputMessageTest :openai-java-core:lintKotlin --console=plain`
  - `ResponseInputItemTest`: 73 tests, 0 failures
  - `EasyInputMessageTest`: 2 tests, 0 failures
  - Kotlin lint passed
- authoritative local Castiron budget check against current `main`: 1,735 / 2,000 custom lines, with budget isolation and budget checks both passing
- `git diff --check`

### Security review note

This touches Jackson polymorphic deserialization. The added dispatch condition only examines the already-parsed `type`, `role`, `content` shape, and `phase` presence; it adds no I/O, recursion, payload limit, or credential/logging behavior. Exact known input roles are required before changing the existing ordering, so malformed, missing, and future roles retain the current `EasyInputMessage`-first path.

AI assistance: I used Codex to help investigate the generated union behavior, draft the implementation and tests, and run validation. I reviewed the resulting code, the ambiguity tradeoff, and the test output.
