### PR TITLE
fix: settle async streams on executor rejection

### DIFF
--- a/openai-java-core/src/main/kotlin/com/openai/core/http/AsyncStreamResponse.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/core/http/AsyncStreamResponse.kt
@@ -91,6 +91,15 @@ internal fun <T> CompletableFuture<StreamResponse<T>>.toAsync(streamHandlerExecu
                     else "Cannot subscribe after the response is closed"
                 }
 
+                val guardedExecutor = Executor { task ->
+                    try {
+                        executor.execute(task)
+                    } catch (error: Throwable) {
+                        if (onCompleteFuture.completeExceptionally(error)) close()
+                        throw error
+                    }
+                }
+
                 this@toAsync.whenCompleteAsync(
                     { streamResponse, futureError ->
                         if (state.get() == State.CLOSED) {
@@ -129,7 +138,7 @@ internal fun <T> CompletableFuture<StreamResponse<T>>.toAsync(streamHandlerExecu
                             }
                         }
                     },
-                    executor,
+                    guardedExecutor,
                 )
             }
 

--- a/openai-java-core/src/test/kotlin/com/openai/core/http/AsyncStreamResponseTest.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/core/http/AsyncStreamResponseTest.kt
@@ -2,7 +2,10 @@ package com.openai.core.http
 
 import java.util.*
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ExecutionException
 import java.util.concurrent.Executor
+import java.util.concurrent.RejectedExecutionException
+import java.util.concurrent.TimeUnit
 import java.util.stream.Stream
 import kotlin.streams.asStream
 import org.assertj.core.api.Assertions.assertThat
@@ -255,6 +258,24 @@ internal class AsyncStreamResponseTest {
         asyncStreamResponse.close()
 
         verify(streamResponse, times(1)).close()
+    }
+
+    @Test
+    fun subscribe_whenExecutorRejects_completesAndCloses() {
+        val future = CompletableFuture.completedFuture(streamResponse)
+        val asyncStreamResponse = future.toAsync(executor)
+        val rejected = RejectedExecutionException("executor rejected")
+        val rejectingExecutor = Executor { throw rejected }
+
+        asyncStreamResponse.subscribe(handler, rejectingExecutor)
+
+        val completionError = catchThrowable {
+            asyncStreamResponse.onCompleteFuture().get(100, TimeUnit.MILLISECONDS)
+        }
+        assertThat(completionError).isInstanceOf(ExecutionException::class.java).hasCause(rejected)
+        verify(streamResponse, times(1)).close()
+        verify(handler, never()).onNext(any())
+        verify(handler, never()).onComplete(any())
     }
 
     @Test


### PR DESCRIPTION
## Summary

Prevent `AsyncStreamResponse` from hanging when a subscriber-provided executor rejects the delivery task.

`CompletableFuture.whenCompleteAsync(..., executor)` reports executor dispatch failures through its dependent future. The current subscription path discards that future, so a rejected task can leave `onCompleteFuture()` pending indefinitely and the underlying response unclosed.

Fixes #973.

## Changes

- wrap the subscriber executor so dispatch failures settle `onCompleteFuture()` exceptionally;
- close the asynchronous stream when that failure wins terminal settlement;
- rethrow the executor failure so the dependent CompletableFuture retains normal exceptional-completion semantics;
- keep handler delivery on the requested executor only, with no fallback execution on another thread;
- add a deterministic regression using a rejecting executor.

## Testing

- pre-fix regression reproduced on current `main`: `onCompleteFuture().get(100ms)` timed out
- `./gradlew :openai-java-core:test --tests com.openai.core.http.AsyncStreamResponseTest --no-daemon --console=plain` — passed
- `./gradlew :openai-java-core:lintKotlin --no-daemon --console=plain` — passed
- `git diff --check` — passed
- Castiron custom-code budget check — passed, 1906 / 2000 lines with 94 lines headroom

## Risk and rollout

Low. Successful executor dispatch and existing stream completion behavior are unchanged. The new path runs only when the supplied executor throws while accepting the delivery task. Older and normal executors retain the existing behavior.