### PR TITLE
fix: allow longer timeout for large Agents stream test

### DIFF
--- a/openai-java-core/src/test/kotlin/com/openai/services/beta/agents/AgentSessionStreamTest.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/services/beta/agents/AgentSessionStreamTest.kt
@@ -198,14 +198,13 @@ internal class AgentSessionStreamTest {
         t: Transport,
         async: Boolean,
         params: AgentSessionStreamParams = params().build(),
+        requestTimeout: Duration = Duration.ofSeconds(9),
+        completionTimeoutSeconds: Long = 10,
         action: (AgentSessionEvent) -> Unit = {},
     ): List<AgentSessionEvent> {
         val events = mutableListOf<AgentSessionEvent>()
         val options =
-            RequestOptions.builder()
-                .timeout(Duration.ofSeconds(9))
-                .responseValidation(false)
-                .build()
+            RequestOptions.builder().timeout(requestTimeout).responseValidation(false).build()
         val client = t.client()
         if (async)
             client
@@ -219,7 +218,7 @@ internal class AgentSessionStreamTest {
                     action(it)
                 }
                 .onCompleteFuture()
-                .get(10, TimeUnit.SECONDS)
+                .get(completionTimeoutSeconds, TimeUnit.SECONDS)
         else
             client.beta().agents().sessions().stream(params, options).use {
                 it.stream().forEach {
@@ -793,6 +792,8 @@ internal class AgentSessionStreamTest {
                             null
                         }
                         .build(),
+                    requestTimeout = Duration.ofSeconds(60),
+                    completionTimeoutSeconds = 70,
                 )
             )
             .hasSize(events.size)

--- a/openai-java-core/src/test/kotlin/com/openai/services/beta/agents/AgentSessionStreamTest.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/services/beta/agents/AgentSessionStreamTest.kt
@@ -198,13 +198,15 @@ internal class AgentSessionStreamTest {
         t: Transport,
         async: Boolean,
         params: AgentSessionStreamParams = params().build(),
-        requestTimeout: Duration = Duration.ofSeconds(9),
         completionTimeoutSeconds: Long = 10,
         action: (AgentSessionEvent) -> Unit = {},
     ): List<AgentSessionEvent> {
         val events = mutableListOf<AgentSessionEvent>()
         val options =
-            RequestOptions.builder().timeout(requestTimeout).responseValidation(false).build()
+            RequestOptions.builder()
+                .timeout(Duration.ofSeconds(9))
+                .responseValidation(false)
+                .build()
         val client = t.client()
         if (async)
             client
@@ -792,7 +794,6 @@ internal class AgentSessionStreamTest {
                             null
                         }
                         .build(),
-                    requestTimeout = Duration.ofSeconds(60),
                     completionTimeoutSeconds = 70,
                 )
             )


### PR DESCRIPTION
## Summary
- Give the large AgentSessionStreamTest cache/dedup case a 70-second async completion wait under the release's GraalVM agent.
- Preserve the 9-second request timeout for this case and the 10-second completion wait for every other case.

## Why
The v4.63.0 release created a GitHub tag but stopped before Maven publication when the async variant timed out at `onCompleteFuture().get(10, SECONDS)` in [Create releases run 34522715468](https://github.com/openai/openai-java/actions/runs/34522715468). This is a narrow release-unblocking change. We still need to determine whether the async path is merely slow with agent instrumentation or can stall.

The existing v4.63.0 tag is immutable, and manual retries check out that tag. After this PR merges, release-please should create a patch release (v4.63.1) from the updated source; merging alone cannot repair the 4.63.0 publication.

## Verification
- Focused AgentSessionStreamTest cache/dedup case on JDK 21: passed after review feedback.
- `./scripts/lint` passed on the initial patch; `:openai-java-core:lintKotlin` passed after narrowing the timeout.
- GitHub CI: pending. The GraalVM release agent only runs after a new release is created, so this PR cannot prove that the original timeout was solely instrumentation overhead.

<!-- codex-thread: 01a08cf7-ffb9-72b2-b726-46b8cf871fc9 -->
