### PR TITLE
Fix Eclipse source attachment for the core JAR

### DIFF
--- a/buildSrc/src/main/kotlin/com/openai/gradle/VerifyCoreCompilationArtifactTask.kt
+++ b/buildSrc/src/main/kotlin/com/openai/gradle/VerifyCoreCompilationArtifactTask.kt
@@ -51,8 +51,7 @@ abstract class VerifyCoreCompilationArtifactTask : DefaultTask() {
             actual = binaryEntries.keys.filterTo(sortedSetOf()) { it.endsWith(".class") },
         )
 
-        val expectedSources =
-            relativeFiles(sourceDirectory.get().asFile, ".kt").mapTo(sortedSetOf()) { "main/$it" }
+        val expectedSources = relativeFiles(sourceDirectory.get().asFile, ".kt").toSortedSet()
         check(expectedSources.isNotEmpty()) { "The core source directory is empty." }
 
         val sourceEntries = zipEntryCounts(sourcesJar.get().asFile)
@@ -72,7 +71,7 @@ abstract class VerifyCoreCompilationArtifactTask : DefaultTask() {
                 "Public API class must appear exactly once in the core jar: $className"
             }
 
-            val sourceEntry = "main/${className.substringBefore('$').replace('.', '/')}.kt"
+            val sourceEntry = "${className.substringBefore('$').replace('.', '/')}.kt"
             check(sourceEntries[sourceEntry] == 1) {
                 "Public API source must appear exactly once in the core sources jar: $className"
             }

--- a/openai-java-core/build.gradle.kts
+++ b/openai-java-core/build.gradle.kts
@@ -88,13 +88,7 @@ val coreJar = tasks.named<Jar>("jar") {
 
 val coreSourcesJar = tasks.named<Jar>("kotlinSourcesJar") {
     duplicatesStrategy = DuplicatesStrategy.FAIL
-    from(
-        fileTree("src/main/kotlin").matching {
-            include(CoreCompilationClaimedSourceIncludeSpec())
-        }
-    ) {
-        into("main")
-    }
+    from(fileTree("src/main/kotlin").matching { include(CoreCompilationClaimedSourceIncludeSpec()) })
 }
 
 val verifyCoreCompilationArtifact =


### PR DESCRIPTION
## What

Fix the core sources JAR layout so Kotlin sources are stored at their package paths instead of under a `main/` prefix. Update the corresponding artifact verification task to expect the corrected layout.

## Why

Eclipse cannot automatically attach the published sources because the current JAR layout places sources under `main/com/...` rather than `com/...`.

Fixes #447

## Tests

- `git diff --check`
- Gradle task discovery was attempted, but the Gradle 8.12 wrapper initialization produced no output in the available environment.