### PR TITLE
chore: raise custom-code budget to 3,000 lines

### DIFF
--- a/.castiron-ratchet.json
+++ b/.castiron-ratchet.json
@@ -1,4 +1,4 @@
 {
   "schema_version": 1,
-  "max_custom_patch_lines": 2000
+  "max_custom_patch_lines": 3000
 }


### PR DESCRIPTION
## Summary

Raise the custom-code budget from 2,000 to 3,000 lines to provide headroom for the upcoming release. Current main uses 1,906 lines. Generator cleanup will follow separately so it does not block the release.

This PR changes only `.castiron-ratchet.json`.