### PR TITLE
Add typed metadata property builder

### DIFF
--- a/openai-java-core/src/main/kotlin/com/openai/models/beta/responses/ResponseCreateParams.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/models/beta/responses/ResponseCreateParams.kt
@@ -4729,6 +4729,11 @@ private constructor(
                 additionalProperties.put(key, value)
             }
 
+            /** Adds a metadata property using the string value type supported by the API. */
+            fun putProperty(key: String, value: String) = apply {
+                putAdditionalProperty(key, JsonValue.from(value))
+            }
+
             fun putAllAdditionalProperties(additionalProperties: Map<String, JsonValue>) = apply {
                 this.additionalProperties.putAll(additionalProperties)
             }

--- a/openai-java-core/src/main/kotlin/com/openai/models/responses/ResponseCreateParams.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/models/responses/ResponseCreateParams.kt
@@ -4607,6 +4607,11 @@ private constructor(
                 additionalProperties.put(key, value)
             }
 
+            /** Adds a metadata property using the string value type supported by the API. */
+            fun putProperty(key: String, value: String) = apply {
+                putAdditionalProperty(key, JsonValue.from(value))
+            }
+
             fun putAllAdditionalProperties(additionalProperties: Map<String, JsonValue>) = apply {
                 this.additionalProperties.putAll(additionalProperties)
             }

--- a/openai-java-core/src/test/kotlin/com/openai/models/beta/responses/ResponseCreateParamsTest.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/models/beta/responses/ResponseCreateParamsTest.kt
@@ -11,6 +11,15 @@ import org.junit.jupiter.api.Test
 internal class ResponseCreateParamsTest {
 
     @Test
+    fun metadataPropertyUsesAStringJsonValue() {
+        val metadata =
+            ResponseCreateParams.Metadata.builder().putProperty("someNumericId", "123").build()
+
+        assertThat(metadata._additionalProperties())
+            .containsEntry("someNumericId", JsonValue.from("123"))
+    }
+
+    @Test
     fun create() {
         ResponseCreateParams.builder()
             .addBeta(ResponseCreateParams.Beta.RESPONSES_MULTI_AGENT_V1)

--- a/openai-java-core/src/test/kotlin/com/openai/models/responses/ResponseCreateParamsTest.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/models/responses/ResponseCreateParamsTest.kt
@@ -15,6 +15,15 @@ import org.junit.jupiter.api.Test
 internal class ResponseCreateParamsTest {
 
     @Test
+    fun metadataPropertyUsesAStringJsonValue() {
+        val metadata =
+            ResponseCreateParams.Metadata.builder().putProperty("someNumericId", "123").build()
+
+        assertThat(metadata._additionalProperties())
+            .containsEntry("someNumericId", JsonValue.from("123"))
+    }
+
+    @Test
     fun create() {
         ResponseCreateParams.builder()
             .background(true)


### PR DESCRIPTION
## Summary

- add a typed `Metadata.Builder.putProperty(String, String)` helper for Responses
- expose the same helper for the Beta Responses API
- preserve `putAdditionalProperty(String, JsonValue)` as the escape hatch for undocumented values
- add regression tests that verify string values are stored as JSON strings

## Motivation

The API only accepts string values for metadata, but the existing builder exposes only the raw `JsonValue` method. This allows values such as JSON numbers to compile and fail later with a 400 response. The typed helper provides a straightforward, API-aligned path while keeping the existing low-level method backward compatible.

## Testing

- targeted stable and Beta `ResponseCreateParamsTest` tests
- `:openai-java-core:lintKotlin`
- full offline build with mock-server-dependent tests skipped
- Castiron custom-code budget check (1886 / 2000)

Closes #338
